### PR TITLE
fix: require UTC timestamps for one-time scheduled tasks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -370,11 +370,17 @@ async function processTaskIpc(
           }
           nextRun = new Date(Date.now() + ms).toISOString();
         } else if (scheduleType === 'once') {
-          const scheduled = new Date(data.schedule_value);
-          if (isNaN(scheduled.getTime())) {
-            logger.warn({ scheduleValue: data.schedule_value }, 'Invalid timestamp');
+          // Expect UTC timestamp with Z suffix (e.g., "2026-02-01T23:30:00.000Z")
+          if (!data.schedule_value.endsWith('Z')) {
+            logger.warn({ scheduleValue: data.schedule_value }, 'Invalid timestamp: must be UTC with Z suffix');
             break;
           }
+          const scheduled = new Date(data.schedule_value);
+          if (isNaN(scheduled.getTime())) {
+            logger.warn({ scheduleValue: data.schedule_value }, 'Invalid UTC timestamp');
+            break;
+          }
+          // Store as-is (already UTC)
           nextRun = scheduled.toISOString();
         }
 


### PR DESCRIPTION
Enforces UTC Z-suffix for one-time task scheduling to prevent timezone bugs.

Ported from #21 by @emcmanus with review validation.

## Changes
- Updated tool description to require Z-suffix
- Added validation in both container IPC and host router (defense-in-depth)
- Clear error messages guide to correct format