### PR TITLE
fix: resolve container binary path for launchd compatibility

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,11 @@
+import fs from 'fs';
 import path from 'path';
+
+// Resolve the container binary path
+// Needed because launchd doesn't inherit the shell PATH
+const CONTAINER_CANDIDATES = ['/opt/homebrew/bin/container', '/usr/local/bin/container'];
+export const CONTAINER_BINARY =
+  CONTAINER_CANDIDATES.find((p) => fs.existsSync(p)) || 'container';
 
 export const ASSISTANT_NAME = process.env.ASSISTANT_NAME || 'Andy';
 export const POLL_INTERVAL = 2000;

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -8,6 +8,7 @@ import os from 'os';
 import path from 'path';
 
 import {
+  CONTAINER_BINARY,
   CONTAINER_IMAGE,
   CONTAINER_MAX_OUTPUT_SIZE,
   CONTAINER_TIMEOUT,
@@ -223,7 +224,7 @@ export async function runContainerAgent(
   fs.mkdirSync(logsDir, { recursive: true });
 
   return new Promise((resolve) => {
-    const container = spawn('container', containerArgs, {
+    const container = spawn(CONTAINER_BINARY, containerArgs, {
       stdio: ['pipe', 'pipe', 'pipe'],
     });
 
@@ -277,7 +278,7 @@ export async function runContainerAgent(
       timedOut = true;
       logger.error({ group: group.name, containerName }, 'Container timeout, stopping gracefully');
       // Graceful stop: sends SIGTERM, waits, then SIGKILL — lets --rm fire
-      exec(`container stop ${containerName}`, { timeout: 15000 }, (err) => {
+      exec(`${CONTAINER_BINARY} stop ${containerName}`, { timeout: 15000 }, (err) => {
         if (err) {
           logger.warn({ group: group.name, containerName, err }, 'Graceful stop failed, force killing');
           container.kill('SIGKILL');


### PR DESCRIPTION
## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description

When running as a launchd service, the `container` binary can't be found because
launchd doesn't inherit the user's shell PATH.

- Added `CONTAINER_BINARY` to `config.ts` that resolves the full path from a
  candidate list (`/opt/homebrew/bin/container`, `/usr/local/bin/container`),
  falling back to bare `container` if neither exists
- Replaced all bare `container` command references in `index.ts` and
  `container-runner.ts` with `CONTAINER_BINARY`
- Added `/opt/homebrew/bin` to `process.env.PATH` at startup as an additional
  fallback