### PR TITLE
fix: skip empty messages from triggering agent responses

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -182,6 +182,7 @@ async function processMessage(msg: NewMessage): Promise<void> {
   if (!group) return;
 
   const content = msg.content.trim();
+  if (!content) return;
   const isMainGroup = group.folder === MAIN_GROUP_FOLDER;
 
   // Main group responds to all messages; other groups require trigger prefix


### PR DESCRIPTION
## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description

Non-text WhatsApp messages (reactions, stickers, read receipts, protocol messages)
are stored in the database with empty content. In main group mode, these bypass
the trigger pattern check and spawn agent runs for blank messages.

Added an early return in `processMessage()` when content is empty after trimming.
Messages are still stored in the database so they appear as context when the agent
runs on a real message.