### PR TITLE
Fix hardcoded home directory fallback in container runner

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -5,6 +5,7 @@
 
 import { spawn } from 'child_process';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import pino from 'pino';
 import {
@@ -19,6 +20,14 @@ const logger = pino({
   level: process.env.LOG_LEVEL || 'info',
   transport: { target: 'pino-pretty', options: { colorize: true } }
 });
+
+function getHomeDir(): string {
+  const home = process.env.HOME || os.homedir();
+  if (!home) {
+    throw new Error('Unable to determine home directory: HOME environment variable is not set and os.homedir() returned empty');
+  }
+  return home;
+}
 
 export interface ContainerInput {
   prompt: string;
@@ -44,7 +53,7 @@ interface VolumeMount {
 
 function buildVolumeMounts(group: RegisteredGroup, isMain: boolean): VolumeMount[] {
   const mounts: VolumeMount[] = [];
-  const homeDir = process.env.HOME || '/Users/gavriel';
+  const homeDir = getHomeDir();
   const projectRoot = process.cwd();
 
   if (isMain) {


### PR DESCRIPTION
Replace environment-specific fallback '/Users/gavriel' with os.homedir()
and proper error handling. The new getHomeDir() helper function:
- First checks process.env.HOME
- Falls back to os.homedir() for cross-platform support
- Throws a clear error if home directory cannot be determined

https://claude.ai/code/session_011Cs2FWxXMvAdAh4w9A6AZC