### PR TITLE
feat: download and store WhatsApp media for agent access

### DIFF
--- a/src/channels/whatsapp.test.ts
+++ b/src/channels/whatsapp.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { EventEmitter } from 'events';
 
+const flushPromises = () => new Promise((r) => setTimeout(r, 0));
+
 // --- Mocks ---
 
 // Mock config
@@ -8,6 +10,7 @@ vi.mock('../config.js', () => ({
   STORE_DIR: '/tmp/nanoclaw-test-store',
   ASSISTANT_NAME: 'Andy',
   ASSISTANT_HAS_OWN_NUMBER: false,
+  GROUPS_DIR: '/tmp/nanoclaw-test-groups',
 }));
 
 // Mock logger
@@ -43,6 +46,15 @@ vi.mock('fs', async () => {
 // Mock child_process (used for osascript notification)
 vi.mock('child_process', () => ({
   exec: vi.fn(),
+}));
+
+// Mock whatsapp-media
+const mockGetMediaInfo = vi.fn<() => { type: string; mimetype: string } | null>(() => null);
+const mockDownloadAndSaveMedia = vi.fn<() => Promise<{ filePath: string; containerPath: string } | null>>();
+
+vi.mock('../whatsapp-media.js', () => ({
+  getMediaInfo: (...args: Parameters<typeof mockGetMediaInfo>) => mockGetMediaInfo(...args),
+  downloadAndSaveMedia: (...args: Parameters<typeof mockDownloadAndSaveMedia>) => mockDownloadAndSaveMedia(...args),
 }));
 
 // Build a fake WASocket that's an EventEmitter with the methods we need
@@ -141,6 +153,8 @@ describe('WhatsAppChannel', () => {
   beforeEach(() => {
     fakeSocket = createFakeSocket();
     vi.mocked(getLastGroupSync).mockReturnValue(null);
+    mockGetMediaInfo.mockReset().mockReturnValue(null);
+    mockDownloadAndSaveMedia.mockReset();
   });
 
   afterEach(() => {
@@ -317,6 +331,8 @@ describe('WhatsAppChannel', () => {
         },
       ]);
 
+      await flushPromises();
+
       expect(opts.onChatMetadata).toHaveBeenCalledWith(
         'registered@g.us',
         expect.any(String),
@@ -352,6 +368,8 @@ describe('WhatsAppChannel', () => {
         },
       ]);
 
+      await flushPromises();
+
       expect(opts.onChatMetadata).toHaveBeenCalledWith(
         'unregistered@g.us',
         expect.any(String),
@@ -377,6 +395,8 @@ describe('WhatsAppChannel', () => {
         },
       ]);
 
+      await flushPromises();
+
       expect(opts.onChatMetadata).not.toHaveBeenCalled();
       expect(opts.onMessage).not.toHaveBeenCalled();
     });
@@ -398,6 +418,8 @@ describe('WhatsAppChannel', () => {
           messageTimestamp: Math.floor(Date.now() / 1000),
         },
       ]);
+
+      await flushPromises();
 
       expect(opts.onMessage).not.toHaveBeenCalled();
     });
@@ -423,6 +445,8 @@ describe('WhatsAppChannel', () => {
           messageTimestamp: Math.floor(Date.now() / 1000),
         },
       ]);
+
+      await flushPromises();
 
       expect(opts.onMessage).toHaveBeenCalledWith(
         'registered@g.us',
@@ -452,6 +476,8 @@ describe('WhatsAppChannel', () => {
         },
       ]);
 
+      await flushPromises();
+
       expect(opts.onMessage).toHaveBeenCalledWith(
         'registered@g.us',
         expect.objectContaining({ content: 'Check this photo' }),
@@ -480,9 +506,115 @@ describe('WhatsAppChannel', () => {
         },
       ]);
 
+      await flushPromises();
+
       expect(opts.onMessage).toHaveBeenCalledWith(
         'registered@g.us',
         expect.objectContaining({ content: 'Watch this' }),
+      );
+    });
+
+    it('prepends media path to content when media download succeeds', async () => {
+      mockGetMediaInfo.mockReturnValueOnce({ type: 'imageMessage', mimetype: 'image/jpeg' });
+      mockDownloadAndSaveMedia.mockResolvedValueOnce({
+        filePath: '/groups/test-group/media/msg-media.jpg',
+        containerPath: '/workspace/group/media/msg-media.jpg',
+      });
+
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      triggerMessages([
+        {
+          key: {
+            id: 'msg-media',
+            remoteJid: 'registered@g.us',
+            participant: '5551234@s.whatsapp.net',
+            fromMe: false,
+          },
+          message: {
+            imageMessage: { caption: 'Check this photo', mimetype: 'image/jpeg' },
+          },
+          pushName: 'Alice',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      // Wait for async media download
+      await flushPromises();
+
+      expect(mockDownloadAndSaveMedia).toHaveBeenCalled();
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'registered@g.us',
+        expect.objectContaining({
+          content: '[media: /workspace/group/media/msg-media.jpg]\nCheck this photo',
+        }),
+      );
+    });
+
+    it('delivers original content when media download fails', async () => {
+      mockGetMediaInfo.mockReturnValueOnce({ type: 'imageMessage', mimetype: 'image/jpeg' });
+      mockDownloadAndSaveMedia.mockResolvedValueOnce(null);
+
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      triggerMessages([
+        {
+          key: {
+            id: 'msg-fail',
+            remoteJid: 'registered@g.us',
+            participant: '5551234@s.whatsapp.net',
+            fromMe: false,
+          },
+          message: {
+            imageMessage: { caption: 'Photo caption', mimetype: 'image/jpeg' },
+          },
+          pushName: 'Bob',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      await flushPromises();
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'registered@g.us',
+        expect.objectContaining({ content: 'Photo caption' }),
+      );
+    });
+
+    it('skips media download for text-only messages', async () => {
+      mockGetMediaInfo.mockReturnValue(null);
+
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      triggerMessages([
+        {
+          key: {
+            id: 'msg-text',
+            remoteJid: 'registered@g.us',
+            participant: '5551234@s.whatsapp.net',
+            fromMe: false,
+          },
+          message: { conversation: 'Just text' },
+          pushName: 'Charlie',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      await flushPromises();
+
+      expect(mockDownloadAndSaveMedia).not.toHaveBeenCalled();
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'registered@g.us',
+        expect.objectContaining({ content: 'Just text' }),
       );
     });
 
@@ -507,6 +639,8 @@ describe('WhatsAppChannel', () => {
           messageTimestamp: Math.floor(Date.now() / 1000),
         },
       ]);
+
+      await flushPromises();
 
       // Still delivered but with empty content
       expect(opts.onMessage).toHaveBeenCalledWith(
@@ -534,6 +668,8 @@ describe('WhatsAppChannel', () => {
           messageTimestamp: Math.floor(Date.now() / 1000),
         },
       ]);
+
+      await flushPromises();
 
       expect(opts.onMessage).toHaveBeenCalledWith(
         'registered@g.us',
@@ -575,6 +711,8 @@ describe('WhatsAppChannel', () => {
         },
       ]);
 
+      await flushPromises();
+
       // Should be translated to phone JID
       expect(opts.onChatMetadata).toHaveBeenCalledWith(
         '1234567890@s.whatsapp.net',
@@ -602,6 +740,8 @@ describe('WhatsAppChannel', () => {
         },
       ]);
 
+      await flushPromises();
+
       expect(opts.onChatMetadata).toHaveBeenCalledWith(
         'registered@g.us',
         expect.any(String),
@@ -626,6 +766,8 @@ describe('WhatsAppChannel', () => {
           messageTimestamp: Math.floor(Date.now() / 1000),
         },
       ]);
+
+      await flushPromises();
 
       // Unknown LID passes through unchanged
       expect(opts.onChatMetadata).toHaveBeenCalledWith(
@@ -697,7 +839,7 @@ describe('WhatsAppChannel', () => {
       await connectChannel(channel);
 
       // Give the async flush time to complete
-      await new Promise((r) => setTimeout(r, 50));
+      await flushPromises();
 
       expect(fakeSocket.sendMessage).toHaveBeenCalledTimes(3);
       // Group messages get prefixed
@@ -722,7 +864,7 @@ describe('WhatsAppChannel', () => {
       await connectChannel(channel);
 
       // Wait for async sync to complete
-      await new Promise((r) => setTimeout(r, 50));
+      await flushPromises();
 
       expect(fakeSocket.groupFetchAllParticipating).toHaveBeenCalled();
       expect(updateChatName).toHaveBeenCalledWith('group1@g.us', 'Group One');
@@ -741,7 +883,7 @@ describe('WhatsAppChannel', () => {
 
       await connectChannel(channel);
 
-      await new Promise((r) => setTimeout(r, 50));
+      await flushPromises();
 
       expect(fakeSocket.groupFetchAllParticipating).not.toHaveBeenCalled();
     });

--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -10,13 +10,14 @@ import makeWASocket, {
   useMultiFileAuthState,
 } from '@whiskeysockets/baileys';
 
-import { ASSISTANT_HAS_OWN_NUMBER, ASSISTANT_NAME, STORE_DIR } from '../config.js';
+import { ASSISTANT_HAS_OWN_NUMBER, ASSISTANT_NAME, GROUPS_DIR, STORE_DIR } from '../config.js';
 import {
   getLastGroupSync,
   setLastGroupSync,
   updateChatName,
 } from '../db.js';
 import { logger } from '../logger.js';
+import { downloadAndSaveMedia, getMediaInfo } from '../whatsapp-media.js';
 import { Channel, OnInboundMessage, OnChatMetadata, RegisteredGroup } from '../types.js';
 
 const GROUP_SYNC_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
@@ -162,8 +163,9 @@ export class WhatsAppChannel implements Channel {
 
         // Only deliver full message for registered groups
         const groups = this.opts.registeredGroups();
-        if (groups[chatJid]) {
-          const content =
+        const group = groups[chatJid];
+        if (group) {
+          let content =
             msg.message?.conversation ||
             msg.message?.extendedTextMessage?.text ||
             msg.message?.imageMessage?.caption ||
@@ -171,6 +173,14 @@ export class WhatsAppChannel implements Channel {
             '';
           const sender = msg.key.participant || msg.key.remoteJid || '';
           const senderName = msg.pushName || sender.split('@')[0];
+
+          // Download media if present
+          if (getMediaInfo(msg)) {
+            const result = await downloadAndSaveMedia(msg, group.folder, GROUPS_DIR);
+            if (result) {
+              content = `[media: ${result.containerPath}]\n${content}`;
+            }
+          }
 
           const fromMe = msg.key.fromMe || false;
           // Detect bot messages: with own number, fromMe is reliable

--- a/src/whatsapp-media.test.ts
+++ b/src/whatsapp-media.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// --- Mocks ---
+
+vi.mock('./logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const mockMkdirSync = vi.fn();
+const mockWriteFileSync = vi.fn();
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      mkdirSync: (...args: unknown[]) => mockMkdirSync(...args),
+      writeFileSync: (...args: unknown[]) => mockWriteFileSync(...args),
+    },
+  };
+});
+
+const mockDownloadMediaMessage = vi.fn();
+
+vi.mock('@whiskeysockets/baileys', () => ({
+  downloadMediaMessage: (...args: unknown[]) => mockDownloadMediaMessage(...args),
+}));
+
+import { getMediaInfo, downloadAndSaveMedia } from './whatsapp-media.js';
+import type { WAMessage } from '@whiskeysockets/baileys';
+
+// --- Helpers ---
+
+function makeMessage(overrides: Partial<WAMessage> = {}): WAMessage {
+  return {
+    key: { id: 'test-msg-id', remoteJid: 'group@g.us' },
+    ...overrides,
+  } as WAMessage;
+}
+
+// --- Tests ---
+
+describe('getMediaInfo', () => {
+  it('returns null when message has no content', () => {
+    expect(getMediaInfo(makeMessage({ message: undefined }))).toBeNull();
+    expect(getMediaInfo(makeMessage({ message: null as any }))).toBeNull();
+  });
+
+  it('detects imageMessage', () => {
+    const msg = makeMessage({
+      message: { imageMessage: { mimetype: 'image/jpeg' } } as any,
+    });
+    expect(getMediaInfo(msg)).toEqual({ type: 'imageMessage', mimetype: 'image/jpeg' });
+  });
+
+  it('detects videoMessage', () => {
+    const msg = makeMessage({
+      message: { videoMessage: { mimetype: 'video/mp4' } } as any,
+    });
+    expect(getMediaInfo(msg)).toEqual({ type: 'videoMessage', mimetype: 'video/mp4' });
+  });
+
+  it('detects audioMessage', () => {
+    const msg = makeMessage({
+      message: { audioMessage: { mimetype: 'audio/ogg; codecs=opus', ptt: true } } as any,
+    });
+    expect(getMediaInfo(msg)).toEqual({ type: 'audioMessage', mimetype: 'audio/ogg; codecs=opus' });
+  });
+
+  it('detects documentMessage', () => {
+    const msg = makeMessage({
+      message: { documentMessage: { mimetype: 'application/pdf' } } as any,
+    });
+    expect(getMediaInfo(msg)).toEqual({ type: 'documentMessage', mimetype: 'application/pdf' });
+  });
+
+  it('detects stickerMessage', () => {
+    const msg = makeMessage({
+      message: { stickerMessage: { mimetype: 'image/webp' } } as any,
+    });
+    expect(getMediaInfo(msg)).toEqual({ type: 'stickerMessage', mimetype: 'image/webp' });
+  });
+
+  it('returns empty mimetype when not set', () => {
+    const msg = makeMessage({
+      message: { imageMessage: {} } as any,
+    });
+    expect(getMediaInfo(msg)).toEqual({ type: 'imageMessage', mimetype: '' });
+  });
+
+  it('returns null for text-only messages', () => {
+    const msg = makeMessage({
+      message: { conversation: 'hello' } as any,
+    });
+    expect(getMediaInfo(msg)).toBeNull();
+  });
+});
+
+describe('downloadAndSaveMedia', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null when message has no media', async () => {
+    const msg = makeMessage({ message: { conversation: 'text only' } as any });
+    const result = await downloadAndSaveMedia(msg, 'test-group', '/groups');
+    expect(result).toBeNull();
+    expect(mockDownloadMediaMessage).not.toHaveBeenCalled();
+  });
+
+  it('returns null when message has no ID', async () => {
+    const msg = makeMessage({
+      key: { id: undefined as any, remoteJid: 'group@g.us' },
+      message: { imageMessage: { mimetype: 'image/jpeg' } } as any,
+    });
+    const result = await downloadAndSaveMedia(msg, 'test-group', '/groups');
+    expect(result).toBeNull();
+  });
+
+  it('downloads and saves image with correct extension', async () => {
+    const buffer = Buffer.from('fake-image-data');
+    mockDownloadMediaMessage.mockResolvedValue(buffer);
+
+    const msg = makeMessage({
+      key: { id: 'img-001', remoteJid: 'group@g.us' },
+      message: { imageMessage: { mimetype: 'image/jpeg' } } as any,
+    });
+
+    const result = await downloadAndSaveMedia(msg, 'test-group', '/groups');
+
+    expect(result).toEqual({
+      filePath: '/groups/test-group/media/img-001.jpg',
+      containerPath: '/workspace/group/media/img-001.jpg',
+    });
+    expect(mockMkdirSync).toHaveBeenCalledWith('/groups/test-group/media', { recursive: true });
+    expect(mockWriteFileSync).toHaveBeenCalledWith('/groups/test-group/media/img-001.jpg', buffer);
+  });
+
+  it('uses correct extension for video/mp4', async () => {
+    mockDownloadMediaMessage.mockResolvedValue(Buffer.from('video'));
+
+    const msg = makeMessage({
+      key: { id: 'vid-001', remoteJid: 'group@g.us' },
+      message: { videoMessage: { mimetype: 'video/mp4' } } as any,
+    });
+
+    const result = await downloadAndSaveMedia(msg, 'my-group', '/groups');
+    expect(result!.filePath).toBe('/groups/my-group/media/vid-001.mp4');
+  });
+
+  it('uses correct extension for audio/ogg opus', async () => {
+    mockDownloadMediaMessage.mockResolvedValue(Buffer.from('audio'));
+
+    const msg = makeMessage({
+      key: { id: 'aud-001', remoteJid: 'group@g.us' },
+      message: { audioMessage: { mimetype: 'audio/ogg; codecs=opus' } } as any,
+    });
+
+    const result = await downloadAndSaveMedia(msg, 'my-group', '/groups');
+    expect(result!.filePath).toBe('/groups/my-group/media/aud-001.ogg');
+  });
+
+  it('uses correct extension for PDF document', async () => {
+    mockDownloadMediaMessage.mockResolvedValue(Buffer.from('pdf'));
+
+    const msg = makeMessage({
+      key: { id: 'doc-001', remoteJid: 'group@g.us' },
+      message: { documentMessage: { mimetype: 'application/pdf' } } as any,
+    });
+
+    const result = await downloadAndSaveMedia(msg, 'my-group', '/groups');
+    expect(result!.filePath).toBe('/groups/my-group/media/doc-001.pdf');
+  });
+
+  it('falls back to default extension for unknown mimetype', async () => {
+    mockDownloadMediaMessage.mockResolvedValue(Buffer.from('data'));
+
+    const msg = makeMessage({
+      key: { id: 'img-002', remoteJid: 'group@g.us' },
+      message: { imageMessage: { mimetype: 'image/x-custom' } } as any,
+    });
+
+    const result = await downloadAndSaveMedia(msg, 'test-group', '/groups');
+    // Unknown mimetype falls back to DEFAULT_EXTENSIONS for imageMessage → 'jpg'
+    expect(result!.filePath).toBe('/groups/test-group/media/img-002.jpg');
+  });
+
+  it('falls back to bin for document with unknown mimetype', async () => {
+    mockDownloadMediaMessage.mockResolvedValue(Buffer.from('data'));
+
+    const msg = makeMessage({
+      key: { id: 'doc-002', remoteJid: 'group@g.us' },
+      message: { documentMessage: { mimetype: 'application/x-unknown' } } as any,
+    });
+
+    const result = await downloadAndSaveMedia(msg, 'test-group', '/groups');
+    expect(result!.filePath).toBe('/groups/test-group/media/doc-002.bin');
+  });
+
+  it('returns null and logs warning on download failure', async () => {
+    mockDownloadMediaMessage.mockRejectedValue(new Error('Network error'));
+
+    const msg = makeMessage({
+      key: { id: 'fail-001', remoteJid: 'group@g.us' },
+      message: { imageMessage: { mimetype: 'image/jpeg' } } as any,
+    });
+
+    const result = await downloadAndSaveMedia(msg, 'test-group', '/groups');
+    expect(result).toBeNull();
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+  });
+});

--- a/src/whatsapp-media.ts
+++ b/src/whatsapp-media.ts
@@ -1,0 +1,103 @@
+import fs from 'fs';
+import path from 'path';
+
+import { downloadMediaMessage, type WAMessage } from '@whiskeysockets/baileys';
+
+import { logger } from './logger.js';
+
+export interface MediaInfo {
+  type: string;
+  mimetype: string;
+}
+
+export interface MediaResult {
+  filePath: string;
+  containerPath: string;
+}
+
+const MIME_TO_EXT: Record<string, string> = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+  'image/gif': 'gif',
+  'video/mp4': 'mp4',
+  'video/3gpp': '3gp',
+  'audio/ogg': 'ogg',
+  'audio/ogg; codecs=opus': 'ogg',
+  'audio/mpeg': 'mp3',
+  'audio/mp4': 'm4a',
+  'application/pdf': 'pdf',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
+    'docx',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'xlsx',
+};
+
+const MEDIA_MESSAGE_KEYS = [
+  'imageMessage',
+  'videoMessage',
+  'audioMessage',
+  'documentMessage',
+  'stickerMessage',
+] as const;
+
+const DEFAULT_EXTENSIONS: Record<string, string> = {
+  imageMessage: 'jpg',
+  videoMessage: 'mp4',
+  audioMessage: 'ogg',
+  documentMessage: 'bin',
+  stickerMessage: 'webp',
+};
+
+export function getMediaInfo(msg: WAMessage): MediaInfo | null {
+  if (!msg.message) return null;
+
+  for (const key of MEDIA_MESSAGE_KEYS) {
+    const mediaMsg = msg.message[key];
+    if (mediaMsg) {
+      return {
+        type: key,
+        mimetype: (mediaMsg as { mimetype?: string }).mimetype || '',
+      };
+    }
+  }
+
+  return null;
+}
+
+export async function downloadAndSaveMedia(
+  msg: WAMessage,
+  groupFolder: string,
+  groupsDir: string,
+): Promise<MediaResult | null> {
+  const info = getMediaInfo(msg);
+  if (!info) return null;
+
+  const msgId = msg.key.id;
+  if (!msgId) return null;
+
+  try {
+    const buffer = await downloadMediaMessage(msg, 'buffer', {});
+
+    const ext =
+      MIME_TO_EXT[info.mimetype] || DEFAULT_EXTENSIONS[info.type] || 'bin';
+    const filename = `${msgId}.${ext}`;
+
+    const mediaDir = path.join(groupsDir, groupFolder, 'media');
+    fs.mkdirSync(mediaDir, { recursive: true });
+
+    const filePath = path.join(mediaDir, filename);
+    fs.writeFileSync(filePath, buffer as Buffer);
+
+    const containerPath = `/workspace/group/media/${filename}`;
+
+    logger.info(
+      { msgId, type: info.type, size: (buffer as Buffer).length },
+      'Media downloaded',
+    );
+
+    return { filePath, containerPath };
+  } catch (err) {
+    logger.warn({ msgId, type: info.type, err }, 'Failed to download media');
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

When a registered group receives a media message (image, video, audio, document, or sticker), NanoClaw now automatically downloads the file and saves it to `groups/{folder}/media/`. The container-accessible path is prepended to the message content as `[media: /workspace/group/media/...]`, so agents can read and use the file directly.

No database schema changes — the media path is embedded in the existing `content` field. The existing container mount already makes the media directory visible, so no mount changes are needed either.

## Motivation

I'm working on letting the assistant post tweets with images that users send via WhatsApp. Currently NanoClaw only extracts caption text from media messages and discards the actual file, so the agent has no way to access user-sent images. This PR fixes that by downloading and storing media on disk, making it available for the agent to use in integrations like X image posting.