### PR TITLE
Telegram/Feishu support

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -52,7 +52,7 @@ RUN mkdir -p /workspace/group /workspace/global /workspace/extra /workspace/ipc/
 
 # Create entrypoint script
 # Sources env from mounted /workspace/env-dir/env if it exists (workaround for Apple Container -i bug)
-RUN printf '#!/bin/bash\nset -e\n[ -f /workspace/env-dir/env ] && export $(cat /workspace/env-dir/env | xargs)\ncat > /tmp/input.json\nnode /app/dist/index.js < /tmp/input.json\n' > /app/entrypoint.sh && chmod +x /app/entrypoint.sh
+RUN printf '#!/bin/bash\nset -e\nif [ -f /workspace/env-dir/env ]; then\n  while IFS= read -r line || [ -n "$line" ]; do\n    # Skip empty lines and comments\n    [[ "$line" =~ ^[[:space:]]*$ ]] && continue\n    [[ "$line" =~ ^[[:space:]]*# ]] && continue\n    export "$line"\n  done < /workspace/env-dir/env\nfi\ncat > /tmp/input.json\nnode /app/dist/index.js < /tmp/input.json\n' > /app/entrypoint.sh && chmod +x /app/entrypoint.sh
 
 # Set ownership to node user (non-root) for writable directories
 RUN chown -R node:node /workspace

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -1,14 +1,14 @@
 # NanoClaw Requirements
 
-Original requirements and design decisions from the project creator.
+Original requirements and design decisions from project creator.
 
 ---
 
 ## Why This Exists
 
-This is a lightweight, secure alternative to OpenClaw (formerly ClawBot). That project became a monstrosity - 4-5 different processes running different gateways, endless configuration files, endless integrations. It's a security nightmare where agents don't run in isolated processes; there's all kinds of leaky workarounds trying to prevent them from accessing parts of the system they shouldn't. It's impossible for anyone to realistically understand the whole codebase. When you run it you're kind of just yoloing it.
+This is a lightweight, secure alternative to OpenClaw (formerly ClawBot). That project became a monstrosity - 4-5 different processes running different gateways, endless configuration files, endless integrations. It's a security nightmare where agents don't run in aisolated processes; there's all kinds of leaky workarounds trying to prevent them from accessing parts of the system they shouldn't. It's impossible for anyone to realistically understand the whole codebase. When you run it you're kind of just yoloing it.
 
-NanoClaw gives you the core functionality without that mess.
+NanoClaw gives you → core functionality without that mess.
 
 ---
 
@@ -24,21 +24,21 @@ Instead of application-level permission systems trying to prevent agents from ac
 
 ### Built for One User
 
-This isn't a framework or a platform. It's working software for my specific needs. I use WhatsApp and Email, so it supports WhatsApp and Email. I don't use Telegram, so it doesn't support Telegram. I add the integrations I actually want, not every possible integration.
+This isn't a framework or a platform. It's working software for my specific needs. I use WhatsApp and Email, so it supports WhatsApp and Email. I don't use Telegram, so it doesn't support Telegram. I add integrations I actually want, not every possible integration.
 
 ### Customization = Code Changes
 
-No configuration sprawl. If you want different behavior, modify the code. The codebase is small enough that this is safe and practical. Very minimal things like the trigger word are in config. Everything else - just change the code to do what you want.
+No configuration sprawl. If you want different behavior, modify the code. The codebase is small enough that this is safe and practical. Very minimal things like the trigger word are in config. Everything else - just change code to do what you want.
 
 ### AI-Native Development
 
-I don't need an installation wizard - Claude Code guides the setup. I don't need a monitoring dashboard - I ask Claude Code what's happening. I don't need elaborate logging UIs - I ask Claude to read the logs. I don't need debugging tools - I describe the problem and Claude fixes it.
+I don't need an installation wizard - Claude Code guides → setup. I don't need a monitoring dashboard - I ask Claude Code what's happening. I don't need elaborate logging UIs - I ask Claude to read → logs. I don't need debugging tools - I describe → problem and Claude fixes it.
 
 The codebase assumes you have an AI collaborator. It doesn't need to be excessively self-documenting or self-debugging because Claude is always there.
 
 ### Skills Over Features
 
-When people contribute, they shouldn't add "Telegram support alongside WhatsApp." They should contribute a skill like `/add-telegram` that transforms the codebase. Users fork the repo, run skills to customize, and end up with clean code that does exactly what they need - not a bloated system trying to support everyone's use case simultaneously.
+When people contribute, they shouldn't add "Telegram support alongside WhatsApp." They should contribute a skill like `/add-telegram` that transforms the codebase. Users fork → repo, run skills to customize, and end up with clean code that does exactly what they need - not a bloated system trying to support everyone's use case simultaneously.
 
 ---
 
@@ -60,7 +60,7 @@ The project currently uses Apple Container (macOS-only). We need:
 - This unlocks Linux support and broader deployment options
 
 ### Platform Support
-- `/setup-linux` - Make the full setup work on Linux (depends on Docker conversion)
+- `/setup-linux` - Make full setup work on Linux (depends on Docker conversion)
 - `/setup-windows` - Windows support via WSL2 + Docker
 
 ---
@@ -115,20 +115,20 @@ A personal Claude assistant accessible via WhatsApp, with minimal custom code.
 - Tasks run as full agents in the context of the group that created them
 - Tasks have access to all tools including Bash (safe in container)
 - Tasks can optionally send messages to their group via `send_message` tool, or complete silently
-- Task runs are logged to the database with duration and result
+- Task runs are logged to → database with duration and result
 - Schedule types: cron expressions, intervals (ms), or one-time (ISO timestamp)
 - From main: can schedule tasks for any group, view/manage all tasks
 - From other groups: can only manage that group's tasks
 
 ### Group Management
-- New groups are added explicitly via the main channel
+- New groups are added explicitly via main channel
 - Groups are registered by editing `data/registered_groups.json`
 - Each group gets a dedicated folder under `groups/`
 - Groups can have additional directories mounted via `containerConfig`
 
 ### Main Channel Privileges
-- Main channel is the admin/control group (typically self-chat)
-- Can write to global memory (`groups/CLAUDE.md`)
+- Main channel is to admin/control group (typically self-chat)
+- Can write to → global memory (`groups/CLAUDE.md`)
 - Can schedule tasks for any group
 - Can view and manage tasks from all groups
 - Can configure additional directory mounts for any group
@@ -155,7 +155,7 @@ A personal Claude assistant accessible via WhatsApp, with minimal custom code.
 - Standard Claude Agent SDK capabilities
 
 ### Browser Automation
-- agent-browser CLI with Chromium in container
+- agent-browser CLI with Chromium in the container
 - Snapshot-based interaction with element references (@e1, @e2, etc.)
 - Screenshots, PDFs, video recording
 - Authentication state persistence
@@ -167,7 +167,7 @@ A personal Claude assistant accessible via WhatsApp, with minimal custom code.
 ### Philosophy
 - Minimal configuration files
 - Setup and customization done via Claude Code
-- Users clone the repo and run Claude Code to configure
+- Users clone → repo and run Claude Code to configure
 - Each user gets a custom setup matching their exact needs
 
 ### Skills
@@ -188,6 +188,52 @@ These are the creator's settings, stored here for reference:
 - **Response prefix**: `Andy:`
 - **Persona**: Default Claude (no custom personality)
 - **Main channel**: Self-chat (messaging yourself in WhatsApp)
+
+---
+
+## Debugging Agent Issues
+
+When an agent isn't responding or behaving unexpectedly, you can check → Claude debug logs:
+
+### Find Debug Logs by SessionId
+
+Debug logs are stored at: `data/sessions/{groupFolder}/.claude/debug/{sessionId}.txt`
+
+**Steps to debug:**
+1. Find running container: `container ls`
+2. Check container logs: `container logs {container-id}`
+3. Extract sessionId from → log (e.g., "Session initialized: 58e6a95d-0a1c-4a60-bc49-2024f7249a8e")
+4. View debug logs: `tail -f data/sessions/main/.claude/debug/{sessionId}.txt`
+
+**Common issues:**
+- **429 errors**: API rate limiting - reduce concurrent requests or increase API quota
+- **Network errors**: Check internet connectivity and API endpoint availability
+- **Timeout**: Agent taking too long - may need to increase timeout in `registered_groups.json`
+
+### Example Debug Session
+
+```bash
+# 1. Find running containers
+container ls
+
+# 2. Check container logs
+container logs dde564a1-0013-4f8b-87c4-6f7919a7b7b9
+
+# 3. Extract sessionId from → logs (e.g., 58e6a95d-0a1c-4a60-bc49-2024f7249a8e)
+
+# 4. View Claude debug logs
+tail -f data/sessions/main/.claude/debug/58e6a95d-0a1c-4a60-bc49-2024f7249a8e.txt
+```
+
+### Container Logs
+
+Container run logs are stored at: `groups/{groupFolder}/logs/container-{timestamp}.log`
+
+These logs show:
+- Input prompt and session ID
+- Container mounts and configuration
+- Stderr output (agent status messages)
+- Duration and exit code
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -9,22 +9,28 @@
     "start": "node dist/index.js",
     "dev": "tsx src/index.ts",
     "auth": "tsx src/whatsapp-auth.ts",
+    "auth:telegram": "tsx src/telegram-auth.ts",
+    "auth:feishu": "tsx src/feishu-auth.ts",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write \"src/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\""
   },
   "dependencies": {
+    "@larksuiteoapi/node-sdk": "^1.58.0",
     "@whiskeysockets/baileys": "^7.0.0-rc.9",
     "better-sqlite3": "^11.8.1",
     "cron-parser": "^5.5.0",
+    "node-telegram-bot-api": "^0.67.0",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",
     "qrcode-terminal": "^0.12.0",
+    "sqlite3": "^5.1.7",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.12",
     "@types/node": "^22.10.0",
+    "@types/node-telegram-bot-api": "^0.64.13",
     "@types/qrcode-terminal": "^0.12.2",
     "prettier": "^3.8.1",
     "tsx": "^4.19.0",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,0 +1,138 @@
+/**
+ * Command Parser and Handlers for NanoClaw
+ * Handles special commands like /help, /new, /reset
+ */
+
+export interface Command {
+  name: string;
+  description: string;
+  handler: CommandHandler;
+}
+
+export interface CommandContext {
+  chatId: string;
+  groupName: string;
+  groupFolder: string;
+  content: string;
+  timestamp: string;
+}
+
+export interface CommandResult {
+  handled: boolean;
+  response?: string;
+  shouldResetSession?: boolean;
+}
+
+export type CommandHandler = (context: CommandContext) => Promise<CommandResult>;
+
+/**
+ * Built-in commands
+ */
+export const commands: Command[] = [
+  {
+    name: 'help',
+    description: 'Show all available commands',
+    handler: handleHelp,
+  },
+  {
+    name: 'new',
+    description: 'Start a new conversation session (reset context)',
+    handler: handleNew,
+  },
+  {
+    name: 'register',
+    description: 'Register current chat as workspace (Feishu only)',
+    handler: handleRegister,
+  },
+];
+
+/**
+ * Parse a message to check if it's a command
+ */
+export function parseCommand(content: string, trigger: string): { isCommand: boolean; command?: Command; args?: string } {
+  const trimmed = content.trim();
+
+  // Check for /command format
+  const cmdMatch = trimmed.match(/^\/(\w+)(?:\s+(.+))?$/);
+  if (cmdMatch) {
+    const cmdName = cmdMatch[1].toLowerCase();
+    const args = cmdMatch[2];
+    const command = commands.find(c => c.name === cmdName);
+    return { isCommand: !!command, command, args };
+  }
+
+  return { isCommand: false };
+}
+
+/**
+ * Handle /help command
+ */
+async function handleHelp(context: CommandContext): Promise<CommandResult> {
+  const helpText = `📚 **Available Commands**
+
+${commands.map(c => `**/${c.name}** - ${c.description}`).join('\n')}
+
+💡 **Tips**
+- Start with trigger word to have AI process
+- Commands start with /
+- Current session context is auto-saved
+`;
+
+  return { handled: true, response: helpText };
+}
+
+/**
+ * Handle /new command - start fresh session
+ */
+async function handleNew(context: CommandContext): Promise<CommandResult> {
+  return {
+    handled: true,
+    response: `✅ **New Session Started**
+
+Previous context cleared. This is a fresh conversation.`,
+    shouldResetSession: true,
+  };
+}
+
+/**
+ * Handle /register command - for Feishu self-registration
+ * Note: For unregistered chats, this is handled in index.ts
+ * This handler is for when /register is sent in an already registered group
+ */
+async function handleRegister(context: CommandContext): Promise<CommandResult> {
+  // Import is not possible here due to circular dependency
+  // This handler is for when /register is sent in an already registered group
+  return {
+    handled: true,
+    response: `✅ Current Workspace Info:
+
+Name: **${context.groupName}**
+Folder: ${context.groupFolder}
+
+Contact admin to re-register.`,
+  };
+}
+
+/**
+ * Check if content is a command and execute it
+ */
+export async function executeCommand(
+  content: string,
+  trigger: string,
+  context: CommandContext
+): Promise<CommandResult> {
+  const { isCommand, command, args } = parseCommand(content, trigger);
+
+  if (!isCommand || !command) {
+    return { handled: false };
+  }
+
+  try {
+    return await command.handler({ ...context, content: args || '' });
+  } catch (error) {
+    return {
+      handled: true,
+      response: `❌ **Command Error**: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -36,7 +36,7 @@ export const MAX_CONCURRENT_CONTAINERS = Math.max(
   parseInt(process.env.MAX_CONCURRENT_CONTAINERS || '5', 10) || 5,
 );
 
-function escapeRegex(str: string): string {
+export function escapeRegex(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -53,6 +53,10 @@ export interface ContainerOutput {
   error?: string;
 }
 
+export interface ContainerOptions {
+  onStatusUpdate?: (message: string) => void;
+}
+
 interface VolumeMount {
   hostPath: string;
   containerPath: string;
@@ -134,7 +138,8 @@ function buildVolumeMounts(
   const envFile = path.join(projectRoot, '.env');
   if (fs.existsSync(envFile)) {
     const envContent = fs.readFileSync(envFile, 'utf-8');
-    const allowedVars = ['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_API_KEY'];
+    const allowedVars = ['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_API_KEY',
+      'ANTHROPIC_BASE_URL', 'ANTHROPIC_AUTH_TOKEN', 'ANTHROPIC_MODEL'];
     const filteredLines = envContent.split('\n').filter((line) => {
       const trimmed = line.trim();
       if (!trimmed || trimmed.startsWith('#')) return false;
@@ -191,6 +196,7 @@ export async function runContainerAgent(
   group: RegisteredGroup,
   input: ContainerInput,
   onProcess: (proc: ChildProcess, containerName: string) => void,
+  options?: ContainerOptions,
 ): Promise<ContainerOutput> {
   const startTime = Date.now();
 
@@ -264,6 +270,20 @@ export async function runContainerAgent(
       const lines = chunk.trim().split('\n');
       for (const line of lines) {
         if (line) logger.debug({ container: group.folder }, line);
+
+        // Detect status updates and send immediately via callback
+        // Lines look like: [agent-runner] STATUS: message
+        if (line.includes('STATUS:')) {
+          const statusMessage = line.split('STATUS:')[1]?.trim();
+          if (statusMessage && options?.onStatusUpdate) {
+            // Send immediately via callback for real-time updates
+            try {
+              options.onStatusUpdate(statusMessage);
+            } catch (err) {
+              logger.error({ group: group.name, err }, 'Status callback error');
+            }
+          }
+        }
       }
       if (stderrTruncated) return;
       const remaining = CONTAINER_MAX_OUTPUT_SIZE - stderr.length;
@@ -271,7 +291,7 @@ export async function runContainerAgent(
         stderr += chunk.slice(0, remaining);
         stderrTruncated = true;
         logger.warn(
-          { group: group.name, size: stderr.length },
+          { group: group.name, size: stdout.length },
           'Container stderr truncated due to size limit',
         );
       } else {

--- a/src/feishu-auth.ts
+++ b/src/feishu-auth.ts
@@ -1,0 +1,246 @@
+/**
+ * Feishu Bot Authentication Setup
+ * Interactive script to configure Feishu (Lark) bot credentials
+ * and start WebSocket connection
+ */
+
+import fs from 'fs';
+import path from 'path';
+import readline from 'readline';
+import * as Lark from '@larksuiteoapi/node-sdk';
+
+const STORE_DIR = path.join(process.cwd(), 'store');
+const CREDS_PATH = path.join(STORE_DIR, 'feishu-credentials.json');
+
+interface FeishuCredentials {
+  appId: string;
+  appSecret: string;
+  encryptKey?: string;
+  verificationToken?: string;
+}
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+function ask(question: string): Promise<string> {
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      resolve(answer.trim());
+    });
+  });
+}
+
+async function testConnection(creds: FeishuCredentials): Promise<{ success: boolean; botName?: string; error?: string }> {
+  try {
+    const client = new Lark.Client({
+      appId: creds.appId,
+      appSecret: creds.appSecret,
+      appType: Lark.AppType.SelfBuild,
+    });
+
+    // Use raw request to get bot info
+    const response = await (client as any).request({
+      method: 'GET',
+      url: '/open-apis/bot/v3/info',
+    });
+
+    if (response.code === 0 && response.bot) {
+      return {
+        success: true,
+        botName: response.bot.bot_name,
+      };
+    } else {
+      return {
+        success: false,
+        error: response.msg || `Error code: ${response.code}`,
+      };
+    }
+  } catch (err) {
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+async function startWebSocketConnection(creds: FeishuCredentials): Promise<never> {
+  console.log('Starting WebSocket connection to Feishu...');
+  console.log('Press Ctrl+C to exit');
+  console.log('');
+
+  const wsClient = new Lark.WSClient({
+    appId: creds.appId,
+    appSecret: creds.appSecret,
+    loggerLevel: Lark.LoggerLevel.info,
+  });
+
+  const eventDispatcher = new Lark.EventDispatcher({
+    encryptKey: creds.encryptKey,
+    verificationToken: creds.verificationToken,
+  });
+
+  // Register event handler for messages
+  eventDispatcher.register({
+    'im.message.receive_v1': async (data) => {
+      console.log('✉️  Received message:', JSON.stringify(data, null, 2));
+    },
+  });
+
+  // Start WebSocket connection
+  wsClient.start({ eventDispatcher });
+  console.log('✅ WebSocket client started');
+
+  // Keep the process running - this promise never resolves
+  return new Promise(() => {
+    // Never resolves - process stays alive until Ctrl+C
+  });
+}
+
+async function main(): Promise<void> {
+  console.log('╔════════════════════════════════════════════════════════════╗');
+  console.log('║           Feishu (Lark) Bot Authentication Setup           ║');
+  console.log('╚════════════════════════════════════════════════════════════╝');
+  console.log('');
+  console.log('To use Feishu as a messenger for NanoClaw, you need to create');
+  console.log('a custom app in the Feishu Developer Console and obtain the');
+  console.log('App ID and App Secret.');
+  console.log('');
+  console.log('Setup Instructions:');
+  console.log('1. Go to https://open.feishu.cn/app');
+  console.log('2. Click "Create Custom App"');
+  console.log('3. Enable "Bot" capability in the app settings');
+  console.log('4. Copy the App ID and App Secret from the app credentials');
+  console.log('5. (Optional) Set Encrypt Key and Verification Token for security');
+  console.log('6. Subscribe to these events: im.message.receive_v1');
+  console.log('7. Set connection mode to WebSocket');
+  console.log('');
+
+  // Check for existing credentials
+  let existingCreds: FeishuCredentials | null = null;
+  if (fs.existsSync(CREDS_PATH)) {
+    try {
+      existingCreds = JSON.parse(fs.readFileSync(CREDS_PATH, 'utf-8'));
+      console.log('⚠️  Existing credentials found.');
+      const overwrite = await ask('Do you want to overwrite them? (y/N): ');
+      if (overwrite.toLowerCase() !== 'y') {
+        console.log('Keeping existing credentials.');
+        // Load existing credentials and start WebSocket connection
+        console.log('');
+        if (!existingCreds) {
+          console.error("Failed to load existing credentials.");
+          rl.close();
+          process.exit(1);
+        }
+        const testResult = await testConnection(existingCreds);
+        if (!testResult.success) {
+          console.error('❌ Connection failed:', testResult.error);
+          console.log('');
+          console.log('Please check your credentials and run the script again.');
+          rl.close();
+          process.exit(1);
+        }
+        console.log(`✅ Connection successful! Bot: ${testResult.botName || 'Unknown'}`);
+        console.log('');
+        rl.close();
+
+        // This should never return
+        try {
+          await startWebSocketConnection(existingCreds);
+        } catch (err) {
+          console.error('WebSocket error:', err);
+          process.exit(1);
+        }
+
+        // Should never reach here
+        process.exit(0);
+      }
+    } catch {
+      // Invalid existing file, continue to ask for new credentials
+    }
+  }
+
+  // Collect credentials
+  console.log('');
+  console.log('Please enter your Feishu app credentials:');
+  console.log('');
+
+  const appId = await ask('App ID: ');
+  if (!appId) {
+    console.error('❌ App ID is required');
+    rl.close();
+    process.exit(1);
+  }
+
+  const appSecret = await ask('App Secret: ');
+  if (!appSecret) {
+    console.error('❌ App Secret is required');
+    rl.close();
+    process.exit(1);
+  }
+
+  console.log('');
+  console.log('Optional security settings (press Enter to skip):');
+
+  const encryptKey = await ask('Encrypt Key (optional): ');
+  const verificationToken = await ask('Verification Token (optional): ');
+
+  const creds: FeishuCredentials = {
+    appId,
+    appSecret,
+    ...(encryptKey && { encryptKey }),
+    ...(verificationToken && { verificationToken }),
+  };
+
+  // Test connection
+  console.log('');
+  console.log('🔄 Testing connection to Feishu API...');
+
+  const testResult = await testConnection(creds);
+
+  if (!testResult.success) {
+    console.error('❌ Connection failed:', testResult.error);
+    console.log('');
+    console.log('Please check your App ID and App Secret and try again.');
+    rl.close();
+    process.exit(1);
+  }
+
+  console.log(`✅ Connection successful! Bot: ${testResult.botName}`);
+
+  // Save credentials
+  fs.mkdirSync(STORE_DIR, { recursive: true });
+  fs.writeFileSync(CREDS_PATH, JSON.stringify(creds, null, 2));
+  fs.chmodSync(CREDS_PATH, 0o600); // Restrict permissions
+
+  console.log('');
+  console.log(`✅ Credentials saved to: ${CREDS_PATH}`);
+  console.log('');
+  console.log('Next steps:');
+  console.log('1. Set MESSENGER=feishu environment variable');
+  console.log('2. Add the bot to your Feishu groups');
+  console.log('3. Start NanoClaw with: npm run dev');
+  console.log('');
+  console.log('To switch back to Telegram:');
+  console.log('  unset MESSENGER  # or set MESSENGER=telegram');
+  console.log('');
+
+  rl.close();
+
+  // Start WebSocket connection - should never return
+  try {
+    await startWebSocketConnection(creds);
+  } catch (err) {
+    console.error('WebSocket error:', err);
+    process.exit(1);
+  }
+
+  // Should never reach here
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('Error:', err);
+  process.exit(1);
+});

--- a/src/feishu.ts
+++ b/src/feishu.ts
@@ -1,0 +1,627 @@
+/**
+ * Feishu (Lark) Messenger Implementation
+ * Handles Feishu bot communication and implements the Messenger interface
+ */
+
+import * as Lark from '@larksuiteoapi/node-sdk';
+import pino from 'pino';
+import fs from 'fs';
+import path from 'path';
+import { exec } from 'child_process';
+import { Messenger, NewMessage, RegisteredGroup } from './types.js';
+import { storeMessage, storeChatMetadata, storeFeishuMessageEvent, FeishuMessage, FeishuSender } from './db.js';
+
+interface FeishuCredentials {
+  appId: string;
+  appSecret: string;
+  encryptKey?: string;
+  verificationToken?: string;
+}
+
+interface FeishuMessageEvent {
+  event_id?: string;  // Unique event ID for deduplication
+  sender: {
+    sender_id: {
+      open_id?: string;
+      user_id?: string;
+      union_id?: string;
+    };
+    sender_type?: string;
+    tenant_key?: string;
+  };
+  message: {
+    message_id: string;
+    root_id?: string;
+    parent_id?: string;
+    chat_id: string;
+    chat_type: 'p2p' | 'group';
+    message_type: string;
+    content: string;
+    create_time?: string;
+    mentions?: Array<{
+      key: string;
+      id: {
+        open_id?: string;
+        user_id?: string;
+        union_id?: string;
+      };
+      name: string;
+      tenant_key?: string;
+    }>;
+  };
+}
+
+export class FeishuMessenger implements Messenger {
+  private client: Lark.Client | null = null;
+  private wsClient: Lark.WSClient | null = null;
+  private eventDispatcher: Lark.EventDispatcher | null = null;
+  private logger: pino.Logger;
+  private storeDir: string;
+  private registeredGroups: Record<string, RegisteredGroup>;
+  private onMessageCallback?: (msg: NewMessage) => Promise<void>;
+  private pollInterval: number;
+  private credentials: FeishuCredentials | null = null;
+  private botOpenId: string | null = null;
+
+  // Track status message IDs for editing by chatId and sessionId
+  private statusMessageIds: Record<string, Record<string, string>> = {}; // chatId -> sessionId -> messageId
+  private accumulatedStatusMessages: Record<string, Record<string, string>> = {}; // chatId -> sessionId -> accumulatedText
+
+  // Track processed message IDs to avoid duplicates
+  private processedMessageIds: Set<string> = new Set();
+
+  constructor(
+    logger: pino.Logger,
+    storeDir: string,
+    registeredGroups: Record<string, RegisteredGroup>,
+    pollInterval: number
+  ) {
+    this.logger = logger.child({ messenger: 'feishu' });
+    this.storeDir = storeDir;
+    this.registeredGroups = registeredGroups;
+    this.pollInterval = pollInterval;
+  }
+
+  async connect(): Promise<void> {
+    const credsPath = path.join(this.storeDir, 'feishu-credentials.json');
+
+    if (!fs.existsSync(credsPath)) {
+      const msg = 'Feishu credentials not found. Run npm run auth:feishu first.';
+      this.logger.error(msg);
+      exec(`osascript -e 'display notification "${msg}" with title "NanoClaw" sound name "Basso"'`);
+      process.exit(1);
+    }
+
+    try {
+      this.credentials = JSON.parse(fs.readFileSync(credsPath, 'utf-8'));
+    } catch (err) {
+      this.logger.error({ err }, 'Failed to parse Feishu credentials');
+      throw new Error('Invalid Feishu credentials file');
+    }
+
+    if (!this.credentials?.appId || !this.credentials?.appSecret) {
+      throw new Error('Feishu credentials missing appId or appSecret');
+    }
+
+    // Create REST client
+    this.client = new Lark.Client({
+      appId: this.credentials.appId,
+      appSecret: this.credentials.appSecret,
+      appType: Lark.AppType.SelfBuild,
+    });
+
+    // Verify connection and get bot info using raw request
+    try {
+      const response = await (this.client as any).request({
+        method: 'GET',
+        url: '/open-apis/bot/v3/info',
+      });
+      if (response.code === 0 && response.bot) {
+        this.botOpenId = response.bot.open_id || null;
+        this.logger.info({ botName: response.bot.bot_name, botOpenId: this.botOpenId }, 'Connected to Feishu');
+      }
+    } catch (err) {
+      this.logger.error({ err }, 'Failed to verify Feishu connection');
+      throw err;
+    }
+
+    // Set up WebSocket client
+    await this.setupWebSocket();
+  }
+
+  private async setupWebSocket(): Promise<void> {
+    if (!this.credentials) return;
+
+    this.wsClient = new Lark.WSClient({
+      appId: this.credentials.appId,
+      appSecret: this.credentials.appSecret,
+      loggerLevel: Lark.LoggerLevel.info,
+    });
+
+    this.eventDispatcher = new Lark.EventDispatcher({
+      encryptKey: this.credentials.encryptKey,
+      verificationToken: this.credentials.verificationToken,
+    });
+
+    // Register event handlers
+    this.eventDispatcher.register({
+      'im.message.receive_v1': async (data) => {
+        this.logger.info({ data }, 'Received im.message.receive_v1 event');
+        try {
+          await this.handleMessageEvent(data as unknown as FeishuMessageEvent);
+        } catch (err) {
+          this.logger.error({ err }, 'Error handling Feishu message');
+        }
+      },
+      'im.message.message_read_v1': async (data) => {
+        this.logger.debug({ data }, 'Received message_read event');
+        // Ignore read receipts
+      },
+      'im.chat.member.bot.added_v1': async (data) => {
+        const event = data as unknown as { chat_id: string };
+        this.logger.info({ chatId: event.chat_id }, 'Bot added to chat');
+      },
+      'im.chat.member.bot.deleted_v1': async (data) => {
+        const event = data as unknown as { chat_id: string };
+        this.logger.info({ chatId: event.chat_id }, 'Bot removed from chat');
+      },
+    });
+
+    // Start WebSocket connection
+    return new Promise((resolve, reject) => {
+      try {
+        this.wsClient!.start({ eventDispatcher: this.eventDispatcher! });
+        this.logger.info('Feishu WebSocket client started');
+        resolve();
+      } catch (err) {
+        reject(err);
+      }
+    });
+  }
+
+  private async handleMessageEvent(event: FeishuMessageEvent): Promise<void> {
+    const messageId = event.message.message_id;
+    const chatId = event.message.chat_id;
+    const senderOpenId = event.sender.sender_id.open_id;
+    const senderUserId = event.sender.sender_id.user_id;
+
+    this.logger.info({
+      eventId: event.event_id,
+      messageId,
+      chatId,
+      senderOpenId,
+      senderUserId,
+      botOpenId: this.botOpenId,
+      isBotMessage: senderOpenId === this.botOpenId || senderUserId === this.botOpenId
+    }, 'Received Feishu message event');
+
+    // Skip messages from bot itself
+    if (senderOpenId === this.botOpenId || senderUserId === this.botOpenId) {
+      this.logger.info({ senderOpenId, botOpenId: this.botOpenId }, 'Bot message, skipping');
+      return;
+    }
+
+    // Skip if chat_id is not valid Feishu format (sanity check)
+    if (!chatId.startsWith('oc_') && !chatId.startsWith('ou_')) {
+      this.logger.warn({ chatId }, 'Invalid Feishu chat_id format, skipping');
+      return;
+    }
+
+    const messageType = event.message.message_type;
+    const chatType = event.message.chat_type === 'p2p' ? 'private' : 'group';
+    const timestamp = event.message.create_time
+      ? new Date(parseInt(event.message.create_time, 10)).toISOString()
+      : new Date().toISOString();
+
+    // Resolve sender name (senderUserId already defined above)
+    const senderName = await this.resolveSenderName(senderOpenId || '');
+
+    // Parse message content based on type
+    const { content, mediaInfo } = this.parseMessageContent(event.message.content, messageType);
+
+    // Get chat name
+    const chatName = await this.getChatName(chatId);
+    storeChatMetadata(chatId, timestamp, chatName);
+
+    // Store message for registered groups
+    if (this.registeredGroups[chatId]) {
+      storeFeishuMessageEvent(
+        { message: event.message as FeishuMessage, sender: event.sender as FeishuSender },
+        chatId,
+        false,
+        senderName
+      );
+    }
+
+    // Call the message listener callback
+    if (this.onMessageCallback) {
+      this.logger.info({
+        messageId: event.message.message_id,
+        chatId,
+        sender: senderOpenId, // Always use open_id for Feishu
+        senderName,
+        content: mediaInfo ? `${content} ${mediaInfo}` : content,
+        timestamp,
+        chatType,
+      }, 'Calling onMessageCallback');
+      await this.onMessageCallback({
+        id: event.message.message_id,
+        chat_jid: chatId,
+        sender: senderOpenId || 'unknown', // Always use open_id for Feishu
+        sender_name: senderName,
+        content: mediaInfo ? `${content} ${mediaInfo}` : content,
+        timestamp,
+        chat_type: chatType,
+      });
+    }
+  }
+
+  private parseMessageContent(content: string, messageType: string): { content: string; mediaInfo?: string } {
+    try {
+      const parsed = JSON.parse(content);
+
+      switch (messageType) {
+        case 'text':
+          return { content: parsed.text || '' };
+
+        case 'post':
+          return { content: this.parsePostContent(parsed) };
+
+        case 'image':
+          return { content: '<media:image>', mediaInfo: `[Image: ${parsed.image_key || 'unknown'}]` };
+
+        case 'file':
+          return { content: '<media:document>', mediaInfo: `[File: ${parsed.file_name || parsed.file_key || 'unknown'}]` };
+
+        case 'audio':
+          return { content: '<media:audio>', mediaInfo: `[Audio: ${parsed.file_key || 'unknown'}]` };
+
+        case 'video':
+          return { content: '<media:video>', mediaInfo: `[Video: ${parsed.file_key || 'unknown'}]` };
+
+        case 'sticker':
+          return { content: '<media:sticker>', mediaInfo: `[Sticker: ${parsed.file_key || 'unknown'}]` };
+
+        default:
+          return { content: `[${messageType}]` };
+      }
+    } catch {
+      return { content };
+    }
+  }
+
+  private parsePostContent(parsed: any): string {
+    // Parse rich text post content
+    const title = parsed.title || '';
+    const contentBlocks = parsed.content || [];
+    let textContent = title ? `${title}\n\n` : '';
+
+    for (const paragraph of contentBlocks) {
+      if (Array.isArray(paragraph)) {
+        for (const element of paragraph) {
+          if (element.tag === 'text') {
+            textContent += element.text || '';
+          } else if (element.tag === 'a') {
+            textContent += element.text || element.href || '';
+          } else if (element.tag === 'at') {
+            textContent += `@${element.user_name || element.user_id || ''}`;
+          } else if (element.tag === 'img') {
+            textContent += '<media:image>';
+          }
+        }
+        textContent += '\n';
+      }
+    }
+
+    return textContent.trim() || '[Rich Text Message]';
+  }
+
+  private async resolveSenderName(openId: string): Promise<string> {
+    if (!this.client || !openId) return 'Unknown';
+
+    try {
+      const res = await this.client.contact.user.get({
+        path: { user_id: openId },
+        params: { user_id_type: 'open_id' },
+      });
+
+      const user = res.data?.user;
+      if (user) {
+        return user.name || user.en_name || openId;
+      }
+    } catch {
+      // Best effort - fall back to openId
+    }
+
+    return openId;
+  }
+
+  private async getChatName(chatId: string): Promise<string> {
+    if (!this.client) return chatId;
+
+    try {
+      const res = await this.client.im.chat.get({
+        path: { chat_id: chatId },
+      });
+
+      return res.data?.name || chatId;
+    } catch {
+      return chatId;
+    }
+  }
+
+  async registerCommands(): Promise<void> {
+    // Feishu doesn't have a direct equivalent to Telegram's bot commands
+    this.logger.info('Feishu does not support native slash command registration');
+  }
+
+  async sendMessage(chatId: string, text: string): Promise<void> {
+    if (!this.client) {
+      this.logger.warn('Cannot send message: client not connected');
+      return;
+    }
+
+    // Validate Feishu chat_id format
+    if (!chatId.startsWith('oc_') && !chatId.startsWith('ou_')) {
+      this.logger.warn({ chatId }, 'Invalid Feishu chat_id format, skipping send');
+      return;
+    }
+
+    try {
+      // Determine receive_id_type based on chat_id format
+      // oc_xxxxxx = group chat, ou_xxxxxx = user (open_id for DM)
+      const receiveIdType = chatId.startsWith('oc_') ? 'chat_id' : 'open_id';
+
+      // Build post message payload for rich text support
+      const content = JSON.stringify({
+        zh_cn: {
+          content: [[{ tag: 'md', text: text }]],
+        },
+      });
+
+      const response = await this.client.im.message.create({
+        params: { receive_id_type: receiveIdType },
+        data: {
+          receive_id: chatId,
+          content,
+          msg_type: 'post',
+        },
+      });
+
+      if (response.code !== 0) {
+        throw new Error(`Feishu send failed: ${response.msg || `code ${response.code}`}`);
+      }
+
+      this.logger.info({ chatId, receiveIdType, messageId: response.data?.message_id }, 'Message sent');
+    } catch (err) {
+      this.logger.error({ chatId, err }, 'Failed to send message');
+    }
+  }
+
+  async sendOrUpdateStatusMessage(
+    chatId: string,
+    sessionId: string,
+    text: string,
+    isNew: boolean = false,
+    replyToMessageId?: string | number | undefined
+  ): Promise<void> {
+    if (!this.client) {
+      this.logger.warn('Cannot send status message: client not connected');
+      return;
+    }
+
+    try {
+      // Determine receive_id_type based on chat_id format
+      const receiveIdType = chatId.startsWith('oc_') ? 'chat_id' : 'open_id';
+
+      // Initialize nested records if they don't exist
+      if (!this.statusMessageIds[chatId]) {
+        this.statusMessageIds[chatId] = {};
+      }
+      if (!this.accumulatedStatusMessages[chatId]) {
+        this.accumulatedStatusMessages[chatId] = {};
+      }
+
+      // Feishu uses interactive_card for updatable status messages
+      // Accumulate status text with line breaks
+      const accumulated = this.accumulatedStatusMessages[chatId][sessionId] || '';
+      const updatedText = accumulated ? accumulated + '\n' + text : text;
+
+      this.logger.info({ chatId, sessionId, accumulated, text, updatedText }, 'Accumulating status');
+
+      // Build interactive card message
+      const card = {
+        config: { wide_screen_mode: true },
+        header: {
+          template: 'blue',
+          title: {
+            tag: 'plain_text',
+            content: '⏳ Processing...',
+          },
+        },
+        elements: [
+          {
+            tag: 'div',
+            text: {
+              tag: 'lark_md',
+              content: updatedText,
+            },
+          },
+        ],
+      };
+
+      const content = JSON.stringify(card);
+
+      if (isNew || !this.statusMessageIds[chatId][sessionId]) {
+        // Send new card message
+        let response;
+        if (replyToMessageId && typeof replyToMessageId === 'string') {
+          // Reply to the original message
+          response = await this.client.im.message.reply({
+            path: { message_id: replyToMessageId },
+            data: {
+              content,
+              msg_type: 'interactive',
+            },
+          });
+        } else {
+          // Send as new message
+          response = await this.client.im.message.create({
+            params: { receive_id_type: receiveIdType },
+            data: {
+              receive_id: chatId,
+              content,
+              msg_type: 'interactive',
+            },
+          });
+        }
+
+        if (response.code !== 0) {
+          throw new Error(`Feishu status send failed: ${response.msg || `code ${response.code}`}`);
+        }
+
+        this.statusMessageIds[chatId][sessionId] = response.data?.message_id || '';
+        this.accumulatedStatusMessages[chatId][sessionId] = updatedText;
+        this.logger.info({ chatId, sessionId, messageId: response.data?.message_id }, 'Status card sent');
+      } else {
+        // Update existing card message using patch
+        const messageId = this.statusMessageIds[chatId][sessionId];
+
+        const response = await this.client.im.message.patch({
+          path: { message_id: messageId },
+          data: { content },
+        });
+
+        if (response.code !== 0) {
+          // If patch fails (message too old, etc.), send a new card
+          this.logger.warn({ chatId, sessionId, error: response.msg }, 'Failed to patch card, sending new');
+
+          const newResponse = await this.client.im.message.create({
+            params: { receive_id_type: receiveIdType },
+            data: {
+              receive_id: chatId,
+              content,
+              msg_type: 'interactive',
+            },
+          });
+
+          if (newResponse.code === 0) {
+            this.statusMessageIds[chatId][sessionId] = newResponse.data?.message_id || '';
+            this.accumulatedStatusMessages[chatId][sessionId] = updatedText;
+          }
+        } else {
+          this.accumulatedStatusMessages[chatId][sessionId] = updatedText;
+          this.logger.debug({ chatId, sessionId, messageId }, 'Status card updated');
+        }
+      }
+    } catch (err) {
+      this.logger.error({ chatId, sessionId, err }, 'Failed to send/update status message');
+    }
+  }
+
+  clearStatusMessage(chatId: string, sessionId?: string): void {
+    if (sessionId) {
+      // Clear status message for specific session
+      if (this.statusMessageIds[chatId]) {
+        delete this.statusMessageIds[chatId][sessionId];
+      }
+      if (this.accumulatedStatusMessages[chatId]) {
+        delete this.accumulatedStatusMessages[chatId][sessionId];
+      }
+    } else {
+      // Clear all status messages for the chat
+      delete this.statusMessageIds[chatId];
+      delete this.accumulatedStatusMessages[chatId];
+    }
+  }
+
+  /**
+   * Set callback for handling new messages
+   * Feishu detects commands (register, help, new) and adds '/' prefix for main flow
+   */
+  startMessageListener(onMessage: (msg: NewMessage) => Promise<void>): void {
+    this.onMessageCallback = async (msg) => {
+      // Feishu doesn't support native slash commands
+      // Convert recognized commands to standard format with '/' prefix
+      const content = msg.content.trim();
+      const lowerContent = content.toLowerCase();
+
+      // Convert recognized commands to slash format
+      if (lowerContent === 'register' || lowerContent.startsWith('register ')) {
+        msg.content = '/' + content;
+      } else if (lowerContent === 'help') {
+        msg.content = '/help';
+      } else if (lowerContent === 'new') {
+        msg.content = '/new';
+      }
+
+      // Pass to main callback
+      await onMessage(msg);
+    };
+    this.logger.info('Feishu message listener registered');
+  }
+
+  getPollInterval(): number {
+    return this.pollInterval;
+  }
+
+  needsPolling(): boolean {
+    return false; // Feishu uses WebSocket, no polling needed
+  }
+
+  async start(): Promise<void> {
+    await this.connect();
+  }
+
+  /**
+   * Update registered groups reference
+   */
+  updateRegisteredGroups(registeredGroups: Record<string, RegisteredGroup>): void {
+    this.registeredGroups = registeredGroups;
+  }
+
+  /**
+   * Send startup greetings to main group
+   */
+  async sendStartupGreetings(registeredGroups: Record<string, RegisteredGroup>, mainGroupFolder: string): Promise<void> {
+    const greetings = [
+      "👋 Hi! I'm online and ready to help!",
+      "🚀 NanoClaw is running - ask me anything!",
+      "✨ Ready to assist! Just mention me in a group or send a DM!",
+      "🤖 Online! What can I help you with?",
+    ];
+
+    // Find main session: either folder === mainGroupFolder OR isMainSession === true
+    // And has valid Feishu chat_id format (oc_xxxxxx for group, ou_xxxxxx for user)
+    const mainEntry = Object.entries(registeredGroups).find(
+      ([jid, group]) =>
+        (group.folder === mainGroupFolder || group.isMainSession === true) &&
+        (jid.startsWith('oc_') || jid.startsWith('ou_'))
+    );
+
+    // Filter to groups with valid Feishu chat_id format
+    const validGroups = Object.entries(registeredGroups).filter(
+      ([jid]) => jid.startsWith('oc_') || jid.startsWith('ou_')
+    );
+
+    if (!mainEntry && validGroups.length === 0) {
+      this.logger.info('No Feishu registered groups found. Use /register to register a Feishu chat.');
+      return;
+    }
+
+    const mainChatId = mainEntry?.[0];
+    if (!mainChatId) {
+      this.logger.info('No main session found for Feishu. Startup greeting skipped.');
+      return;
+    }
+
+    const greeting = greetings[Math.floor(Math.random() * greetings.length)];
+
+    try {
+      await this.sendMessage(mainChatId, greeting);
+      this.logger.info({ chatId: mainChatId, name: registeredGroups[mainChatId].name }, 'Startup greeting sent');
+    } catch (err) {
+      this.logger.error({ chatId: mainChatId, err }, 'Failed to send startup greeting');
+    }
+  }
+}

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -65,7 +65,8 @@ async function runTask(
   }
 
   // Update tasks snapshot for container to read (filtered by group)
-  const isMain = task.group_folder === MAIN_GROUP_FOLDER;
+  // Check both folder name and isMainSession flag
+  const isMain = task.group_folder === MAIN_GROUP_FOLDER || group.isMainSession === true;
   const tasks = getAllTasks();
   writeTasksSnapshot(
     task.group_folder,

--- a/src/telegram-auth.ts
+++ b/src/telegram-auth.ts
@@ -1,0 +1,84 @@
+/**
+ * Telegram Bot Authentication Script
+ *
+ * Creates a Telegram bot and saves the token.
+ *
+ * Usage: npx tsx src/telegram-auth.ts
+ */
+
+import TelegramBot from 'node-telegram-bot-api';
+import fs from 'fs';
+import path from 'path';
+import readline from 'readline';
+
+const TOKEN_FILE = './store/telegram-token.txt';
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout
+});
+
+function question(query: string): Promise<string> {
+  return new Promise(resolve => rl.question(query, resolve));
+}
+
+async function authenticate(): Promise<void> {
+  const storeDir = './store';
+  fs.mkdirSync(storeDir, { recursive: true });
+
+  // Check if already authenticated
+  if (fs.existsSync(TOKEN_FILE)) {
+    const existingToken = fs.readFileSync(TOKEN_FILE, 'utf-8').trim();
+    console.log('✓ Telegram bot token already configured');
+    console.log(`  Token: ${existingToken.substring(0, 10)}...${existingToken.substring(existingToken.length - 4)}`);
+    console.log('  To re-authenticate, delete store/telegram-token.txt and run again.');
+    rl.close();
+    process.exit(0);
+  }
+
+  console.log('Setting up Telegram bot for NanoClaw...\n');
+  console.log('To create a Telegram bot:');
+  console.log('  1. Open Telegram and search for @BotFather');
+  console.log('  2. Send /newbot');
+  console.log('  3. Follow the prompts to name your bot');
+  console.log('  4. Copy the API token BotFather gives you\n');
+
+  const token = await question('Enter your Telegram bot token: ');
+
+  if (!token || token.length < 30) {
+    console.log('\n✗ Invalid token. Token should be a long string from BotFather.');
+    rl.close();
+    process.exit(1);
+  }
+
+  // Test the token
+  console.log('\nTesting bot token...');
+  const bot = new TelegramBot(token, { polling: false });
+
+  try {
+    const me = await bot.getMe();
+    console.log(`✓ Bot connected: @${me.username} (${me.first_name})`);
+  } catch (err) {
+    console.log('\n✗ Failed to connect to Telegram. Check your token.');
+    console.log('  Error:', (err as Error).message);
+    rl.close();
+    process.exit(1);
+  }
+
+  // Save the token
+  fs.writeFileSync(TOKEN_FILE, token.trim());
+  console.log('\n✓ Successfully authenticated with Telegram!');
+  console.log('  Token saved to store/telegram-token.txt');
+  console.log('  You can now start the NanoClaw service.\n');
+  console.log('IMPORTANT: Send a message to your bot in Telegram to get started.');
+  console.log('  Find your bot by searching: @' + (await bot.getMe()).username);
+
+  rl.close();
+  process.exit(0);
+}
+
+authenticate().catch((err) => {
+  console.error('Authentication failed:', err.message);
+  rl.close();
+  process.exit(1);
+});

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -1,0 +1,281 @@
+/**
+ * Telegram Messenger Implementation
+ * Handles Telegram bot communication and implements the Messenger interface
+ */
+
+import TelegramBot from 'node-telegram-bot-api';
+import pino from 'pino';
+import fs from 'fs';
+import path from 'path';
+import { exec } from 'child_process';
+import { Messenger, NewMessage, RegisteredGroup } from './types.js';
+import { storeTelegramMessage, storeChatMetadata } from './db.js';
+
+export class TelegramMessenger implements Messenger {
+  private bot: TelegramBot | null = null;
+  private logger: pino.Logger;
+  private storeDir: string;
+  private registeredGroups: Record<string, RegisteredGroup>;
+  private onMessageCallback?: (msg: NewMessage) => Promise<void>;
+  private pollInterval: number;
+
+  // Track current status message IDs for editing by chatId and sessionId
+  private statusMessageIds: Record<string, Record<string, number>> = {}; // chatId -> sessionId -> statusMessageId
+  private lastStatusMessage: Record<string, Record<string, { message: string; timestamp: number }>> = {}; // chatId -> sessionId -> {message, timestamp}
+  private accumulatedStatusMessages: Record<string, Record<string, string>> = {}; // chatId -> sessionId -> accumulatedText
+  private readonly STATUS_DEBOUNCE_MS = 2000; // Minimum 2 seconds between status updates
+
+  constructor(
+    logger: pino.Logger,
+    storeDir: string,
+    registeredGroups: Record<string, RegisteredGroup>,
+    pollInterval: number
+  ) {
+    this.logger = logger.child({ messenger: 'telegram' });
+    this.storeDir = storeDir;
+    this.registeredGroups = registeredGroups;
+    this.pollInterval = pollInterval;
+  }
+
+  async connect(): Promise<void> {
+    const tokenFile = path.join(this.storeDir, 'telegram-token.txt');
+
+    if (!fs.existsSync(tokenFile)) {
+      const msg = 'Telegram bot token not found. Run npm run auth first.';
+      this.logger.error(msg);
+      exec(`osascript -e 'display notification "${msg}" with title "NanoClaw" sound name "Basso"'`);
+      process.exit(1);
+    }
+
+    const token = fs.readFileSync(tokenFile, 'utf-8').trim();
+    this.bot = new TelegramBot(token, { polling: true });
+
+    // Set up message handler
+    this.bot.on('message', async (msg) => {
+      const chatJid = msg.chat.id.toString();
+      if (!msg.text) return;
+
+      const timestamp = new Date(msg.date * 1000).toISOString();
+
+      // Always store chat metadata
+      const chatName = msg.chat.type === 'private'
+        ? `${msg.from?.first_name || ''} ${msg.from?.last_name || ''}`.trim() || msg.chat.username || chatJid
+        : msg.chat.title || msg.chat.username || chatJid;
+      storeChatMetadata(chatJid, timestamp, chatName);
+
+      // Only store full message content for registered groups
+      if (this.registeredGroups[chatJid] && msg.from) {
+        storeTelegramMessage(msg, chatJid, false);
+      }
+    });
+
+    this.bot.on('polling_error', (error) => {
+      this.logger.error({ error }, 'Telegram polling error');
+    });
+
+    this.logger.info('Connected to Telegram');
+  }
+
+  async registerCommands(commands: Array<{ name: string; description: string }>): Promise<void> {
+    if (!this.bot) {
+      this.logger.warn('Cannot register commands: bot not connected');
+      return;
+    }
+
+    try {
+      // Transform to Telegram's expected format (command, description)
+      const botCommands = commands.map(cmd => ({
+        command: cmd.name,
+        description: cmd.description
+      }));
+
+      this.logger.debug({ commands: botCommands }, 'Registering commands with Telegram');
+
+      const result = await this.bot.setMyCommands(botCommands);
+      this.logger.info({ count: botCommands.length, result }, 'Bot commands registered with Telegram');
+    } catch (err) {
+      this.logger.error({ err }, 'Failed to register bot commands');
+    }
+  }
+
+  async sendMessage(chatId: string, text: string): Promise<void> {
+    if (!this.bot) {
+      this.logger.warn('Cannot send message: bot not connected');
+      return;
+    }
+
+    try {
+      await this.bot.sendMessage(chatId, text);
+      this.logger.info({ chatId, length: text.length }, 'Message sent');
+    } catch (err) {
+      this.logger.error({ chatId, err }, 'Failed to send message');
+    }
+  }
+
+  async sendOrUpdateStatusMessage(
+    chatId: string,
+    sessionId: string,
+    text: string,
+    isNew: boolean = false,
+    replyToMessageId?: number
+  ): Promise<void> {
+    if (!this.bot) {
+      this.logger.warn('Cannot send status message: bot not connected');
+      return;
+    }
+
+    try {
+      // Initialize nested records if they don't exist
+      if (!this.statusMessageIds[chatId]) {
+        this.statusMessageIds[chatId] = {};
+      }
+      if (!this.lastStatusMessage[chatId]) {
+        this.lastStatusMessage[chatId] = {};
+      }
+      if (!this.accumulatedStatusMessages[chatId]) {
+        this.accumulatedStatusMessages[chatId] = {};
+      }
+
+      if (isNew || !this.statusMessageIds[chatId][sessionId]) {
+        // Send new status message, replying to original trigger message
+        const msg = await this.bot.sendMessage(chatId, text, { reply_to_message_id: replyToMessageId });
+        this.statusMessageIds[chatId][sessionId] = msg.message_id;
+        this.accumulatedStatusMessages[chatId][sessionId] = text;
+        this.logger.info({ chatId, sessionId, statusMessageId: msg.message_id }, 'Status message sent');
+      } else {
+        // Append new text to existing message with newline
+        const accumulated = this.accumulatedStatusMessages[chatId][sessionId] || '';
+        const updatedText = accumulated + '\n' + text;
+        try {
+          await this.bot.editMessageText(updatedText, {
+            chat_id: chatId,
+            message_id: this.statusMessageIds[chatId][sessionId]
+          });
+          this.accumulatedStatusMessages[chatId][sessionId] = updatedText;
+          this.logger.debug({ chatId, sessionId, statusMessageId: this.statusMessageIds[chatId][sessionId] }, 'Status message updated');
+        } catch (editErr) {
+          // If edit fails (message too old, deleted, etc.), send new message
+          const msg = await this.bot.sendMessage(chatId, updatedText);
+          this.statusMessageIds[chatId][sessionId] = msg.message_id;
+          this.accumulatedStatusMessages[chatId][sessionId] = updatedText;
+          this.logger.info({ chatId, sessionId, statusMessageId: msg.message_id }, 'Status message: re-sent');
+        }
+      }
+    } catch (err) {
+      this.logger.error({ chatId, sessionId, err }, 'Failed to send/update status message');
+    }
+  }
+
+  clearStatusMessage(chatId: string, sessionId?: string): void {
+    if (sessionId) {
+      // Clear status message for specific session
+      if (this.statusMessageIds[chatId]) {
+        delete this.statusMessageIds[chatId][sessionId];
+      }
+      if (this.lastStatusMessage[chatId]) {
+        delete this.lastStatusMessage[chatId][sessionId];
+      }
+      if (this.accumulatedStatusMessages[chatId]) {
+        delete this.accumulatedStatusMessages[chatId][sessionId];
+      }
+    } else {
+      // Clear all status messages for the chat
+      delete this.statusMessageIds[chatId];
+      delete this.lastStatusMessage[chatId];
+      delete this.accumulatedStatusMessages[chatId];
+    }
+  }
+
+  startMessageListener(onMessage: (msg: NewMessage) => Promise<void>): void {
+    this.onMessageCallback = onMessage;
+  }
+
+  getPollInterval(): number {
+    return this.pollInterval;
+  }
+
+  needsPolling(): boolean {
+    return true; // Telegram uses database polling
+  }
+
+  async start(): Promise<void> {
+    await this.connect();
+  }
+
+  /**
+   * Update registered groups reference
+   */
+  updateRegisteredGroups(registeredGroups: Record<string, RegisteredGroup>): void {
+    this.registeredGroups = registeredGroups;
+  }
+
+  /**
+   * Send startup greetings to main group
+   */
+  async sendStartupGreetings(registeredGroups: Record<string, RegisteredGroup>, mainGroupFolder: string): Promise<void> {
+    const greetings = [
+      "👋 Hi! I'm online and ready to help!",
+      "🚀 NanoClaw is running - ask me anything!",
+      "✨ Ready to assist! Just mention @Andy",
+      "🤖 Online! What can I help you with?",
+    ];
+
+    // Find main session: either folder === mainGroupFolder OR isMainSession === true
+    const mainEntry = Object.entries(registeredGroups).find(
+      ([, group]) => group.folder === mainGroupFolder || group.isMainSession === true
+    );
+
+    if (!mainEntry) {
+      this.logger.warn('No main group found to send startup greeting');
+      return;
+    }
+
+    const mainChatId = mainEntry[0];
+    const greeting = greetings[Math.floor(Math.random() * greetings.length)];
+
+    try {
+      await this.sendMessage(mainChatId, greeting);
+      this.logger.info({ chatId: mainChatId, name: registeredGroups[mainChatId].name }, 'Startup greeting sent');
+    } catch (err) {
+      this.logger.error({ chatId: mainChatId, err }, 'Failed to send startup greeting');
+    }
+  }
+
+  /**
+   * Get current commands from Telegram API
+   */
+  async getMyCommands(): Promise<any[]> {
+    if (!this.bot) {
+      return [];
+    }
+
+    try {
+      const commands = await this.bot.getMyCommands();
+      return commands || [];
+    } catch (err) {
+      this.logger.error({ err }, 'Failed to get bot commands');
+      return [];
+    }
+  }
+
+  /**
+   * Verify commands are registered correctly (runs once)
+   */
+  async verifyCommands(expectedCommands: Array<{ name: string; description: string }>): Promise<void> {
+    const currentCommands = await this.getMyCommands();
+    const expectedNames = expectedCommands.map(c => c.name).sort();
+    const currentNames = currentCommands.map((c: any) => c.command).sort();
+
+    if (JSON.stringify(expectedNames) !== JSON.stringify(currentNames)) {
+      this.logger.warn({
+        expected: expectedNames,
+        current: currentNames,
+      }, 'Commands mismatch detected, re-registering');
+      await this.registerCommands(expectedCommands);
+    } else {
+      this.logger.info({
+        commands: currentCommands,
+      }, 'Commands verified on Telegram');
+    }
+  }
+}


### PR DESCRIPTION


## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [x] **Improvment* add messager api and supports telegram and feishu

## Description
- Reset src/index.ts to 80e68dc base with WhatsApp as primary messenger
- Add Telegram and Feishu messenger support via MESSENGER env var
- WhatsApp remains default; use MESSENGER=telegram or MESSENGER=feishu to switch
- Add authentication scripts for Telegram (telegram-auth.ts) and Feishu (feishu-auth.ts)
- Add command system (src/commands.ts) for bot interactions
- Update database schema with Feishu message types and storage functions
- Update package.json with WhatsApp dependencies (@whiskeysockets/baileys, qrcode-terminal)

## For Skills

- [ ] I have not made any changes to source code
- [ ] My skill contains instructions for Claude to follow (not pre-built code)
- [ ] I tested this skill on a fresh clone
