### PR TITLE
Remove ToS gray areas section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ Then run `/setup`. Claude Code handles everything: dependencies, authentication,
 
 **Best harness, best model.** This runs on Claude Agent SDK, which means you're running Claude Code directly. The harness matters. A bad harness makes even smart models seem dumb, a good harness gives them superpowers. Claude Code is (IMO) the best harness available.
 
-**No ToS gray areas.** Because it uses Claude Agent SDK natively with no hacks or workarounds, using your subscription with your auth token is completely legitimate (I think). No risk of being shut down for terms of service violations (I am not a lawyer).
-
 ## What It Supports
 
 - **WhatsApp I/O** - Message Claude from your phone


### PR DESCRIPTION
Removed a section discussing the legitimacy of using the Claude Agent SDK with a subscription. You shouldn't be saying that. 
You are right, you are not a lawyer. 
Claude's ToS specify fair use about what an agent can be used for. It's nothing to do with whether you've used the SDK.  Let people make their own minds up. 
To advertise something like this is beyond our pay grade.

## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description


## For Skills

- [x] I have not made any changes to source code
- [ ] My skill contains instructions for Claude to follow (not pre-built code)
- [ ] I tested this skill on a fresh clone
