### PR TITLE
Fix: Use current timestamp for new chats in updateChatName

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -95,14 +95,15 @@ export function storeChatMetadata(chatJid: string, timestamp: string, name?: str
 }
 
 /**
- * Update chat name without changing timestamp.
+ * Update chat name without changing timestamp for existing chats.
+ * New chats get the current time as their initial timestamp.
  * Used during group metadata sync.
  */
 export function updateChatName(chatJid: string, name: string): void {
   db.prepare(`
     INSERT INTO chats (jid, name, last_message_time) VALUES (?, ?, ?)
     ON CONFLICT(jid) DO UPDATE SET name = excluded.name
-  `).run(chatJid, name, new Date(0).toISOString());
+  `).run(chatJid, name, new Date().toISOString());
 }
 
 export interface ChatInfo {


### PR DESCRIPTION
## Summary
Fixed a bug in the `updateChatName` function where new chats were being assigned the Unix epoch (January 1, 1970) as their initial timestamp instead of the current time.

## Changes
- Changed `new Date(0).toISOString()` to `new Date().toISOString()` in the `updateChatName` function
- Updated the JSDoc comment to clarify that existing chats preserve their timestamp while new chats receive the current time as their initial timestamp

## Details
The `updateChatName` function uses an `INSERT ... ON CONFLICT` pattern to either create a new chat or update an existing one. Previously, all chats (both new and existing) were being assigned the epoch timestamp. This change ensures:
- **Existing chats**: Timestamp remains unchanged (as intended)
- **New chats**: Receive the current timestamp as their `last_message_time` instead of 1970

This fix prevents new chats from appearing with incorrect historical timestamps during group metadata sync operations.

https://claude.ai/code/session_018rcZvALfF3ND2jfcvBaFo2