### PR TITLE
fix: add maxTurns limit to prevent agent loop runaway

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -237,6 +237,7 @@ async function main(): Promise<void> {
     for await (const message of query({
       prompt,
       options: {
+        maxTurns: 10, // Prevent runaway loops (see issue #30)
         cwd: '/workspace/group',
         resume: input.sessionId,
         allowedTools: [

--- a/container/agent-runner/src/ipc-mcp.ts
+++ b/container/agent-runner/src/ipc-mcp.ts
@@ -55,12 +55,14 @@ export function createIpcMcp(ctx: IpcMcpContext) {
             timestamp: new Date().toISOString()
           };
 
-          const filename = writeIpcFile(MESSAGES_DIR, data);
+          writeIpcFile(MESSAGES_DIR, data);
 
+          // Return clear success signal to prevent agent from retrying
+          const preview = args.text.length > 80 ? args.text.slice(0, 80) + '...' : args.text;
           return {
             content: [{
               type: 'text',
-              text: `Message queued for delivery (${filename})`
+              text: `✓ Message sent successfully. The user will receive: "${preview}"`
             }]
           };
         }


### PR DESCRIPTION
## Summary

Fixes #30 - Adds `maxTurns` limit and improves tool response format to prevent agent loop runaway.

## Changes

### 1. Add `maxTurns: 10` to query options

**File**: `container/agent-runner/src/index.ts`

```typescript
options: {
  maxTurns: 10, // Prevent runaway loops (see issue #30)
  // ... other options
}
```

10 turns is sufficient for complex tasks while preventing runaway behavior that caused the incident (21 duplicate messages in 32 seconds).

### 2. Improve `send_message` tool response

**File**: `container/agent-runner/src/ipc-mcp.ts`

Before (ambiguous):
```
Message queued for delivery (filename)
```

After (clear success signal):
```
✓ Message sent successfully. The user will receive: "preview of message..."
```

The clearer response format helps the SDK understand the task is complete, reducing retry behavior.

## Test plan

- [ ] Rebuild container: `./container/build.sh`
- [ ] Test with reminder request to verify no duplicate sends
- [ ] Verify agent completes within 10 turns for normal tasks

## Acceptance Criteria from Issue

- [x] `maxTurns: 10` added to query options in `container/agent-runner/src/index.ts`
- [x] Tool response format improved in `ipc-mcp.ts`

🤖 Generated with [Claude Code](https://claude.ai/code)