### PR TITLE
refactor: deduplicate logger into shared module

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -7,7 +7,6 @@ import { spawn } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import pino from 'pino';
 import {
   CONTAINER_IMAGE,
   CONTAINER_TIMEOUT,
@@ -17,11 +16,7 @@ import {
 } from './config.js';
 import { RegisteredGroup } from './types.js';
 import { validateAdditionalMounts } from './mount-security.js';
-
-const logger = pino({
-  level: process.env.LOG_LEVEL || 'info',
-  transport: { target: 'pino-pretty', options: { colorize: true } }
-});
+import { logger } from './logger.js';
 
 // Sentinel markers for robust output parsing (must match agent-runner)
 const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,6 @@ import makeWASocket, {
   makeCacheableSignalKeyStore,
   WASocket
 } from '@whiskeysockets/baileys';
-import pino from 'pino';
 import { exec, execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
@@ -24,13 +23,9 @@ import { initDatabase, storeMessage, storeChatMetadata, getNewMessages, getMessa
 import { startSchedulerLoop } from './task-scheduler.js';
 import { runContainerAgent, writeTasksSnapshot, writeGroupsSnapshot, AvailableGroup } from './container-runner.js';
 import { loadJson, saveJson } from './utils.js';
+import { logger } from './logger.js';
 
 const GROUP_SYNC_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
-
-const logger = pino({
-  level: process.env.LOG_LEVEL || 'info',
-  transport: { target: 'pino-pretty', options: { colorize: true } }
-});
 
 let sock: WASocket;
 let lastTimestamp = '';

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,6 @@
+import pino from 'pino';
+
+export const logger = pino({
+  level: process.env.LOG_LEVEL || 'info',
+  transport: { target: 'pino-pretty', options: { colorize: true } }
+});

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -1,16 +1,11 @@
 import fs from 'fs';
 import path from 'path';
-import pino from 'pino';
 import { CronExpressionParser } from 'cron-parser';
 import { getDueTasks, updateTaskAfterRun, logTaskRun, getTaskById, getAllTasks } from './db.js';
 import { ScheduledTask, RegisteredGroup } from './types.js';
 import { GROUPS_DIR, SCHEDULER_POLL_INTERVAL, DATA_DIR, MAIN_GROUP_FOLDER, TIMEZONE } from './config.js';
 import { runContainerAgent, writeTasksSnapshot } from './container-runner.js';
-
-const logger = pino({
-  level: process.env.LOG_LEVEL || 'info',
-  transport: { target: 'pino-pretty', options: { colorize: true } }
-});
+import { logger } from './logger.js';
 
 export interface SchedulerDependencies {
   sendMessage: (jid: string, text: string) => Promise<void>;


### PR DESCRIPTION
Consolidates 3 identical pino logger configs into shared `src/logger.ts`.

Ported from #39 by @Ejae-dev with review validation.

## Changes
- New: `src/logger.ts` with shared config
- Updated imports in index.ts, container-runner.ts, task-scheduler.ts
- Net -9 lines, zero behavior change