### PR TITLE
Remove message content from info-level logs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -138,7 +138,7 @@ async function runAgent(group: RegisteredGroup, prompt: string, chatJid: string)
 async function sendMessage(jid: string, text: string): Promise<void> {
   try {
     await sock.sendMessage(jid, { text });
-    logger.info({ jid, text: text.slice(0, 50) }, 'Message sent');
+    logger.info({ jid, length: text.length }, 'Message sent');
   } catch (err) {
     logger.error({ jid, err }, 'Failed to send message');
   }


### PR DESCRIPTION
Previously logged first 50 chars of message text at info level, which
could expose sensitive user content in production logs. Now logs only
message length instead.

https://claude.ai/code/session_01V9b7PCAVA7LoyrR89t3GTG