### PR TITLE
fix: use valid browser fingerprint for WhatsApp connection

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -662,7 +662,7 @@ async function connectWhatsApp(): Promise<void> {
     },
     printQRInTerminal: false,
     logger,
-    browser: ['NanoClaw', 'Chrome', '1.0.0'],
+    browser: ['Mac OS', 'NanoClaw', '14.4.1'],
   });
 
   sock.ev.on('connection.update', (update) => {

--- a/src/whatsapp-auth.ts
+++ b/src/whatsapp-auth.ts
@@ -45,7 +45,7 @@ async function authenticate(): Promise<void> {
     },
     printQRInTerminal: false,
     logger,
-    browser: ['NanoClaw', 'Chrome', '1.0.0'],
+    browser: ['Mac OS', 'NanoClaw', '14.4.1'],
   });
 
   sock.ev.on('connection.update', (update) => {


### PR DESCRIPTION
## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description

The Baileys `browser` parameter format is `[OS, AppName, Version]`. The current
value `['NanoClaw', 'Chrome', '1.0.0']` puts the app name in the OS field, which
is a non-standard fingerprint that can cause pairing failures and 515 loops.

Changed to `['Mac OS', 'NanoClaw', '14.4.1']` in both `src/index.ts` and
`src/whatsapp-auth.ts`, matching the format used by Baileys' own browser presets.