### PR TITLE
Add SECURITY.md reference to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,10 @@ Single Node.js process that connects to WhatsApp, routes messages to Claude Agen
 | `/customize` | Adding channels, integrations, changing behavior |
 | `/debug` | Container issues, logs, troubleshooting |
 
+## Security
+
+Agents run in containers with explicit mount boundaries. Before modifying files that handle mounts, paths, credentials, or IPC authorization, read [docs/SECURITY.md](docs/SECURITY.md) and consider the security implications.
+
 ## Development
 
 Run commands directly—don't tell the user to run them.


### PR DESCRIPTION
## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description

Claude Code loads CLAUDE.md automatically on session start but has no reference to the security model documented in docs/SECURITY.md.

This means if a user opens Claude Code and says "mount my home directory into the container so the agent can access my notes" Claude Code has no prompt to check whether that violates the mount security model. It may help the user bypass the blocked patterns and symlink validation by modifying container-runner.ts directly rather than going through the allowlist, because nothing in its loaded context told it those guardrails exist.

The same applies to other security-sensitive code paths: credential filtering of allowed env vars, IPC authorization checks, nonMainReadOnly enforcement, and session isolation. A well-intentioned Claude Code edit could quietly weaken any of  these boundaries if it doesn't know the threat model.