### PR TITLE
Fix container JSON parsing with sentinel markers

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -45,8 +45,16 @@ async function readStdin(): Promise<string> {
   });
 }
 
+// Sentinel markers for robust output parsing
+const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
+const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
+
 function writeOutput(output: ContainerOutput): void {
+  // Use sentinel markers so the host can reliably find the JSON
+  // even if there's extra logging before or after
+  console.log(OUTPUT_START_MARKER);
   console.log(JSON.stringify(output));
+  console.log(OUTPUT_END_MARKER);
 }
 
 function log(message: string): void {

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -20,6 +20,10 @@ const logger = pino({
   transport: { target: 'pino-pretty', options: { colorize: true } }
 });
 
+// Sentinel markers for robust output parsing (must match agent-runner)
+const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
+const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
+
 export interface ContainerInput {
   prompt: string;
   sessionId?: string;
@@ -297,9 +301,23 @@ export async function runContainerAgent(
       }
 
       try {
-        // Last non-empty line is the JSON output
-        const lines = stdout.trim().split('\n');
-        const jsonLine = lines[lines.length - 1];
+        // Extract JSON between sentinel markers for robust parsing
+        const startIdx = stdout.indexOf(OUTPUT_START_MARKER);
+        const endIdx = stdout.indexOf(OUTPUT_END_MARKER);
+
+        let jsonLine: string;
+        if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
+          // Extract content between markers
+          jsonLine = stdout
+            .slice(startIdx + OUTPUT_START_MARKER.length, endIdx)
+            .trim();
+        } else {
+          // Fallback: last non-empty line (for backwards compatibility)
+          logger.warn({ group: group.name }, 'Sentinel markers not found, falling back to last-line parsing');
+          const lines = stdout.trim().split('\n');
+          jsonLine = lines[lines.length - 1];
+        }
+
         const output: ContainerOutput = JSON.parse(jsonLine);
 
         logger.info({


### PR DESCRIPTION
The container output parsing previously relied on the last non-empty
stdout line being valid JSON. Any extra logging after the JSON payload
would break parsing and mark runs as errors.

Now uses sentinel markers (---NANOCLAW_OUTPUT_START--- and
---NANOCLAW_OUTPUT_END---) to reliably extract the JSON output
regardless of surrounding logging. Includes backwards-compatible
fallback to last-line parsing if markers aren't found.

https://claude.ai/code/session_019FP4gM63uhG1obo78GvzUe