### PR TITLE
Add Docker support and fix duplicate response bug

### DIFF
--- a/container/build.sh
+++ b/container/build.sh
@@ -6,18 +6,35 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
+# Add Docker Desktop credential helpers to PATH (macOS)
+if [ -d "/Applications/Docker.app/Contents/Resources/bin" ]; then
+  export PATH="/Applications/Docker.app/Contents/Resources/bin:$PATH"
+fi
+
+# Find docker (may be in /usr/local/opt/docker/bin on macOS with Homebrew)
+if command -v docker &> /dev/null; then
+  DOCKER=docker
+elif [ -x /usr/local/opt/docker/bin/docker ]; then
+  DOCKER=/usr/local/opt/docker/bin/docker
+elif [ -x /usr/local/bin/docker ]; then
+  DOCKER=/usr/local/bin/docker
+else
+  echo "Error: docker not found" >&2
+  exit 1
+fi
+
 IMAGE_NAME="nanoclaw-agent"
 TAG="${1:-latest}"
 
 echo "Building NanoClaw agent container image..."
 echo "Image: ${IMAGE_NAME}:${TAG}"
 
-# Build with Apple Container
-container build -t "${IMAGE_NAME}:${TAG}" .
+# Build with Docker
+$DOCKER build -t "${IMAGE_NAME}:${TAG}" .
 
 echo ""
 echo "Build complete!"
 echo "Image: ${IMAGE_NAME}:${TAG}"
 echo ""
 echo "Test with:"
-echo "  echo '{\"prompt\":\"What is 2+2?\",\"groupFolder\":\"test\",\"chatJid\":\"test@g.us\",\"isMain\":false}' | container run -i ${IMAGE_NAME}:${TAG}"
+echo "  echo '{\"prompt\":\"What is 2+2?\",\"groupFolder\":\"test\",\"chatJid\":\"test@g.us\",\"isMain\":false}' | docker run -i ${IMAGE_NAME}:${TAG}"

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -1,6 +1,6 @@
 /**
  * Container Runner for NanoClaw
- * Spawns agent execution in Apple Container and handles IPC
+ * Spawns agent execution in Docker container and handles IPC
  */
 
 import { spawn } from 'child_process';
@@ -85,7 +85,7 @@ function buildVolumeMounts(group: RegisteredGroup, isMain: boolean): VolumeMount
     });
 
     // Global memory directory (read-only for non-main)
-    // Apple Container only supports directory mounts, not file mounts
+    // Docker bind mounts work with both files and directories
     const globalDir = path.join(GROUPS_DIR, 'global');
     if (fs.existsSync(globalDir)) {
       mounts.push({
@@ -117,7 +117,7 @@ function buildVolumeMounts(group: RegisteredGroup, isMain: boolean): VolumeMount
     readonly: false
   });
 
-  // Environment file directory (workaround for Apple Container -i env var bug)
+  // Environment file directory (keeps credentials out of process listings)
   // Only expose specific auth variables needed by Claude Code, not the entire .env
   const envDir = path.join(DATA_DIR, 'env');
   fs.mkdirSync(envDir, { recursive: true });
@@ -159,10 +159,10 @@ function buildVolumeMounts(group: RegisteredGroup, isMain: boolean): VolumeMount
 function buildContainerArgs(mounts: VolumeMount[]): string[] {
   const args: string[] = ['run', '-i', '--rm'];
 
-  // Apple Container: --mount for readonly, -v for read-write
+  // Docker: -v with :ro suffix for readonly
   for (const mount of mounts) {
     if (mount.readonly) {
-      args.push('--mount', `type=bind,source=${mount.hostPath},target=${mount.containerPath},readonly`);
+      args.push('-v', `${mount.hostPath}:${mount.containerPath}:ro`);
     } else {
       args.push('-v', `${mount.hostPath}:${mount.containerPath}`);
     }
@@ -201,7 +201,7 @@ export async function runContainerAgent(
   fs.mkdirSync(logsDir, { recursive: true });
 
   return new Promise((resolve) => {
-    const container = spawn('container', containerArgs, {
+    const container = spawn('docker', containerArgs, {
       stdio: ['pipe', 'pipe', 'pipe']
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -579,32 +579,27 @@ async function startMessageLoop(): Promise<void> {
   }
 }
 
-function ensureContainerSystemRunning(): void {
+function ensureDockerRunning(): void {
   try {
-    execSync('container system status', { stdio: 'pipe' });
-    logger.debug('Apple Container system already running');
+    execSync('docker info', { stdio: 'pipe', timeout: 10000 });
+    logger.debug('Docker daemon is running');
   } catch {
-    logger.info('Starting Apple Container system...');
-    try {
-      execSync('container system start', { stdio: 'pipe', timeout: 30000 });
-      logger.info('Apple Container system started');
-    } catch (err) {
-      logger.error({ err }, 'Failed to start Apple Container system');
-      console.error('\n╔════════════════════════════════════════════════════════════════╗');
-      console.error('║  FATAL: Apple Container system failed to start                 ║');
-      console.error('║                                                                ║');
-      console.error('║  Agents cannot run without Apple Container. To fix:           ║');
-      console.error('║  1. Install from: https://github.com/apple/container/releases ║');
-      console.error('║  2. Run: container system start                               ║');
-      console.error('║  3. Restart NanoClaw                                          ║');
-      console.error('╚════════════════════════════════════════════════════════════════╝\n');
-      throw new Error('Apple Container system is required but failed to start');
-    }
+    logger.error('Docker daemon is not running');
+    console.error('\n╔════════════════════════════════════════════════════════════════╗');
+    console.error('║  FATAL: Docker is not running                                  ║');
+    console.error('║                                                                ║');
+    console.error('║  Agents cannot run without Docker. To fix:                     ║');
+    console.error('║  macOS: Start Docker Desktop                                   ║');
+    console.error('║  Linux: sudo systemctl start docker                            ║');
+    console.error('║                                                                ║');
+    console.error('║  Install from: https://docker.com/products/docker-desktop      ║');
+    console.error('╚════════════════════════════════════════════════════════════════╝\n');
+    throw new Error('Docker is required but not running');
   }
 }
 
 async function main(): Promise<void> {
-  ensureContainerSystemRunning();
+  ensureDockerRunning();
   initDatabase();
   logger.info('Database initialized');
   loadState();


### PR DESCRIPTION
## Summary

- **Fix duplicate responses on reconnect**: When the WhatsApp connection drops (e.g. laptop sleep/wake), `connectWhatsApp()` is called recursively, spawning duplicate `startMessageLoop()`, `startIpcWatcher()`, and `startSchedulerLoop()` instances. After N reconnects, N+1 loops process the same messages, causing 5-6x duplicate replies. Added a `loopsStarted` guard so loops only start once.

- **Add Docker support**: Replaces Apple Container commands with Docker equivalents, making NanoClaw accessible on non-Apple-Silicon Macs and Linux hosts. Changes `container` CLI calls to `docker`, adjusts volume mount syntax, and auto-detects Docker binary location on macOS.

## Test plan

- [ ] Verify single response after multiple sleep/wake cycles
- [ ] Verify `npm run build` passes
- [ ] Verify `./container/build.sh` builds the image with Docker
- [ ] Verify agent containers spawn and respond correctly via Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)