### PR TITLE
Add setup-token alternative for OAuth authentication in setup skill

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -81,19 +81,41 @@ Ask the user:
 Ask the user:
 > Want me to grab the OAuth token from your current Claude session?
 
-If yes:
+If yes, first try extracting from the credentials file:
 ```bash
 TOKEN=$(cat ~/.claude/.credentials.json 2>/dev/null | jq -r '.claudeAiOauth.accessToken // empty')
 if [ -n "$TOKEN" ]; then
   echo "CLAUDE_CODE_OAUTH_TOKEN=$TOKEN" > .env
   echo "Token configured: ${TOKEN:0:20}...${TOKEN: -4}"
 else
-  echo "No token found - are you logged in to Claude Code?"
+  echo "No token found in credentials file"
 fi
 ```
 
 If the token wasn't found, tell the user:
-> Run `claude` in another terminal and log in first, then come back here.
+> The credentials file wasn't found. This is common on newer macOS versions (Tahoe+).
+>
+> You have two options:
+> 1. **Generate a setup token** (recommended) - Run `claude --setup-token` in another terminal. This generates a long-lived token valid for 1 year.
+> 2. **Log in first** - Run `claude` in another terminal and log in, then we'll try again.
+>
+> Which would you prefer?
+
+If they choose the setup token option:
+> Run this command in another terminal:
+> ```
+> claude --setup-token
+> ```
+> Copy the token that's displayed (starts with `sk-ant-oat01-`) and paste it here.
+
+When they provide the token:
+```bash
+# User provides TOKEN value
+echo "CLAUDE_CODE_OAUTH_TOKEN=$TOKEN" > .env
+echo "Token configured: ${TOKEN:0:20}...${TOKEN: -4}"
+```
+
+If they choose to log in first, have them run `claude` and log in, then re-run the extraction command above.
 
 ### Option 2: API Key
 


### PR DESCRIPTION
On macOS Tahoe+, the ~/.claude/.credentials.json file may not exist.
This adds an alternative flow using `claude --setup-token` to generate
a long-lived authentication token when the credentials file is missing.

Fixes #41

https://claude.ai/code/session_01VAjctQmH2oPjpMkkpW3pFg