### PR TITLE
fix: replace hardcoded /Users/user fallback with os.homedir()

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+import os from 'os';
 import path from 'path';
 
 export const ASSISTANT_NAME = process.env.ASSISTANT_NAME || 'Andy';
@@ -6,7 +7,7 @@ export const SCHEDULER_POLL_INTERVAL = 60000;
 
 // Absolute paths needed for container mounts
 const PROJECT_ROOT = process.cwd();
-const HOME_DIR = process.env.HOME || '/Users/user';
+const HOME_DIR = process.env.HOME || os.homedir();
 
 // Mount security: allowlist stored OUTSIDE project root, never mounted into containers
 export const MOUNT_ALLOWLIST_PATH = path.join(

--- a/src/mount-security.ts
+++ b/src/mount-security.ts
@@ -7,6 +7,7 @@
  * Allowlist location: ~/.config/nanoclaw/mount-allowlist.json
  */
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import pino from 'pino';
 
@@ -121,7 +122,7 @@ export function loadMountAllowlist(): MountAllowlist | null {
  * Expand ~ to home directory and resolve to absolute path
  */
 function expandPath(p: string): string {
-  const homeDir = process.env.HOME || '/Users/user';
+  const homeDir = process.env.HOME || os.homedir();
   if (p.startsWith('~/')) {
     return path.join(homeDir, p.slice(2));
   }


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

Both `src/config.ts` and `src/mount-security.ts` had `process.env.HOME || '/Users/user'` as a fallback for the home directory. This is macOS-specific and would silently produce an incorrect path on Linux or in containers where HOME is unset.

Replaces with `os.homedir()` which works cross-platform and returns the actual home directory from the OS.

**Files changed:** `src/config.ts`, `src/mount-security.ts`

Made with [Cursor](https://cursor.com)