### PR TITLE
feat: expose additional env vars and mount GitHub CLI config in containers

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -116,6 +116,16 @@ function buildVolumeMounts(
     readonly: false,
   });
 
+  // GitHub CLI configuration (shared across all groups, read-only)
+  const ghConfigDir = path.join(homeDir, '.config', 'gh');
+  if (fs.existsSync(ghConfigDir)) {
+    mounts.push({
+      hostPath: ghConfigDir,
+      containerPath: '/home/node/.config/gh',
+      readonly: true,
+    });
+  }
+
   // Per-group IPC namespace: each group gets its own IPC directory
   // This prevents cross-group privilege escalation via IPC
   const groupIpcDir = path.join(DATA_DIR, 'ipc', group.folder);
@@ -134,7 +144,14 @@ function buildVolumeMounts(
   const envFile = path.join(projectRoot, '.env');
   if (fs.existsSync(envFile)) {
     const envContent = fs.readFileSync(envFile, 'utf-8');
-    const allowedVars = ['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_API_KEY'];
+    const allowedVars = [
+      'CLAUDE_CODE_OAUTH_TOKEN',
+      'ANTHROPIC_API_KEY',
+      'ANTHROPIC_BASE_URL',
+      'ANTHROPIC_MODEL',
+      'CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC',
+      'GITHUB_TOKEN',
+    ];
     const filteredLines = envContent.split('\n').filter((line) => {
       const trimmed = line.trim();
       if (!trimmed || trimmed.startsWith('#')) return false;


### PR DESCRIPTION
## Summary

- Expand the container env var allowlist to pass through `ANTHROPIC_BASE_URL`, `ANTHROPIC_MODEL`, `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`, and `GITHUB_TOKEN`
- Mount `~/.config/gh` (read-only) into containers so agents can use the GitHub CLI

## Motivation

The current allowlist only passes `CLAUDE_CODE_OAUTH_TOKEN` and `ANTHROPIC_API_KEY`. This means users who need custom API endpoints (proxies, regional deployments), model selection, or GitHub integration in their agents have no way to configure this without modifying source code.

**Env vars added:**
| Variable | Use Case |
|----------|----------|
| `ANTHROPIC_BASE_URL` | Custom API endpoints, proxies, regional deployments |
| `ANTHROPIC_MODEL` | Model selection without code changes |
| `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` | Respect user's traffic preferences inside containers |
| `GITHUB_TOKEN` | Enable GitHub API access for agents (PRs, issues, etc.) |

**GitHub CLI mount:** If `~/.config/gh` exists on the host, it's mounted read-only at `/home/node/.config/gh` so `gh` commands work inside containers without additional auth setup.

## Backwards compatibility

Fully backwards-compatible:
- Env vars only take effect when set in `.env` (existing behavior unchanged)
- The gh config mount is skipped if the directory doesn't exist
- Security model unchanged: only explicitly allowlisted vars are exposed, and gh config is read-only

## Test plan

- [ ] Verify existing auth vars (`ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`) still work
- [ ] Set `ANTHROPIC_BASE_URL` in `.env` and verify it's available inside the container
- [ ] Set `GITHUB_TOKEN` in `.env` and verify `gh` CLI works inside the container
- [ ] Verify containers without `~/.config/gh` on host still start correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)