### PR TITLE
refactor: deduplicate logger into shared module

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -6,7 +6,6 @@ import { spawn } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import pino from 'pino';
 
 import {
   CONTAINER_IMAGE,
@@ -15,13 +14,9 @@ import {
   DATA_DIR,
   GROUPS_DIR,
 } from './config.js';
+import { logger } from './logger.js';
 import { validateAdditionalMounts } from './mount-security.js';
 import { RegisteredGroup } from './types.js';
-
-const logger = pino({
-  level: process.env.LOG_LEVEL || 'info',
-  transport: { target: 'pino-pretty', options: { colorize: true } },
-});
 
 // Sentinel markers for robust output parsing (must match agent-runner)
 const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import { exec, execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
-import pino from 'pino';
 
 import makeWASocket, {
   DisconnectReason,
@@ -42,13 +41,9 @@ import {
 import { startSchedulerLoop } from './task-scheduler.js';
 import { NewMessage, RegisteredGroup, Session } from './types.js';
 import { loadJson, saveJson } from './utils.js';
+import { logger } from './logger.js';
 
 const GROUP_SYNC_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
-
-const logger = pino({
-  level: process.env.LOG_LEVEL || 'info',
-  transport: { target: 'pino-pretty', options: { colorize: true } },
-});
 
 let sock: WASocket;
 let lastTimestamp = '';

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,6 @@
+import pino from 'pino';
+
+export const logger = pino({
+  level: process.env.LOG_LEVEL || 'info',
+  transport: { target: 'pino-pretty', options: { colorize: true } },
+});

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -1,7 +1,6 @@
 import { CronExpressionParser } from 'cron-parser';
 import fs from 'fs';
 import path from 'path';
-import pino from 'pino';
 
 import {
   DATA_DIR,
@@ -18,12 +17,8 @@ import {
   logTaskRun,
   updateTaskAfterRun,
 } from './db.js';
+import { logger } from './logger.js';
 import { RegisteredGroup, ScheduledTask } from './types.js';
-
-const logger = pino({
-  level: process.env.LOG_LEVEL || 'info',
-  transport: { target: 'pino-pretty', options: { colorize: true } },
-});
 
 export interface SchedulerDependencies {
   sendMessage: (jid: string, text: string) => Promise<void>;


### PR DESCRIPTION
## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [ ] **Fix** - bug fix or security fix to source code
- [x] **Simplification** - reduces or simplifies source code

## Description

three files (`index.ts`, `container-runner.ts`, `task-scheduler.ts`) each created their own identical pino logger with the same config:

```typescript
const logger = pino({
  level: process.env.LOG_LEVEL || 'info',
  transport: { target: 'pino-pretty', options: { colorize: true } }
});
```

this extracts it into a single `src/logger.ts` module and replaces the three copies with imports. net result: **-9 lines**, zero behavior change.

**files changed:**
| file | change |
|------|--------|
| `src/logger.ts` | new shared module |
| `src/index.ts` | remove pino import + logger block, add logger import |
| `src/container-runner.ts` | same |
| `src/task-scheduler.ts` | same |

typechecks clean (`tsc --noEmit` passes with zero errors).