### PR TITLE
Fix security: only expose auth vars to containers, not full .env

### DIFF
--- a/.claude/skills/debug/SKILL.md
+++ b/.claude/skills/debug/SKILL.md
@@ -82,7 +82,7 @@ cat .env  # Should show one of:
 
 **Apple Container Bug:** Environment variables passed via `-e` are lost when using `-i` (interactive/piped stdin).
 
-**Workaround:** The system mounts `.env` as a file and sources it inside the container.
+**Workaround:** The system extracts only authentication variables (`CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`) from `.env` and mounts them for sourcing inside the container. Other env vars are not exposed.
 
 To verify env vars are reaching the container:
 ```bash

--- a/SPEC.md
+++ b/SPEC.md
@@ -230,7 +230,7 @@ The token can be extracted from `~/.claude/.credentials.json` if you're logged i
 ANTHROPIC_API_KEY=sk-ant-api03-...
 ```
 
-The `.env` file is automatically mounted into the container at `/workspace/env-dir/env` and sourced by the entrypoint script. This workaround is needed because Apple Container loses `-e` environment variables when using `-i` (interactive mode with piped stdin).
+Only the authentication variables (`CLAUDE_CODE_OAUTH_TOKEN` and `ANTHROPIC_API_KEY`) are extracted from `.env` and mounted into the container at `/workspace/env-dir/env`, then sourced by the entrypoint script. This ensures other environment variables in `.env` are not exposed to the agent. This workaround is needed because Apple Container loses `-e` environment variables when using `-i` (interactive mode with piped stdin).
 
 ### Changing the Assistant Name
 


### PR DESCRIPTION
Previously, the entire .env file was copied and mounted into containers,
exposing all environment variables to the agent. Now only the specific
authentication variables needed by Claude Code (CLAUDE_CODE_OAUTH_TOKEN
and ANTHROPIC_API_KEY) are extracted and mounted.

https://claude.ai/code/session_01Y6Az5oUPkYmJhA1N9MUd67