### PR TITLE
fix: use execFile instead of exec for osascript notification

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { exec, execSync } from 'child_process';
+import { execFile, execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 
@@ -672,9 +672,10 @@ async function connectWhatsApp(): Promise<void> {
       const msg =
         'WhatsApp authentication required. Run /setup in Claude Code.';
       logger.error(msg);
-      exec(
-        `osascript -e 'display notification "${msg}" with title "NanoClaw" sound name "Basso"'`,
-      );
+      execFile('osascript', [
+        '-e',
+        `display notification "${msg}" with title "NanoClaw" sound name "Basso"`,
+      ]);
       setTimeout(() => process.exit(1), 1000);
     }
 


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

Replaces `exec()` with string interpolation for the macOS notification with `execFile()` using an argument array. This eliminates a potential command injection vector -- while the current message is hardcoded, the pattern is fragile and any future change could introduce injection.

Also removes the unused `exec` import (only `execFile` and `execSync` remain).

**Files changed:** `src/index.ts`

Made with [Cursor](https://cursor.com)