### PR TITLE
feat: auto-cleanup old Apple Container snapshots after build

### DIFF
--- a/container/build.sh
+++ b/container/build.sh
@@ -21,3 +21,11 @@ echo "Image: ${IMAGE_NAME}:${TAG}"
 echo ""
 echo "Test with:"
 echo "  echo '{\"prompt\":\"What is 2+2?\",\"groupFolder\":\"test\",\"chatJid\":\"test@g.us\",\"isMain\":false}' | container run -i ${IMAGE_NAME}:${TAG}"
+
+# Auto-cleanup old snapshots to save disk space
+CLEANUP_SCRIPT="$SCRIPT_DIR/../scripts/cleanup-snapshots.sh"
+if [ -x "$CLEANUP_SCRIPT" ]; then
+  echo ""
+  echo "Cleaning up old container snapshots..."
+  "$CLEANUP_SCRIPT" || echo "Warning: Snapshot cleanup failed (non-critical)"
+fi

--- a/scripts/cleanup-snapshots.sh
+++ b/scripts/cleanup-snapshots.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Clean up old Apple Container snapshots
+# Keeps only the newest 2 snapshots to save disk space
+#
+# Apple Container accumulates snapshot images after each build,
+# consuming significant disk space over time. This script removes
+# all but the 2 most recent snapshots.
+#
+# Usage:
+#   ./scripts/cleanup-snapshots.sh          # interactive
+#   KEEP=5 ./scripts/cleanup-snapshots.sh   # keep 5 instead of 2
+
+KEEP="${KEEP:-2}"
+SNAPSHOTS_DIR="$HOME/Library/Application Support/com.apple.container/snapshots"
+
+if [ ! -d "$SNAPSHOTS_DIR" ]; then
+  echo "Snapshots directory not found: $SNAPSHOTS_DIR"
+  exit 0
+fi
+
+cd "$SNAPSHOTS_DIR" || exit 1
+
+# Count snapshots (excluding ingest directory)
+SNAPSHOT_COUNT=$(ls -t | grep -v ingest | wc -l | tr -d ' ')
+
+if [ "$SNAPSHOT_COUNT" -le "$KEEP" ]; then
+  echo "Only $SNAPSHOT_COUNT snapshot(s) found, nothing to clean up"
+  exit 0
+fi
+
+TO_DELETE=$((SNAPSHOT_COUNT - KEEP))
+echo "Found $SNAPSHOT_COUNT snapshots, deleting oldest $TO_DELETE..."
+
+ls -t | grep -v ingest | tail -n +"$((KEEP + 1))" | while read -r snapshot; do
+  echo "  Deleting: $snapshot"
+  rm -rf "$snapshot"
+done
+
+NEW_SIZE=$(du -sh "$SNAPSHOTS_DIR" | cut -f1)
+echo ""
+echo "Cleanup complete! Current size: $NEW_SIZE"


### PR DESCRIPTION
## Summary

- Add `scripts/cleanup-snapshots.sh` that removes old Apple Container snapshots, keeping only the 2 most recent
- Integrate cleanup into `container/build.sh` so it runs automatically after each build

## Motivation

Apple Container accumulates snapshot images after each `container build`, and each snapshot is ~2GB. After a few rebuilds, this can easily consume 10-20GB of disk space with no visible warning to the user.

This is especially impactful for users who frequently iterate on container builds during development or skill testing.

## How it works

```
$ ./container/build.sh
Building NanoClaw agent container image...
...
Build complete!

Cleaning up old container snapshots...
Found 5 snapshots, deleting oldest 3...
  Deleting: abc123...
  Deleting: def456...
  Deleting: ghi789...

Cleanup complete! Current size: 3.8G
```

**Configurable retention:** `KEEP=5 ./scripts/cleanup-snapshots.sh` to keep more snapshots.

## Safety

- Cleanup is non-blocking: failures don't affect the build (`|| echo "Warning: ..."`)
- Only runs if the script exists and is executable
- Skips the `ingest` directory used by Apple Container internally
- Can be run standalone: `./scripts/cleanup-snapshots.sh`

## Test plan

- [ ] Run `./container/build.sh` and verify cleanup message appears
- [ ] Verify only the 2 newest snapshots remain after cleanup
- [ ] Remove `scripts/cleanup-snapshots.sh` and verify build still works (graceful skip)
- [ ] Run `KEEP=1 ./scripts/cleanup-snapshots.sh` to test custom retention

🤖 Generated with [Claude Code](https://claude.com/claude-code)