### PR TITLE
fix security: add CPU and memory limits to agent containers

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -170,6 +170,9 @@ function buildVolumeMounts(
 function buildContainerArgs(mounts: VolumeMount[], containerName: string): string[] {
   const args: string[] = ['run', '-i', '--rm', '--name', containerName];
 
+  // Resource limits: prevent CPU/memory exhaustion from runaway or malicious processes
+  args.push('--cpus', '2', '--memory', '512M');
+
   // Apple Container: --mount for readonly, -v for read-write
   for (const mount of mounts) {
     if (mount.readonly) {


### PR DESCRIPTION
## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description

Without explicit limits, each container gets the default 4 CPUs and 1GB RAM. With MAX_CONCURRENT_CONTAINERS=5, 20 CPUs are committed which over-commits on most M-series Macs (8-12 cores). A prompt-injected agent could also run a memory bomb and exhaust host resources.

Setting --cpus 2 --memory 512M caps each container and is sufficient since agent work is network-bound (API calls to Anthropic).


