### PR TITLE
Add Telegram channel support

### DIFF
--- a/.claude/skills/add-telegram/SKILL.md
+++ b/.claude/skills/add-telegram/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: add-telegram
+description: Add Telegram as a channel. Can replace WhatsApp entirely or run alongside it. Also configurable as a control-only channel (triggers actions) or passive channel (receives notifications only).
+---
+
+# Add Telegram Channel
+
+This skill adds Telegram support to NanoClaw. Users can choose to:
+
+1. **Replace WhatsApp** - Use Telegram as the only messaging channel
+2. **Add alongside WhatsApp** - Both channels active, shared or separate memory
+3. **Control channel only** - Telegram triggers agent, but doesn't receive scheduled task outputs
+4. **Notification channel only** - Receives outputs but can't trigger the agent
+
+## Prerequisites
+
+The user needs a Telegram Bot Token from [@BotFather](https://t.me/botfather):
+
+1. Open Telegram and search for `@BotFather`
+2. Send `/newbot` and follow prompts
+3. Copy the bot token (looks like `123456789:ABCdefGHIjklMNOpqrsTUVwxyz`)
+
+## Questions to Ask
+
+Before making changes, clarify:
+
+1. **Mode**: Replace WhatsApp or add alongside it?
+2. **Trigger behavior**: Should Telegram messages trigger the agent, or just receive notifications?
+3. **If adding alongside**: Share memory with WhatsApp groups, or separate contexts?
+
+## Implementation
+
+### Step 1: Install Dependencies
+
+```bash
+npm install grammy dotenv
+```
+
+Grammy is the modern, TypeScript-first Telegram bot framework.
+
+### Step 2: Create Telegram Connection Module
+
+Create `src/telegram.ts` - see the implementation in this repo.
+
+### Step 3: Update Configuration
+
+Add to `src/config.ts`:
+
+```typescript
+export const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN || "";
+export const TELEGRAM_ONLY = process.env.TELEGRAM_ONLY === "true";
+```
+
+### Step 4: Update Main Application
+
+Modify `src/index.ts`:
+
+1. Add `import "dotenv/config";` at the top
+2. Import Telegram module
+3. Update `sendMessage` to route by channel prefix (`tg:` for Telegram)
+4. Add Telegram initialization in `main()`
+
+### Step 5: Update Database
+
+Add `storeMessageDirect()` function to `src/db.ts` for storing messages from non-WhatsApp channels.
+
+### Step 6: Environment Configuration
+
+Add to `.env`:
+
+```bash
+TELEGRAM_BOT_TOKEN=your_bot_token_here
+
+# Optional: Set to "true" to disable WhatsApp entirely
+# TELEGRAM_ONLY=true
+```
+
+### Step 7: Register a Telegram Chat
+
+Update `data/registered_groups.json` to add Telegram chats:
+
+```json
+{
+  "tg:-1001234567890": {
+    "name": "My Telegram Group",
+    "folder": "telegram-main",
+    "trigger": "@Pepper",
+    "added_at": "2026-02-02T12:00:00.000Z"
+  }
+}
+```
+
+For private chats (DMs with the bot), use positive chat IDs:
+
+```json
+{
+  "tg:123456789": {
+    "name": "Personal",
+    "folder": "main",
+    "trigger": "@Pepper",
+    "added_at": "2026-02-02T12:00:00.000Z"
+  }
+}
+```
+
+## Replace WhatsApp Entirely
+
+If the user wants Telegram-only:
+
+1. Set `TELEGRAM_ONLY=true` in `.env`
+2. The app will skip WhatsApp connection and run Telegram only
+
+## Getting the Chat ID
+
+Users need to find their Telegram chat ID to register it:
+
+1. Send `/chatid` to the bot (built-in command)
+2. For groups: Add `@RawDataBot` temporarily
+3. Check logs when sending a message
+
+## After Changes
+
+```bash
+npm run build
+systemctl --user restart nanoclaw  # or launchctl on macOS
+```
+
+## Testing
+
+1. Start the service
+2. Send `/chatid` to get your chat ID
+3. Register the chat in `registered_groups.json`
+4. Send a message to test the response

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
         "@whiskeysockets/baileys": "^7.0.0-rc.9",
         "better-sqlite3": "^11.8.1",
         "cron-parser": "^5.5.0",
+        "dotenv": "^17.2.3",
+        "grammy": "^1.39.3",
         "pino": "^9.6.0",
         "pino-pretty": "^13.0.0",
         "qrcode-terminal": "^0.12.0",
@@ -526,6 +528,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/@grammyjs/types": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@grammyjs/types/-/types-3.23.0.tgz",
+      "integrity": "sha512-D3jQ4UWERPsyR3op/YFudMMIPNTU47vy7L51uO9/73tMELmjO/+LX5N36/Y0CG5IQfIsz43MxiHI5rgsK0/k+g==",
+      "license": "MIT"
+    },
     "node_modules/@hapi/boom": {
       "version": "9.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
@@ -917,6 +925,18 @@
         }
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/async-mutex": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
@@ -1121,6 +1141,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/dotenv": {
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -1170,6 +1202,15 @@
         "@esbuild/win32-arm64": "0.27.2",
         "@esbuild/win32-ia32": "0.27.2",
         "@esbuild/win32-x64": "0.27.2"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/eventemitter3": {
@@ -1262,6 +1303,21 @@
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
+    },
+    "node_modules/grammy": {
+      "version": "1.39.3",
+      "resolved": "https://registry.npmjs.org/grammy/-/grammy-1.39.3.tgz",
+      "integrity": "sha512-7arRRoOtOh9UwMwANZ475kJrWV6P3/EGNooeHlY0/SwZv4t3ZZ3Uiz9cAXK8Zg9xSdgmm8T21kx6n7SZaWvOcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@grammyjs/types": "3.23.0",
+        "abort-controller": "^3.0.0",
+        "debug": "^4.4.3",
+        "node-fetch": "^2.7.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || >=14.13.1"
+      }
     },
     "node_modules/hashery": {
       "version": "1.4.0",
@@ -1498,6 +1554,26 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/on-exit-leak-free": {
@@ -2332,6 +2408,12 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -2407,6 +2489,22 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/win-guid": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "@whiskeysockets/baileys": "^7.0.0-rc.9",
     "better-sqlite3": "^11.8.1",
     "cron-parser": "^5.5.0",
+    "dotenv": "^17.2.3",
+    "grammy": "^1.39.3",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",
     "qrcode-terminal": "^0.12.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,31 +1,49 @@
-import path from 'path';
+import path from "path";
 
-export const ASSISTANT_NAME = process.env.ASSISTANT_NAME || 'Andy';
+export const ASSISTANT_NAME = process.env.ASSISTANT_NAME || "Andy";
+export const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN || "";
+export const TELEGRAM_ONLY = process.env.TELEGRAM_ONLY === "true";
 export const POLL_INTERVAL = 2000;
 export const SCHEDULER_POLL_INTERVAL = 60000;
 
 // Absolute paths needed for container mounts
 const PROJECT_ROOT = process.cwd();
-const HOME_DIR = process.env.HOME || '/Users/user';
+const HOME_DIR = process.env.HOME || "/Users/user";
 
 // Mount security: allowlist stored OUTSIDE project root, never mounted into containers
-export const MOUNT_ALLOWLIST_PATH = path.join(HOME_DIR, '.config', 'nanoclaw', 'mount-allowlist.json');
-export const STORE_DIR = path.resolve(PROJECT_ROOT, 'store');
-export const GROUPS_DIR = path.resolve(PROJECT_ROOT, 'groups');
-export const DATA_DIR = path.resolve(PROJECT_ROOT, 'data');
-export const MAIN_GROUP_FOLDER = 'main';
+export const MOUNT_ALLOWLIST_PATH = path.join(
+  HOME_DIR,
+  ".config",
+  "nanoclaw",
+  "mount-allowlist.json",
+);
+export const STORE_DIR = path.resolve(PROJECT_ROOT, "store");
+export const GROUPS_DIR = path.resolve(PROJECT_ROOT, "groups");
+export const DATA_DIR = path.resolve(PROJECT_ROOT, "data");
+export const MAIN_GROUP_FOLDER = "main";
 
-export const CONTAINER_IMAGE = process.env.CONTAINER_IMAGE || 'nanoclaw-agent:latest';
-export const CONTAINER_TIMEOUT = parseInt(process.env.CONTAINER_TIMEOUT || '300000', 10);
-export const CONTAINER_MAX_OUTPUT_SIZE = parseInt(process.env.CONTAINER_MAX_OUTPUT_SIZE || '10485760', 10); // 10MB default
+export const CONTAINER_IMAGE =
+  process.env.CONTAINER_IMAGE || "nanoclaw-agent:latest";
+export const CONTAINER_TIMEOUT = parseInt(
+  process.env.CONTAINER_TIMEOUT || "300000",
+  10,
+);
+export const CONTAINER_MAX_OUTPUT_SIZE = parseInt(
+  process.env.CONTAINER_MAX_OUTPUT_SIZE || "10485760",
+  10,
+); // 10MB default
 export const IPC_POLL_INTERVAL = 1000;
 
 function escapeRegex(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-export const TRIGGER_PATTERN = new RegExp(`^@${escapeRegex(ASSISTANT_NAME)}\\b`, 'i');
+export const TRIGGER_PATTERN = new RegExp(
+  `^@${escapeRegex(ASSISTANT_NAME)}\\b`,
+  "i",
+);
 
 // Timezone for scheduled tasks (cron expressions, etc.)
 // Uses system timezone by default
-export const TIMEZONE = process.env.TZ || Intl.DateTimeFormat().resolvedOptions().timeZone;
+export const TIMEZONE =
+  process.env.TZ || Intl.DateTimeFormat().resolvedOptions().timeZone;

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,14 +1,14 @@
-import Database from 'better-sqlite3';
-import fs from 'fs';
-import path from 'path';
-import { proto } from '@whiskeysockets/baileys';
-import { NewMessage, ScheduledTask, TaskRunLog } from './types.js';
-import { STORE_DIR } from './config.js';
+import Database from "better-sqlite3";
+import fs from "fs";
+import path from "path";
+import { proto } from "@whiskeysockets/baileys";
+import { NewMessage, ScheduledTask, TaskRunLog } from "./types.js";
+import { STORE_DIR } from "./config.js";
 
 let db: Database.Database;
 
 export function initDatabase(): void {
-  const dbPath = path.join(STORE_DIR, 'messages.db');
+  const dbPath = path.join(STORE_DIR, "messages.db");
   fs.mkdirSync(path.dirname(dbPath), { recursive: true });
 
   db = new Database(dbPath);
@@ -63,34 +63,48 @@ export function initDatabase(): void {
   // Add sender_name column if it doesn't exist (migration for existing DBs)
   try {
     db.exec(`ALTER TABLE messages ADD COLUMN sender_name TEXT`);
-  } catch { /* column already exists */ }
+  } catch {
+    /* column already exists */
+  }
 
   // Add context_mode column if it doesn't exist (migration for existing DBs)
   try {
-    db.exec(`ALTER TABLE scheduled_tasks ADD COLUMN context_mode TEXT DEFAULT 'isolated'`);
-  } catch { /* column already exists */ }
+    db.exec(
+      `ALTER TABLE scheduled_tasks ADD COLUMN context_mode TEXT DEFAULT 'isolated'`,
+    );
+  } catch {
+    /* column already exists */
+  }
 }
 
 /**
  * Store chat metadata only (no message content).
  * Used for all chats to enable group discovery without storing sensitive content.
  */
-export function storeChatMetadata(chatJid: string, timestamp: string, name?: string): void {
+export function storeChatMetadata(
+  chatJid: string,
+  timestamp: string,
+  name?: string,
+): void {
   if (name) {
     // Update with name, preserving existing timestamp if newer
-    db.prepare(`
+    db.prepare(
+      `
       INSERT INTO chats (jid, name, last_message_time) VALUES (?, ?, ?)
       ON CONFLICT(jid) DO UPDATE SET
         name = excluded.name,
         last_message_time = MAX(last_message_time, excluded.last_message_time)
-    `).run(chatJid, name, timestamp);
+    `,
+    ).run(chatJid, name, timestamp);
   } else {
     // Update timestamp only, preserve existing name if any
-    db.prepare(`
+    db.prepare(
+      `
       INSERT INTO chats (jid, name, last_message_time) VALUES (?, ?, ?)
       ON CONFLICT(jid) DO UPDATE SET
         last_message_time = MAX(last_message_time, excluded.last_message_time)
-    `).run(chatJid, chatJid, timestamp);
+    `,
+    ).run(chatJid, chatJid, timestamp);
   }
 }
 
@@ -100,10 +114,12 @@ export function storeChatMetadata(chatJid: string, timestamp: string, name?: str
  * Used during group metadata sync.
  */
 export function updateChatName(chatJid: string, name: string): void {
-  db.prepare(`
+  db.prepare(
+    `
     INSERT INTO chats (jid, name, last_message_time) VALUES (?, ?, ?)
     ON CONFLICT(jid) DO UPDATE SET name = excluded.name
-  `).run(chatJid, name, new Date().toISOString());
+  `,
+  ).run(chatJid, name, new Date().toISOString());
 }
 
 export interface ChatInfo {
@@ -116,11 +132,15 @@ export interface ChatInfo {
  * Get all known chats, ordered by most recent activity.
  */
 export function getAllChats(): ChatInfo[] {
-  return db.prepare(`
+  return db
+    .prepare(
+      `
     SELECT jid, name, last_message_time
     FROM chats
     ORDER BY last_message_time DESC
-  `).all() as ChatInfo[];
+  `,
+    )
+    .all() as ChatInfo[];
 }
 
 /**
@@ -128,7 +148,9 @@ export function getAllChats(): ChatInfo[] {
  */
 export function getLastGroupSync(): string | null {
   // Store sync time in a special chat entry
-  const row = db.prepare(`SELECT last_message_time FROM chats WHERE jid = '__group_sync__'`).get() as { last_message_time: string } | undefined;
+  const row = db
+    .prepare(`SELECT last_message_time FROM chats WHERE jid = '__group_sync__'`)
+    .get() as { last_message_time: string } | undefined;
   return row?.last_message_time || null;
 }
 
@@ -137,14 +159,21 @@ export function getLastGroupSync(): string | null {
  */
 export function setLastGroupSync(): void {
   const now = new Date().toISOString();
-  db.prepare(`INSERT OR REPLACE INTO chats (jid, name, last_message_time) VALUES ('__group_sync__', '__group_sync__', ?)`).run(now);
+  db.prepare(
+    `INSERT OR REPLACE INTO chats (jid, name, last_message_time) VALUES ('__group_sync__', '__group_sync__', ?)`,
+  ).run(now);
 }
 
 /**
  * Store a message with full content.
  * Only call this for registered groups where message history is needed.
  */
-export function storeMessage(msg: proto.IWebMessageInfo, chatJid: string, isFromMe: boolean, pushName?: string): void {
+export function storeMessage(
+  msg: proto.IWebMessageInfo,
+  chatJid: string,
+  isFromMe: boolean,
+  pushName?: string,
+): void {
   if (!msg.key) return;
 
   const content =
@@ -152,21 +181,59 @@ export function storeMessage(msg: proto.IWebMessageInfo, chatJid: string, isFrom
     msg.message?.extendedTextMessage?.text ||
     msg.message?.imageMessage?.caption ||
     msg.message?.videoMessage?.caption ||
-    '';
+    "";
 
   const timestamp = new Date(Number(msg.messageTimestamp) * 1000).toISOString();
-  const sender = msg.key.participant || msg.key.remoteJid || '';
-  const senderName = pushName || sender.split('@')[0];
-  const msgId = msg.key.id || '';
+  const sender = msg.key.participant || msg.key.remoteJid || "";
+  const senderName = pushName || sender.split("@")[0];
+  const msgId = msg.key.id || "";
 
-  db.prepare(`INSERT OR REPLACE INTO messages (id, chat_jid, sender, sender_name, content, timestamp, is_from_me) VALUES (?, ?, ?, ?, ?, ?, ?)`)
-    .run(msgId, chatJid, sender, senderName, content, timestamp, isFromMe ? 1 : 0);
+  db.prepare(
+    `INSERT OR REPLACE INTO messages (id, chat_jid, sender, sender_name, content, timestamp, is_from_me) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    msgId,
+    chatJid,
+    sender,
+    senderName,
+    content,
+    timestamp,
+    isFromMe ? 1 : 0,
+  );
 }
 
-export function getNewMessages(jids: string[], lastTimestamp: string, botPrefix: string): { messages: NewMessage[]; newTimestamp: string } {
+/**
+ * Store a message directly from parsed values (for non-WhatsApp channels).
+ */
+export function storeMessageDirect(msg: {
+  id: string;
+  chat_jid: string;
+  sender: string;
+  sender_name: string;
+  content: string;
+  timestamp: string;
+  is_from_me: boolean;
+}): void {
+  db.prepare(
+    `INSERT OR REPLACE INTO messages (id, chat_jid, sender, sender_name, content, timestamp, is_from_me) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    msg.id,
+    msg.chat_jid,
+    msg.sender,
+    msg.sender_name,
+    msg.content,
+    msg.timestamp,
+    msg.is_from_me ? 1 : 0,
+  );
+}
+
+export function getNewMessages(
+  jids: string[],
+  lastTimestamp: string,
+  botPrefix: string,
+): { messages: NewMessage[]; newTimestamp: string } {
   if (jids.length === 0) return { messages: [], newTimestamp: lastTimestamp };
 
-  const placeholders = jids.map(() => '?').join(',');
+  const placeholders = jids.map(() => "?").join(",");
   // Filter out bot's own messages by checking content prefix (not is_from_me, since user shares the account)
   const sql = `
     SELECT id, chat_jid, sender, sender_name, content, timestamp
@@ -175,7 +242,9 @@ export function getNewMessages(jids: string[], lastTimestamp: string, botPrefix:
     ORDER BY timestamp
   `;
 
-  const rows = db.prepare(sql).all(lastTimestamp, ...jids, `${botPrefix}:%`) as NewMessage[];
+  const rows = db
+    .prepare(sql)
+    .all(lastTimestamp, ...jids, `${botPrefix}:%`) as NewMessage[];
 
   let newTimestamp = lastTimestamp;
   for (const row of rows) {
@@ -185,7 +254,11 @@ export function getNewMessages(jids: string[], lastTimestamp: string, botPrefix:
   return { messages: rows, newTimestamp };
 }
 
-export function getMessagesSince(chatJid: string, sinceTimestamp: string, botPrefix: string): NewMessage[] {
+export function getMessagesSince(
+  chatJid: string,
+  sinceTimestamp: string,
+  botPrefix: string,
+): NewMessage[] {
   // Filter out bot's own messages by checking content prefix
   const sql = `
     SELECT id, chat_jid, sender, sender_name, content, timestamp
@@ -193,92 +266,154 @@ export function getMessagesSince(chatJid: string, sinceTimestamp: string, botPre
     WHERE chat_jid = ? AND timestamp > ? AND content NOT LIKE ?
     ORDER BY timestamp
   `;
-  return db.prepare(sql).all(chatJid, sinceTimestamp, `${botPrefix}:%`) as NewMessage[];
+  return db
+    .prepare(sql)
+    .all(chatJid, sinceTimestamp, `${botPrefix}:%`) as NewMessage[];
 }
 
-export function createTask(task: Omit<ScheduledTask, 'last_run' | 'last_result'>): void {
-  db.prepare(`
+export function createTask(
+  task: Omit<ScheduledTask, "last_run" | "last_result">,
+): void {
+  db.prepare(
+    `
     INSERT INTO scheduled_tasks (id, group_folder, chat_jid, prompt, schedule_type, schedule_value, context_mode, next_run, status, created_at)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-  `).run(
+  `,
+  ).run(
     task.id,
     task.group_folder,
     task.chat_jid,
     task.prompt,
     task.schedule_type,
     task.schedule_value,
-    task.context_mode || 'isolated',
+    task.context_mode || "isolated",
     task.next_run,
     task.status,
-    task.created_at
+    task.created_at,
   );
 }
 
 export function getTaskById(id: string): ScheduledTask | undefined {
-  return db.prepare('SELECT * FROM scheduled_tasks WHERE id = ?').get(id) as ScheduledTask | undefined;
+  return db.prepare("SELECT * FROM scheduled_tasks WHERE id = ?").get(id) as
+    | ScheduledTask
+    | undefined;
 }
 
 export function getTasksForGroup(groupFolder: string): ScheduledTask[] {
-  return db.prepare('SELECT * FROM scheduled_tasks WHERE group_folder = ? ORDER BY created_at DESC').all(groupFolder) as ScheduledTask[];
+  return db
+    .prepare(
+      "SELECT * FROM scheduled_tasks WHERE group_folder = ? ORDER BY created_at DESC",
+    )
+    .all(groupFolder) as ScheduledTask[];
 }
 
 export function getAllTasks(): ScheduledTask[] {
-  return db.prepare('SELECT * FROM scheduled_tasks ORDER BY created_at DESC').all() as ScheduledTask[];
+  return db
+    .prepare("SELECT * FROM scheduled_tasks ORDER BY created_at DESC")
+    .all() as ScheduledTask[];
 }
 
-export function updateTask(id: string, updates: Partial<Pick<ScheduledTask, 'prompt' | 'schedule_type' | 'schedule_value' | 'next_run' | 'status'>>): void {
+export function updateTask(
+  id: string,
+  updates: Partial<
+    Pick<
+      ScheduledTask,
+      "prompt" | "schedule_type" | "schedule_value" | "next_run" | "status"
+    >
+  >,
+): void {
   const fields: string[] = [];
   const values: unknown[] = [];
 
-  if (updates.prompt !== undefined) { fields.push('prompt = ?'); values.push(updates.prompt); }
-  if (updates.schedule_type !== undefined) { fields.push('schedule_type = ?'); values.push(updates.schedule_type); }
-  if (updates.schedule_value !== undefined) { fields.push('schedule_value = ?'); values.push(updates.schedule_value); }
-  if (updates.next_run !== undefined) { fields.push('next_run = ?'); values.push(updates.next_run); }
-  if (updates.status !== undefined) { fields.push('status = ?'); values.push(updates.status); }
+  if (updates.prompt !== undefined) {
+    fields.push("prompt = ?");
+    values.push(updates.prompt);
+  }
+  if (updates.schedule_type !== undefined) {
+    fields.push("schedule_type = ?");
+    values.push(updates.schedule_type);
+  }
+  if (updates.schedule_value !== undefined) {
+    fields.push("schedule_value = ?");
+    values.push(updates.schedule_value);
+  }
+  if (updates.next_run !== undefined) {
+    fields.push("next_run = ?");
+    values.push(updates.next_run);
+  }
+  if (updates.status !== undefined) {
+    fields.push("status = ?");
+    values.push(updates.status);
+  }
 
   if (fields.length === 0) return;
 
   values.push(id);
-  db.prepare(`UPDATE scheduled_tasks SET ${fields.join(', ')} WHERE id = ?`).run(...values);
+  db.prepare(
+    `UPDATE scheduled_tasks SET ${fields.join(", ")} WHERE id = ?`,
+  ).run(...values);
 }
 
 export function deleteTask(id: string): void {
   // Delete child records first (FK constraint)
-  db.prepare('DELETE FROM task_run_logs WHERE task_id = ?').run(id);
-  db.prepare('DELETE FROM scheduled_tasks WHERE id = ?').run(id);
+  db.prepare("DELETE FROM task_run_logs WHERE task_id = ?").run(id);
+  db.prepare("DELETE FROM scheduled_tasks WHERE id = ?").run(id);
 }
 
 export function getDueTasks(): ScheduledTask[] {
   const now = new Date().toISOString();
-  return db.prepare(`
+  return db
+    .prepare(
+      `
     SELECT * FROM scheduled_tasks
     WHERE status = 'active' AND next_run IS NOT NULL AND next_run <= ?
     ORDER BY next_run
-  `).all(now) as ScheduledTask[];
+  `,
+    )
+    .all(now) as ScheduledTask[];
 }
 
-export function updateTaskAfterRun(id: string, nextRun: string | null, lastResult: string): void {
+export function updateTaskAfterRun(
+  id: string,
+  nextRun: string | null,
+  lastResult: string,
+): void {
   const now = new Date().toISOString();
-  db.prepare(`
+  db.prepare(
+    `
     UPDATE scheduled_tasks
     SET next_run = ?, last_run = ?, last_result = ?, status = CASE WHEN ? IS NULL THEN 'completed' ELSE status END
     WHERE id = ?
-  `).run(nextRun, now, lastResult, nextRun, id);
+  `,
+  ).run(nextRun, now, lastResult, nextRun, id);
 }
 
 export function logTaskRun(log: TaskRunLog): void {
-  db.prepare(`
+  db.prepare(
+    `
     INSERT INTO task_run_logs (task_id, run_at, duration_ms, status, result, error)
     VALUES (?, ?, ?, ?, ?, ?)
-  `).run(log.task_id, log.run_at, log.duration_ms, log.status, log.result, log.error);
+  `,
+  ).run(
+    log.task_id,
+    log.run_at,
+    log.duration_ms,
+    log.status,
+    log.result,
+    log.error,
+  );
 }
 
 export function getTaskRunLogs(taskId: string, limit = 10): TaskRunLog[] {
-  return db.prepare(`
+  return db
+    .prepare(
+      `
     SELECT task_id, run_at, duration_ms, status, result, error
     FROM task_run_logs
     WHERE task_id = ?
     ORDER BY run_at DESC
     LIMIT ?
-  `).all(taskId, limit) as TaskRunLog[];
+  `,
+    )
+    .all(taskId, limit) as TaskRunLog[];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,14 @@
+import "dotenv/config";
 import makeWASocket, {
   useMultiFileAuthState,
   DisconnectReason,
   makeCacheableSignalKeyStore,
-  WASocket
-} from '@whiskeysockets/baileys';
-import pino from 'pino';
-import { exec, execSync } from 'child_process';
-import fs from 'fs';
-import path from 'path';
+  WASocket,
+} from "@whiskeysockets/baileys";
+import pino from "pino";
+import { exec, execSync } from "child_process";
+import fs from "fs";
+import path from "path";
 
 import {
   ASSISTANT_NAME,
@@ -17,59 +18,94 @@ import {
   TRIGGER_PATTERN,
   MAIN_GROUP_FOLDER,
   IPC_POLL_INTERVAL,
-  TIMEZONE
-} from './config.js';
-import { RegisteredGroup, Session, NewMessage } from './types.js';
-import { initDatabase, storeMessage, storeChatMetadata, getNewMessages, getMessagesSince, getAllTasks, getTaskById, updateChatName, getAllChats, getLastGroupSync, setLastGroupSync } from './db.js';
-import { startSchedulerLoop } from './task-scheduler.js';
-import { runContainerAgent, writeTasksSnapshot, writeGroupsSnapshot, AvailableGroup } from './container-runner.js';
-import { loadJson, saveJson } from './utils.js';
+  TIMEZONE,
+  TELEGRAM_BOT_TOKEN,
+  TELEGRAM_ONLY,
+} from "./config.js";
+import { connectTelegram, sendTelegramMessage } from "./telegram.js";
+import { RegisteredGroup, Session, NewMessage } from "./types.js";
+import {
+  initDatabase,
+  storeMessage,
+  storeChatMetadata,
+  getNewMessages,
+  getMessagesSince,
+  getAllTasks,
+  getTaskById,
+  updateChatName,
+  getAllChats,
+  getLastGroupSync,
+  setLastGroupSync,
+} from "./db.js";
+import { startSchedulerLoop } from "./task-scheduler.js";
+import {
+  runContainerAgent,
+  writeTasksSnapshot,
+  writeGroupsSnapshot,
+  AvailableGroup,
+} from "./container-runner.js";
+import { loadJson, saveJson } from "./utils.js";
 
 const GROUP_SYNC_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 const logger = pino({
-  level: process.env.LOG_LEVEL || 'info',
-  transport: { target: 'pino-pretty', options: { colorize: true } }
+  level: process.env.LOG_LEVEL || "info",
+  transport: { target: "pino-pretty", options: { colorize: true } },
 });
 
 let sock: WASocket;
-let lastTimestamp = '';
+let lastTimestamp = "";
 let sessions: Session = {};
 let registeredGroups: Record<string, RegisteredGroup> = {};
 let lastAgentTimestamp: Record<string, string> = {};
 
 async function setTyping(jid: string, isTyping: boolean): Promise<void> {
   try {
-    await sock.sendPresenceUpdate(isTyping ? 'composing' : 'paused', jid);
+    await sock.sendPresenceUpdate(isTyping ? "composing" : "paused", jid);
   } catch (err) {
-    logger.debug({ jid, err }, 'Failed to update typing status');
+    logger.debug({ jid, err }, "Failed to update typing status");
   }
 }
 
 function loadState(): void {
-  const statePath = path.join(DATA_DIR, 'router_state.json');
-  const state = loadJson<{ last_timestamp?: string; last_agent_timestamp?: Record<string, string> }>(statePath, {});
-  lastTimestamp = state.last_timestamp || '';
+  const statePath = path.join(DATA_DIR, "router_state.json");
+  const state = loadJson<{
+    last_timestamp?: string;
+    last_agent_timestamp?: Record<string, string>;
+  }>(statePath, {});
+  lastTimestamp = state.last_timestamp || "";
   lastAgentTimestamp = state.last_agent_timestamp || {};
-  sessions = loadJson(path.join(DATA_DIR, 'sessions.json'), {});
-  registeredGroups = loadJson(path.join(DATA_DIR, 'registered_groups.json'), {});
-  logger.info({ groupCount: Object.keys(registeredGroups).length }, 'State loaded');
+  sessions = loadJson(path.join(DATA_DIR, "sessions.json"), {});
+  registeredGroups = loadJson(
+    path.join(DATA_DIR, "registered_groups.json"),
+    {},
+  );
+  logger.info(
+    { groupCount: Object.keys(registeredGroups).length },
+    "State loaded",
+  );
 }
 
 function saveState(): void {
-  saveJson(path.join(DATA_DIR, 'router_state.json'), { last_timestamp: lastTimestamp, last_agent_timestamp: lastAgentTimestamp });
-  saveJson(path.join(DATA_DIR, 'sessions.json'), sessions);
+  saveJson(path.join(DATA_DIR, "router_state.json"), {
+    last_timestamp: lastTimestamp,
+    last_agent_timestamp: lastAgentTimestamp,
+  });
+  saveJson(path.join(DATA_DIR, "sessions.json"), sessions);
 }
 
 function registerGroup(jid: string, group: RegisteredGroup): void {
   registeredGroups[jid] = group;
-  saveJson(path.join(DATA_DIR, 'registered_groups.json'), registeredGroups);
+  saveJson(path.join(DATA_DIR, "registered_groups.json"), registeredGroups);
 
   // Create group folder
-  const groupDir = path.join(DATA_DIR, '..', 'groups', group.folder);
-  fs.mkdirSync(path.join(groupDir, 'logs'), { recursive: true });
+  const groupDir = path.join(DATA_DIR, "..", "groups", group.folder);
+  fs.mkdirSync(path.join(groupDir, "logs"), { recursive: true });
 
-  logger.info({ jid, name: group.name, folder: group.folder }, 'Group registered');
+  logger.info(
+    { jid, name: group.name, folder: group.folder },
+    "Group registered",
+  );
 }
 
 /**
@@ -85,14 +121,14 @@ async function syncGroupMetadata(force = false): Promise<void> {
       const lastSyncTime = new Date(lastSync).getTime();
       const now = Date.now();
       if (now - lastSyncTime < GROUP_SYNC_INTERVAL_MS) {
-        logger.debug({ lastSync }, 'Skipping group sync - synced recently');
+        logger.debug({ lastSync }, "Skipping group sync - synced recently");
         return;
       }
     }
   }
 
   try {
-    logger.info('Syncing group metadata from WhatsApp...');
+    logger.info("Syncing group metadata from WhatsApp...");
     const groups = await sock.groupFetchAllParticipating();
 
     let count = 0;
@@ -104,9 +140,9 @@ async function syncGroupMetadata(force = false): Promise<void> {
     }
 
     setLastGroupSync();
-    logger.info({ count }, 'Group metadata synced');
+    logger.info({ count }, "Group metadata synced");
   } catch (err) {
-    logger.error({ err }, 'Failed to sync group metadata');
+    logger.error({ err }, "Failed to sync group metadata");
   }
 }
 
@@ -119,12 +155,12 @@ function getAvailableGroups(): AvailableGroup[] {
   const registeredJids = new Set(Object.keys(registeredGroups));
 
   return chats
-    .filter(c => c.jid !== '__group_sync__' && c.jid.endsWith('@g.us'))
-    .map(c => ({
+    .filter((c) => c.jid !== "__group_sync__" && c.jid.endsWith("@g.us"))
+    .map((c) => ({
       jid: c.jid,
       name: c.name,
       lastActivity: c.last_message_time,
-      isRegistered: registeredJids.has(c.jid)
+      isRegistered: registeredJids.has(c.jid),
     }));
 }
 
@@ -139,23 +175,31 @@ async function processMessage(msg: NewMessage): Promise<void> {
   if (!isMainGroup && !TRIGGER_PATTERN.test(content)) return;
 
   // Get all messages since last agent interaction so the session has full context
-  const sinceTimestamp = lastAgentTimestamp[msg.chat_jid] || '';
-  const missedMessages = getMessagesSince(msg.chat_jid, sinceTimestamp, ASSISTANT_NAME);
+  const sinceTimestamp = lastAgentTimestamp[msg.chat_jid] || "";
+  const missedMessages = getMessagesSince(
+    msg.chat_jid,
+    sinceTimestamp,
+    ASSISTANT_NAME,
+  );
 
-  const lines = missedMessages.map(m => {
+  const lines = missedMessages.map((m) => {
     // Escape XML special characters in content
-    const escapeXml = (s: string) => s
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;');
+    const escapeXml = (s: string) =>
+      s
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;");
     return `<message sender="${escapeXml(m.sender_name)}" time="${m.timestamp}">${escapeXml(m.content)}</message>`;
   });
-  const prompt = `<messages>\n${lines.join('\n')}\n</messages>`;
+  const prompt = `<messages>\n${lines.join("\n")}\n</messages>`;
 
   if (!prompt) return;
 
-  logger.info({ group: group.name, messageCount: missedMessages.length }, 'Processing message');
+  logger.info(
+    { group: group.name, messageCount: missedMessages.length },
+    "Processing message",
+  );
 
   await setTyping(msg.chat_jid, true);
   const response = await runAgent(group, prompt, msg.chat_jid);
@@ -167,25 +211,38 @@ async function processMessage(msg: NewMessage): Promise<void> {
   }
 }
 
-async function runAgent(group: RegisteredGroup, prompt: string, chatJid: string): Promise<string | null> {
+async function runAgent(
+  group: RegisteredGroup,
+  prompt: string,
+  chatJid: string,
+): Promise<string | null> {
   const isMain = group.folder === MAIN_GROUP_FOLDER;
   const sessionId = sessions[group.folder];
 
   // Update tasks snapshot for container to read (filtered by group)
   const tasks = getAllTasks();
-  writeTasksSnapshot(group.folder, isMain, tasks.map(t => ({
-    id: t.id,
-    groupFolder: t.group_folder,
-    prompt: t.prompt,
-    schedule_type: t.schedule_type,
-    schedule_value: t.schedule_value,
-    status: t.status,
-    next_run: t.next_run
-  })));
+  writeTasksSnapshot(
+    group.folder,
+    isMain,
+    tasks.map((t) => ({
+      id: t.id,
+      groupFolder: t.group_folder,
+      prompt: t.prompt,
+      schedule_type: t.schedule_type,
+      schedule_value: t.schedule_value,
+      status: t.status,
+      next_run: t.next_run,
+    })),
+  );
 
   // Update available groups snapshot (main group only can see all groups)
   const availableGroups = getAvailableGroups();
-  writeGroupsSnapshot(group.folder, isMain, availableGroups, new Set(Object.keys(registeredGroups)));
+  writeGroupsSnapshot(
+    group.folder,
+    isMain,
+    availableGroups,
+    new Set(Object.keys(registeredGroups)),
+  );
 
   try {
     const output = await runContainerAgent(group, {
@@ -193,110 +250,148 @@ async function runAgent(group: RegisteredGroup, prompt: string, chatJid: string)
       sessionId,
       groupFolder: group.folder,
       chatJid,
-      isMain
+      isMain,
     });
 
     if (output.newSessionId) {
       sessions[group.folder] = output.newSessionId;
-      saveJson(path.join(DATA_DIR, 'sessions.json'), sessions);
+      saveJson(path.join(DATA_DIR, "sessions.json"), sessions);
     }
 
-    if (output.status === 'error') {
-      logger.error({ group: group.name, error: output.error }, 'Container agent error');
+    if (output.status === "error") {
+      logger.error(
+        { group: group.name, error: output.error },
+        "Container agent error",
+      );
       return null;
     }
 
     return output.result;
   } catch (err) {
-    logger.error({ group: group.name, err }, 'Agent error');
+    logger.error({ group: group.name, err }, "Agent error");
     return null;
   }
 }
 
 async function sendMessage(jid: string, text: string): Promise<void> {
-  try {
-    await sock.sendMessage(jid, { text });
-    logger.info({ jid, length: text.length }, 'Message sent');
-  } catch (err) {
-    logger.error({ jid, err }, 'Failed to send message');
+  if (jid.startsWith("tg:")) {
+    await sendTelegramMessage(jid, text);
+  } else {
+    try {
+      await sock.sendMessage(jid, { text });
+      logger.info({ jid, length: text.length }, "Message sent");
+    } catch (err) {
+      logger.error({ jid, err }, "Failed to send message");
+    }
   }
 }
 
 function startIpcWatcher(): void {
-  const ipcBaseDir = path.join(DATA_DIR, 'ipc');
+  const ipcBaseDir = path.join(DATA_DIR, "ipc");
   fs.mkdirSync(ipcBaseDir, { recursive: true });
 
   const processIpcFiles = async () => {
     // Scan all group IPC directories (identity determined by directory)
     let groupFolders: string[];
     try {
-      groupFolders = fs.readdirSync(ipcBaseDir).filter(f => {
+      groupFolders = fs.readdirSync(ipcBaseDir).filter((f) => {
         const stat = fs.statSync(path.join(ipcBaseDir, f));
-        return stat.isDirectory() && f !== 'errors';
+        return stat.isDirectory() && f !== "errors";
       });
     } catch (err) {
-      logger.error({ err }, 'Error reading IPC base directory');
+      logger.error({ err }, "Error reading IPC base directory");
       setTimeout(processIpcFiles, IPC_POLL_INTERVAL);
       return;
     }
 
     for (const sourceGroup of groupFolders) {
       const isMain = sourceGroup === MAIN_GROUP_FOLDER;
-      const messagesDir = path.join(ipcBaseDir, sourceGroup, 'messages');
-      const tasksDir = path.join(ipcBaseDir, sourceGroup, 'tasks');
+      const messagesDir = path.join(ipcBaseDir, sourceGroup, "messages");
+      const tasksDir = path.join(ipcBaseDir, sourceGroup, "tasks");
 
       // Process messages from this group's IPC directory
       try {
         if (fs.existsSync(messagesDir)) {
-          const messageFiles = fs.readdirSync(messagesDir).filter(f => f.endsWith('.json'));
+          const messageFiles = fs
+            .readdirSync(messagesDir)
+            .filter((f) => f.endsWith(".json"));
           for (const file of messageFiles) {
             const filePath = path.join(messagesDir, file);
             try {
-              const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-              if (data.type === 'message' && data.chatJid && data.text) {
+              const data = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+              if (data.type === "message" && data.chatJid && data.text) {
                 // Authorization: verify this group can send to this chatJid
                 const targetGroup = registeredGroups[data.chatJid];
-                if (isMain || (targetGroup && targetGroup.folder === sourceGroup)) {
-                  await sendMessage(data.chatJid, `${ASSISTANT_NAME}: ${data.text}`);
-                  logger.info({ chatJid: data.chatJid, sourceGroup }, 'IPC message sent');
+                if (
+                  isMain ||
+                  (targetGroup && targetGroup.folder === sourceGroup)
+                ) {
+                  await sendMessage(
+                    data.chatJid,
+                    `${ASSISTANT_NAME}: ${data.text}`,
+                  );
+                  logger.info(
+                    { chatJid: data.chatJid, sourceGroup },
+                    "IPC message sent",
+                  );
                 } else {
-                  logger.warn({ chatJid: data.chatJid, sourceGroup }, 'Unauthorized IPC message attempt blocked');
+                  logger.warn(
+                    { chatJid: data.chatJid, sourceGroup },
+                    "Unauthorized IPC message attempt blocked",
+                  );
                 }
               }
               fs.unlinkSync(filePath);
             } catch (err) {
-              logger.error({ file, sourceGroup, err }, 'Error processing IPC message');
-              const errorDir = path.join(ipcBaseDir, 'errors');
+              logger.error(
+                { file, sourceGroup, err },
+                "Error processing IPC message",
+              );
+              const errorDir = path.join(ipcBaseDir, "errors");
               fs.mkdirSync(errorDir, { recursive: true });
-              fs.renameSync(filePath, path.join(errorDir, `${sourceGroup}-${file}`));
+              fs.renameSync(
+                filePath,
+                path.join(errorDir, `${sourceGroup}-${file}`),
+              );
             }
           }
         }
       } catch (err) {
-        logger.error({ err, sourceGroup }, 'Error reading IPC messages directory');
+        logger.error(
+          { err, sourceGroup },
+          "Error reading IPC messages directory",
+        );
       }
 
       // Process tasks from this group's IPC directory
       try {
         if (fs.existsSync(tasksDir)) {
-          const taskFiles = fs.readdirSync(tasksDir).filter(f => f.endsWith('.json'));
+          const taskFiles = fs
+            .readdirSync(tasksDir)
+            .filter((f) => f.endsWith(".json"));
           for (const file of taskFiles) {
             const filePath = path.join(tasksDir, file);
             try {
-              const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+              const data = JSON.parse(fs.readFileSync(filePath, "utf-8"));
               // Pass source group identity to processTaskIpc for authorization
               await processTaskIpc(data, sourceGroup, isMain);
               fs.unlinkSync(filePath);
             } catch (err) {
-              logger.error({ file, sourceGroup, err }, 'Error processing IPC task');
-              const errorDir = path.join(ipcBaseDir, 'errors');
+              logger.error(
+                { file, sourceGroup, err },
+                "Error processing IPC task",
+              );
+              const errorDir = path.join(ipcBaseDir, "errors");
               fs.mkdirSync(errorDir, { recursive: true });
-              fs.renameSync(filePath, path.join(errorDir, `${sourceGroup}-${file}`));
+              fs.renameSync(
+                filePath,
+                path.join(errorDir, `${sourceGroup}-${file}`),
+              );
             }
           }
         }
       } catch (err) {
-        logger.error({ err, sourceGroup }, 'Error reading IPC tasks directory');
+        logger.error({ err, sourceGroup }, "Error reading IPC tasks directory");
       }
     }
 
@@ -304,7 +399,7 @@ function startIpcWatcher(): void {
   };
 
   processIpcFiles();
-  logger.info('IPC watcher started (per-group namespaces)');
+  logger.info("IPC watcher started (per-group namespaces)");
 }
 
 async function processTaskIpc(
@@ -322,66 +417,94 @@ async function processTaskIpc(
     name?: string;
     folder?: string;
     trigger?: string;
-    containerConfig?: RegisteredGroup['containerConfig'];
+    containerConfig?: RegisteredGroup["containerConfig"];
   },
-  sourceGroup: string,  // Verified identity from IPC directory
-  isMain: boolean       // Verified from directory path
+  sourceGroup: string, // Verified identity from IPC directory
+  isMain: boolean, // Verified from directory path
 ): Promise<void> {
   // Import db functions dynamically to avoid circular deps
-  const { createTask, updateTask, deleteTask, getTaskById: getTask } = await import('./db.js');
-  const { CronExpressionParser } = await import('cron-parser');
+  const {
+    createTask,
+    updateTask,
+    deleteTask,
+    getTaskById: getTask,
+  } = await import("./db.js");
+  const { CronExpressionParser } = await import("cron-parser");
 
   switch (data.type) {
-    case 'schedule_task':
-      if (data.prompt && data.schedule_type && data.schedule_value && data.groupFolder) {
+    case "schedule_task":
+      if (
+        data.prompt &&
+        data.schedule_type &&
+        data.schedule_value &&
+        data.groupFolder
+      ) {
         // Authorization: non-main groups can only schedule for themselves
         const targetGroup = data.groupFolder;
         if (!isMain && targetGroup !== sourceGroup) {
-          logger.warn({ sourceGroup, targetGroup }, 'Unauthorized schedule_task attempt blocked');
+          logger.warn(
+            { sourceGroup, targetGroup },
+            "Unauthorized schedule_task attempt blocked",
+          );
           break;
         }
 
         // Resolve the correct JID for the target group (don't trust IPC payload)
         const targetJid = Object.entries(registeredGroups).find(
-          ([, group]) => group.folder === targetGroup
+          ([, group]) => group.folder === targetGroup,
         )?.[0];
 
         if (!targetJid) {
-          logger.warn({ targetGroup }, 'Cannot schedule task: target group not registered');
+          logger.warn(
+            { targetGroup },
+            "Cannot schedule task: target group not registered",
+          );
           break;
         }
 
-        const scheduleType = data.schedule_type as 'cron' | 'interval' | 'once';
+        const scheduleType = data.schedule_type as "cron" | "interval" | "once";
 
         let nextRun: string | null = null;
-        if (scheduleType === 'cron') {
+        if (scheduleType === "cron") {
           try {
-            const interval = CronExpressionParser.parse(data.schedule_value, { tz: TIMEZONE });
+            const interval = CronExpressionParser.parse(data.schedule_value, {
+              tz: TIMEZONE,
+            });
             nextRun = interval.next().toISOString();
           } catch {
-            logger.warn({ scheduleValue: data.schedule_value }, 'Invalid cron expression');
+            logger.warn(
+              { scheduleValue: data.schedule_value },
+              "Invalid cron expression",
+            );
             break;
           }
-        } else if (scheduleType === 'interval') {
+        } else if (scheduleType === "interval") {
           const ms = parseInt(data.schedule_value, 10);
           if (isNaN(ms) || ms <= 0) {
-            logger.warn({ scheduleValue: data.schedule_value }, 'Invalid interval');
+            logger.warn(
+              { scheduleValue: data.schedule_value },
+              "Invalid interval",
+            );
             break;
           }
           nextRun = new Date(Date.now() + ms).toISOString();
-        } else if (scheduleType === 'once') {
+        } else if (scheduleType === "once") {
           const scheduled = new Date(data.schedule_value);
           if (isNaN(scheduled.getTime())) {
-            logger.warn({ scheduleValue: data.schedule_value }, 'Invalid timestamp');
+            logger.warn(
+              { scheduleValue: data.schedule_value },
+              "Invalid timestamp",
+            );
             break;
           }
           nextRun = scheduled.toISOString();
         }
 
         const taskId = `task-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-        const contextMode = (data.context_mode === 'group' || data.context_mode === 'isolated')
-          ? data.context_mode
-          : 'isolated';
+        const contextMode =
+          data.context_mode === "group" || data.context_mode === "isolated"
+            ? data.context_mode
+            : "isolated";
         createTask({
           id: taskId,
           group_folder: targetGroup,
@@ -391,67 +514,103 @@ async function processTaskIpc(
           schedule_value: data.schedule_value,
           context_mode: contextMode,
           next_run: nextRun,
-          status: 'active',
-          created_at: new Date().toISOString()
+          status: "active",
+          created_at: new Date().toISOString(),
         });
-        logger.info({ taskId, sourceGroup, targetGroup, contextMode }, 'Task created via IPC');
+        logger.info(
+          { taskId, sourceGroup, targetGroup, contextMode },
+          "Task created via IPC",
+        );
       }
       break;
 
-    case 'pause_task':
+    case "pause_task":
       if (data.taskId) {
         const task = getTask(data.taskId);
         if (task && (isMain || task.group_folder === sourceGroup)) {
-          updateTask(data.taskId, { status: 'paused' });
-          logger.info({ taskId: data.taskId, sourceGroup }, 'Task paused via IPC');
+          updateTask(data.taskId, { status: "paused" });
+          logger.info(
+            { taskId: data.taskId, sourceGroup },
+            "Task paused via IPC",
+          );
         } else {
-          logger.warn({ taskId: data.taskId, sourceGroup }, 'Unauthorized task pause attempt');
+          logger.warn(
+            { taskId: data.taskId, sourceGroup },
+            "Unauthorized task pause attempt",
+          );
         }
       }
       break;
 
-    case 'resume_task':
+    case "resume_task":
       if (data.taskId) {
         const task = getTask(data.taskId);
         if (task && (isMain || task.group_folder === sourceGroup)) {
-          updateTask(data.taskId, { status: 'active' });
-          logger.info({ taskId: data.taskId, sourceGroup }, 'Task resumed via IPC');
+          updateTask(data.taskId, { status: "active" });
+          logger.info(
+            { taskId: data.taskId, sourceGroup },
+            "Task resumed via IPC",
+          );
         } else {
-          logger.warn({ taskId: data.taskId, sourceGroup }, 'Unauthorized task resume attempt');
+          logger.warn(
+            { taskId: data.taskId, sourceGroup },
+            "Unauthorized task resume attempt",
+          );
         }
       }
       break;
 
-    case 'cancel_task':
+    case "cancel_task":
       if (data.taskId) {
         const task = getTask(data.taskId);
         if (task && (isMain || task.group_folder === sourceGroup)) {
           deleteTask(data.taskId);
-          logger.info({ taskId: data.taskId, sourceGroup }, 'Task cancelled via IPC');
+          logger.info(
+            { taskId: data.taskId, sourceGroup },
+            "Task cancelled via IPC",
+          );
         } else {
-          logger.warn({ taskId: data.taskId, sourceGroup }, 'Unauthorized task cancel attempt');
+          logger.warn(
+            { taskId: data.taskId, sourceGroup },
+            "Unauthorized task cancel attempt",
+          );
         }
       }
       break;
 
-    case 'refresh_groups':
+    case "refresh_groups":
       // Only main group can request a refresh
       if (isMain) {
-        logger.info({ sourceGroup }, 'Group metadata refresh requested via IPC');
+        logger.info(
+          { sourceGroup },
+          "Group metadata refresh requested via IPC",
+        );
         await syncGroupMetadata(true);
         // Write updated snapshot immediately
         const availableGroups = getAvailableGroups();
-        const { writeGroupsSnapshot: writeGroups } = await import('./container-runner.js');
-        writeGroups(sourceGroup, true, availableGroups, new Set(Object.keys(registeredGroups)));
+        const { writeGroupsSnapshot: writeGroups } =
+          await import("./container-runner.js");
+        writeGroups(
+          sourceGroup,
+          true,
+          availableGroups,
+          new Set(Object.keys(registeredGroups)),
+        );
       } else {
-        logger.warn({ sourceGroup }, 'Unauthorized refresh_groups attempt blocked');
+        logger.warn(
+          { sourceGroup },
+          "Unauthorized refresh_groups attempt blocked",
+        );
       }
       break;
 
-    case 'register_group':
+    case "register_group":
       // Only main group can register new groups
       if (!isMain) {
-        logger.warn({ sourceGroup }, 'Unauthorized register_group attempt blocked');
+        logger.warn(
+          { sourceGroup },
+          "Unauthorized register_group attempt blocked",
+        );
         break;
       }
       if (data.jid && data.name && data.folder && data.trigger) {
@@ -460,87 +619,107 @@ async function processTaskIpc(
           folder: data.folder,
           trigger: data.trigger,
           added_at: new Date().toISOString(),
-          containerConfig: data.containerConfig
+          containerConfig: data.containerConfig,
         });
       } else {
-        logger.warn({ data }, 'Invalid register_group request - missing required fields');
+        logger.warn(
+          { data },
+          "Invalid register_group request - missing required fields",
+        );
       }
       break;
 
     default:
-      logger.warn({ type: data.type }, 'Unknown IPC task type');
+      logger.warn({ type: data.type }, "Unknown IPC task type");
   }
 }
 
 async function connectWhatsApp(): Promise<void> {
-  const authDir = path.join(STORE_DIR, 'auth');
+  const authDir = path.join(STORE_DIR, "auth");
   fs.mkdirSync(authDir, { recursive: true });
 
   const { state, saveCreds } = await useMultiFileAuthState(authDir);
 
   sock = makeWASocket({
-    auth: { creds: state.creds, keys: makeCacheableSignalKeyStore(state.keys, logger) },
+    auth: {
+      creds: state.creds,
+      keys: makeCacheableSignalKeyStore(state.keys, logger),
+    },
     printQRInTerminal: false,
     logger,
-    browser: ['NanoClaw', 'Chrome', '1.0.0']
+    browser: ["NanoClaw", "Chrome", "1.0.0"],
   });
 
-  sock.ev.on('connection.update', (update) => {
+  sock.ev.on("connection.update", (update) => {
     const { connection, lastDisconnect, qr } = update;
 
     if (qr) {
-      const msg = 'WhatsApp authentication required. Run /setup in Claude Code.';
+      const msg =
+        "WhatsApp authentication required. Run /setup in Claude Code.";
       logger.error(msg);
-      exec(`osascript -e 'display notification "${msg}" with title "NanoClaw" sound name "Basso"'`);
+      exec(
+        `osascript -e 'display notification "${msg}" with title "NanoClaw" sound name "Basso"'`,
+      );
       setTimeout(() => process.exit(1), 1000);
     }
 
-    if (connection === 'close') {
+    if (connection === "close") {
       const reason = (lastDisconnect?.error as any)?.output?.statusCode;
       const shouldReconnect = reason !== DisconnectReason.loggedOut;
-      logger.info({ reason, shouldReconnect }, 'Connection closed');
+      logger.info({ reason, shouldReconnect }, "Connection closed");
 
       if (shouldReconnect) {
-        logger.info('Reconnecting...');
+        logger.info("Reconnecting...");
         connectWhatsApp();
       } else {
-        logger.info('Logged out. Run /setup to re-authenticate.');
+        logger.info("Logged out. Run /setup to re-authenticate.");
         process.exit(0);
       }
-    } else if (connection === 'open') {
-      logger.info('Connected to WhatsApp');
+    } else if (connection === "open") {
+      logger.info("Connected to WhatsApp");
       // Sync group metadata on startup (respects 24h cache)
-      syncGroupMetadata().catch(err => logger.error({ err }, 'Initial group sync failed'));
+      syncGroupMetadata().catch((err) =>
+        logger.error({ err }, "Initial group sync failed"),
+      );
       // Set up daily sync timer
       setInterval(() => {
-        syncGroupMetadata().catch(err => logger.error({ err }, 'Periodic group sync failed'));
+        syncGroupMetadata().catch((err) =>
+          logger.error({ err }, "Periodic group sync failed"),
+        );
       }, GROUP_SYNC_INTERVAL_MS);
       startSchedulerLoop({
         sendMessage,
         registeredGroups: () => registeredGroups,
-        getSessions: () => sessions
+        getSessions: () => sessions,
       });
       startIpcWatcher();
       startMessageLoop();
     }
   });
 
-  sock.ev.on('creds.update', saveCreds);
+  sock.ev.on("creds.update", saveCreds);
 
-  sock.ev.on('messages.upsert', ({ messages }) => {
+  sock.ev.on("messages.upsert", ({ messages }) => {
     for (const msg of messages) {
       if (!msg.message) continue;
       const chatJid = msg.key.remoteJid;
-      if (!chatJid || chatJid === 'status@broadcast') continue;
+      if (!chatJid || chatJid === "status@broadcast") continue;
 
-      const timestamp = new Date(Number(msg.messageTimestamp) * 1000).toISOString();
+      const timestamp = new Date(
+        Number(msg.messageTimestamp) * 1000,
+      ).toISOString();
 
       // Always store chat metadata for group discovery
       storeChatMetadata(chatJid, timestamp);
 
       // Only store full message content for registered groups
       if (registeredGroups[chatJid]) {
-        storeMessage(msg, chatJid, msg.key.fromMe || false, msg.pushName || undefined);
+        storeMessage(
+          msg,
+          chatJid,
+          msg.key.fromMe || false,
+          msg.pushName || undefined,
+        );
       }
     }
   });
@@ -554,7 +733,8 @@ async function startMessageLoop(): Promise<void> {
       const jids = Object.keys(registeredGroups);
       const { messages } = getNewMessages(jids, lastTimestamp, ASSISTANT_NAME);
 
-      if (messages.length > 0) logger.info({ count: messages.length }, 'New messages');
+      if (messages.length > 0)
+        logger.info({ count: messages.length }, "New messages");
       for (const msg of messages) {
         try {
           await processMessage(msg);
@@ -562,38 +742,57 @@ async function startMessageLoop(): Promise<void> {
           lastTimestamp = msg.timestamp;
           saveState();
         } catch (err) {
-          logger.error({ err, msg: msg.id }, 'Error processing message, will retry');
+          logger.error(
+            { err, msg: msg.id },
+            "Error processing message, will retry",
+          );
           // Stop processing this batch - failed message will be retried next loop
           break;
         }
       }
     } catch (err) {
-      logger.error({ err }, 'Error in message loop');
+      logger.error({ err }, "Error in message loop");
     }
-    await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL));
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL));
   }
 }
 
 function ensureContainerSystemRunning(): void {
   try {
-    execSync('container system status', { stdio: 'pipe' });
-    logger.debug('Apple Container system already running');
+    execSync("container system status", { stdio: "pipe" });
+    logger.debug("Apple Container system already running");
   } catch {
-    logger.info('Starting Apple Container system...');
+    logger.info("Starting Apple Container system...");
     try {
-      execSync('container system start', { stdio: 'pipe', timeout: 30000 });
-      logger.info('Apple Container system started');
+      execSync("container system start", { stdio: "pipe", timeout: 30000 });
+      logger.info("Apple Container system started");
     } catch (err) {
-      logger.error({ err }, 'Failed to start Apple Container system');
-      console.error('\n╔════════════════════════════════════════════════════════════════╗');
-      console.error('║  FATAL: Apple Container system failed to start                 ║');
-      console.error('║                                                                ║');
-      console.error('║  Agents cannot run without Apple Container. To fix:           ║');
-      console.error('║  1. Install from: https://github.com/apple/container/releases ║');
-      console.error('║  2. Run: container system start                               ║');
-      console.error('║  3. Restart NanoClaw                                          ║');
-      console.error('╚════════════════════════════════════════════════════════════════╝\n');
-      throw new Error('Apple Container system is required but failed to start');
+      logger.error({ err }, "Failed to start Apple Container system");
+      console.error(
+        "\n╔════════════════════════════════════════════════════════════════╗",
+      );
+      console.error(
+        "║  FATAL: Apple Container system failed to start                 ║",
+      );
+      console.error(
+        "║                                                                ║",
+      );
+      console.error(
+        "║  Agents cannot run without Apple Container. To fix:           ║",
+      );
+      console.error(
+        "║  1. Install from: https://github.com/apple/container/releases ║",
+      );
+      console.error(
+        "║  2. Run: container system start                               ║",
+      );
+      console.error(
+        "║  3. Restart NanoClaw                                          ║",
+      );
+      console.error(
+        "╚════════════════════════════════════════════════════════════════╝\n",
+      );
+      throw new Error("Apple Container system is required but failed to start");
     }
   }
 }
@@ -601,12 +800,67 @@ function ensureContainerSystemRunning(): void {
 async function main(): Promise<void> {
   ensureContainerSystemRunning();
   initDatabase();
-  logger.info('Database initialized');
+  logger.info("Database initialized");
   loadState();
-  await connectWhatsApp();
+
+  const hasTelegram = !!TELEGRAM_BOT_TOKEN;
+  const hasWhatsApp = !TELEGRAM_ONLY;
+
+  if (hasTelegram) {
+    await connectTelegram(TELEGRAM_BOT_TOKEN, {
+      onMessage: async (msg, group) => {
+        // Get messages since last agent interaction for context
+        const sinceTimestamp = lastAgentTimestamp[msg.chat_jid] || "";
+        const missedMessages = getMessagesSince(
+          msg.chat_jid,
+          sinceTimestamp,
+          ASSISTANT_NAME,
+        );
+
+        const lines = missedMessages.map((m) => {
+          const escapeXml = (s: string) =>
+            s
+              .replace(/&/g, "&amp;")
+              .replace(/</g, "&lt;")
+              .replace(/>/g, "&gt;")
+              .replace(/"/g, "&quot;");
+          return `<message sender="${escapeXml(m.sender_name)}" time="${m.timestamp}">${escapeXml(m.content)}</message>`;
+        });
+        const prompt = `<messages>\n${lines.join("\n")}\n</messages>`;
+
+        const response = await runAgent(group, prompt, msg.chat_jid);
+        if (response) {
+          lastAgentTimestamp[msg.chat_jid] = msg.timestamp;
+          saveState();
+        }
+        return response;
+      },
+      getRegisteredGroups: () => registeredGroups,
+    });
+
+    if (!hasWhatsApp) {
+      // Telegram-only mode: start scheduler and IPC without WhatsApp
+      startSchedulerLoop({
+        sendMessage,
+        registeredGroups: () => registeredGroups,
+        getSessions: () => sessions,
+      });
+      startIpcWatcher();
+      logger.info(
+        `NanoClaw running (Telegram-only, trigger: @${ASSISTANT_NAME})`,
+      );
+
+      // Keep the process alive
+      await new Promise(() => {});
+    }
+  }
+
+  if (hasWhatsApp) {
+    await connectWhatsApp();
+  }
 }
 
-main().catch(err => {
-  logger.error({ err }, 'Failed to start NanoClaw');
+main().catch((err) => {
+  logger.error({ err }, "Failed to start NanoClaw");
   process.exit(1);
 });

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -1,0 +1,185 @@
+import { Bot } from "grammy";
+import pino from "pino";
+import {
+  ASSISTANT_NAME,
+  TRIGGER_PATTERN,
+  MAIN_GROUP_FOLDER,
+} from "./config.js";
+import { RegisteredGroup, NewMessage } from "./types.js";
+import { storeChatMetadata, storeMessageDirect } from "./db.js";
+
+const logger = pino({
+  level: process.env.LOG_LEVEL || "info",
+  transport: { target: "pino-pretty", options: { colorize: true } },
+});
+
+export interface TelegramCallbacks {
+  onMessage: (
+    msg: NewMessage,
+    group: RegisteredGroup,
+  ) => Promise<string | null>;
+  getRegisteredGroups: () => Record<string, RegisteredGroup>;
+}
+
+let bot: Bot | null = null;
+let callbacks: TelegramCallbacks | null = null;
+
+export async function connectTelegram(
+  botToken: string,
+  cbs: TelegramCallbacks,
+): Promise<void> {
+  callbacks = cbs;
+  bot = new Bot(botToken);
+
+  // Command to get chat ID (useful for registration)
+  bot.command("chatid", (ctx) => {
+    const chatId = ctx.chat.id;
+    const chatType = ctx.chat.type;
+    const chatName =
+      chatType === "private"
+        ? ctx.from?.first_name || "Private"
+        : (ctx.chat as any).title || "Unknown";
+
+    ctx.reply(
+      `Chat ID: \`tg:${chatId}\`\nName: ${chatName}\nType: ${chatType}`,
+      { parse_mode: "Markdown" },
+    );
+  });
+
+  // Command to check bot status
+  bot.command("ping", (ctx) => {
+    ctx.reply(`${ASSISTANT_NAME} is online.`);
+  });
+
+  bot.on("message:text", async (ctx) => {
+    // Skip commands
+    if (ctx.message.text.startsWith("/")) return;
+
+    const chatId = `tg:${ctx.chat.id}`;
+    const content = ctx.message.text;
+    const timestamp = new Date(ctx.message.date * 1000).toISOString();
+    const senderName =
+      ctx.from?.first_name ||
+      ctx.from?.username ||
+      ctx.from?.id.toString() ||
+      "Unknown";
+    const sender = ctx.from?.id.toString() || "";
+    const msgId = ctx.message.message_id.toString();
+
+    // Determine chat name
+    const chatName =
+      ctx.chat.type === "private"
+        ? senderName
+        : (ctx.chat as any).title || chatId;
+
+    // Store chat metadata for discovery
+    storeChatMetadata(chatId, timestamp, chatName);
+
+    // Check if this chat is registered
+    const registeredGroups = callbacks!.getRegisteredGroups();
+    const group = registeredGroups[chatId];
+
+    if (!group) {
+      logger.debug(
+        { chatId, chatName },
+        "Message from unregistered Telegram chat",
+      );
+      return;
+    }
+
+    // Store message for registered chats
+    storeMessageDirect({
+      id: msgId,
+      chat_jid: chatId,
+      sender,
+      sender_name: senderName,
+      content,
+      timestamp,
+      is_from_me: false,
+    });
+
+    const isMain = group.folder === MAIN_GROUP_FOLDER;
+
+    // Check trigger pattern (main responds to all, others need trigger)
+    if (!isMain && !TRIGGER_PATTERN.test(content)) {
+      return;
+    }
+
+    logger.info(
+      { chatId, chatName, sender: senderName },
+      "Processing Telegram message",
+    );
+
+    // Send typing indicator
+    await ctx.replyWithChatAction("typing");
+
+    const msg: NewMessage = {
+      id: msgId,
+      chat_jid: chatId,
+      sender,
+      sender_name: senderName,
+      content,
+      timestamp,
+    };
+
+    try {
+      const response = await callbacks!.onMessage(msg, group);
+      if (response) {
+        await ctx.reply(`${ASSISTANT_NAME}: ${response}`);
+      }
+    } catch (err) {
+      logger.error({ err, chatId }, "Error processing Telegram message");
+    }
+  });
+
+  // Handle errors gracefully
+  bot.catch((err) => {
+    logger.error({ err: err.message }, "Telegram bot error");
+  });
+
+  // Start polling
+  bot.start({
+    onStart: (botInfo) => {
+      logger.info(
+        { username: botInfo.username, id: botInfo.id },
+        "Telegram bot connected",
+      );
+      console.log(`\n  Telegram bot: @${botInfo.username}`);
+      console.log(
+        `  Send /chatid to the bot to get a chat's registration ID\n`,
+      );
+    },
+  });
+}
+
+export async function sendTelegramMessage(
+  chatId: string,
+  text: string,
+): Promise<void> {
+  if (!bot) {
+    logger.warn("Telegram bot not initialized");
+    return;
+  }
+
+  try {
+    // Remove tg: prefix if present
+    const numericId = chatId.replace(/^tg:/, "");
+    await bot.api.sendMessage(numericId, text);
+    logger.info({ chatId, length: text.length }, "Telegram message sent");
+  } catch (err) {
+    logger.error({ chatId, err }, "Failed to send Telegram message");
+  }
+}
+
+export function isTelegramConnected(): boolean {
+  return bot !== null;
+}
+
+export function stopTelegram(): void {
+  if (bot) {
+    bot.stop();
+    bot = null;
+    callbacks = null;
+    logger.info("Telegram bot stopped");
+  }
+}


### PR DESCRIPTION
## Summary

Adds Telegram as a messaging channel option for NanoClaw.

- **Skill**: `/add-telegram` guides users through setup
- **Dual-channel**: Run Telegram alongside WhatsApp, or use `TELEGRAM_ONLY=true` for Telegram-only mode
- **Routing**: Messages route by prefix (`tg:` for Telegram, `@g.us` for WhatsApp)
- **Built-in commands**: `/chatid` and `/ping` for easy setup

## Changes

- `.claude/skills/add-telegram/SKILL.md` - Skill documentation
- `src/telegram.ts` - Telegram connection module using Grammy
- `src/config.ts` - `TELEGRAM_BOT_TOKEN` and `TELEGRAM_ONLY` env vars
- `src/db.ts` - `storeMessageDirect()` for non-WhatsApp channels
- `src/index.ts` - Multi-channel routing in `sendMessage()` and `main()`
- `package.json` - Added `grammy` and `dotenv` dependencies

## Usage

1. Create a bot via [@BotFather](https://t.me/botfather)
2. Set `TELEGRAM_BOT_TOKEN` in `.env`
3. Optionally set `TELEGRAM_ONLY=true` to disable WhatsApp
4. Send `/chatid` to bot to get chat ID for registration
5. Add chat to `registered_groups.json`

## Test plan

- [ ] Bot connects with valid token
- [ ] `/chatid` returns correct chat ID
- [ ] Messages from registered chats trigger agent
- [ ] Responses are sent back via Telegram
- [ ] Works alongside WhatsApp when both configured