### PR TITLE
feat: per-group queue, SQLite state, graceful shutdown

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -40,9 +40,15 @@ export interface ContainerInput {
   isMain: boolean;
 }
 
+export interface AgentResponse {
+  status: 'responded' | 'silent';
+  userMessage?: string;
+  internalLog?: string;
+}
+
 export interface ContainerOutput {
   status: 'success' | 'error';
-  result: string | null;
+  result: AgentResponse | null;
   newSessionId?: string;
   error?: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import {
   TRIGGER_PATTERN,
 } from './config.js';
 import {
+  AgentResponse,
   AvailableGroup,
   runContainerAgent,
   writeGroupsSnapshot,
@@ -236,22 +237,35 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   const response = await runAgent(group, prompt, chatJid);
   await setTyping(chatJid, false);
 
-  if (response) {
-    // Fix batching bug: advance to latest message in batch, not just the trigger
-    lastAgentTimestamp[chatJid] =
-      missedMessages[missedMessages.length - 1].timestamp;
-    saveState();
-    await sendMessage(chatJid, `${ASSISTANT_NAME}: ${response}`);
-    return true;
+  if (response === 'error') {
+    // Container or agent error — signal failure so queue can retry with backoff
+    return false;
   }
-  return false;
+
+  // Agent processed messages successfully (whether it responded or stayed silent)
+  lastAgentTimestamp[chatJid] =
+    missedMessages[missedMessages.length - 1].timestamp;
+  saveState();
+
+  if (response.status === 'responded' && response.userMessage) {
+    await sendMessage(chatJid, `${ASSISTANT_NAME}: ${response.userMessage}`);
+  }
+
+  if (response.internalLog) {
+    logger.info(
+      { group: group.name, agentStatus: response.status },
+      `Agent: ${response.internalLog}`,
+    );
+  }
+
+  return true;
 }
 
 async function runAgent(
   group: RegisteredGroup,
   prompt: string,
   chatJid: string,
-): Promise<string | null> {
+): Promise<AgentResponse | 'error'> {
   const isMain = group.folder === MAIN_GROUP_FOLDER;
   const sessionId = sessions[group.folder];
 
@@ -303,13 +317,13 @@ async function runAgent(
         { group: group.name, error: output.error },
         'Container agent error',
       );
-      return null;
+      return 'error';
     }
 
-    return output.result;
+    return output.result ?? { status: 'silent' };
   } catch (err) {
     logger.error({ group: group.name, err }, 'Agent error');
-    return null;
+    return 'error';
   }
 }
 

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -103,8 +103,8 @@ async function runTask(
 
     if (output.status === 'error') {
       error = output.error || 'Unknown error';
-    } else {
-      result = output.result;
+    } else if (output.result) {
+      result = output.result.userMessage || output.result.internalLog || null;
     }
 
     logger.info(


### PR DESCRIPTION
Add per-group container locking with global concurrency limit to prevent
concurrent containers for the same group (#89) and cap total containers.
Fix message batching bug where lastAgentTimestamp advanced to trigger
message instead of latest in batch, causing redundant re-processing.
Move router state, sessions, and registered groups from JSON files to
SQLite with automatic one-time migration. Add SIGTERM/SIGINT handlers
with graceful shutdown (SIGTERM -> grace period -> SIGKILL). Add startup
recovery for messages missed during crash. Remove dead code: utils.ts,
Session type, isScheduledTask flag, ContainerConfig.env, getTaskRunLogs,
GroupQueue.isActive.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>