### PR TITLE
feat: add proxy support for onboarding against GFW

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@whiskeysockets/baileys": "^7.0.0-rc.9",
         "better-sqlite3": "^11.8.1",
         "cron-parser": "^5.5.0",
+        "https-proxy-agent": "^7.0.6",
         "pino": "^9.6.0",
         "pino-pretty": "^13.0.0",
         "qrcode-terminal": "^0.12.0",
@@ -1218,6 +1219,15 @@
         }
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/async-mutex": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
@@ -1587,6 +1597,19 @@
       "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
       "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
       "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/ieee754": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@whiskeysockets/baileys": "^7.0.0-rc.9",
     "better-sqlite3": "^11.8.1",
     "cron-parser": "^5.5.0",
+    "https-proxy-agent": "^7.0.6",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",
     "qrcode-terminal": "^0.12.0",


### PR DESCRIPTION
## Summary

This PR adds HTTP proxy support to the WhatsApp authentication script, allowing users to connect through a proxy by setting the `HTTPS_PROXY` environment variable.

## Motivation

In mainland China, direct connections to WhatsApp servers are blocked by the Great Firewall (GFW). During the NanoClaw setup process, the `npm run auth` step fails with connection errors like:

```
stream errored out (code 515)
Connection failed. Please try again.
```

This makes it impossible for developers in China to complete the initial setup without additional workarounds.

## Solution

- Added `https-proxy-agent` dependency
- Modified `src/whatsapp-auth.ts` to detect `HTTPS_PROXY`/`https_proxy` environment variables
- Pass the proxy agent to both `agent` and `fetchAgent` options in the Baileys socket configuration

## Usage

```bash
HTTPS_PROXY=http://127.0.0.1:6152 npm run auth
```

This change is backward-compatible - when no proxy is configured, the authentication works exactly as before.

## Test Plan

- [x] Tested with Surge proxy on macOS in mainland China
- [x] Successfully authenticated with WhatsApp through the proxy
- [x] Verified no impact when `HTTPS_PROXY` is not set

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Manual test record without proxy config (even with `HTTP_PROXY` config, the `npm run auth` fails):

<img width="1626" height="1350" alt="image" src="https://github.com/user-attachments/assets/e5970329-883e-464e-89d7-1b80e7c1a842" />

With the proxy config, the onboarding process could pass using `HTTP_PROXY`:

<img width="1604" height="558" alt="image" src="https://github.com/user-attachments/assets/c4693c45-f933-4236-add3-fa7b184097cd" />

The code comment also ensures that when we meet GFW issues during `/setup`, the agent could identify and fix it.