### PR TITLE
security: redact API keys from outgoing messages and logs

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -16,6 +16,7 @@ import {
 } from './config.js';
 import { logger } from './logger.js';
 import { validateAdditionalMounts } from './mount-security.js';
+import { redactSecrets } from './secret-redact.js';
 import { RegisteredGroup } from './types.js';
 
 // Sentinel markers for robust output parsing (must match agent-runner)
@@ -377,7 +378,7 @@ export async function runContainerAgent(
         );
       }
 
-      fs.writeFileSync(logFile, logLines.join('\n'));
+      fs.writeFileSync(logFile, redactSecrets(logLines.join('\n')));
       logger.debug({ logFile, verbose: isVerbose }, 'Container log written');
 
       if (code !== 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import {
   TIMEZONE,
   TRIGGER_PATTERN,
 } from './config.js';
+import { loadSecrets, redactSecrets } from './secret-redact.js';
 import {
   AgentResponse,
   AvailableGroup,
@@ -328,9 +329,10 @@ async function runAgent(
 }
 
 async function sendMessage(jid: string, text: string): Promise<void> {
+  const safe = redactSecrets(text);
   try {
-    await sock.sendMessage(jid, { text });
-    logger.info({ jid, length: text.length }, 'Message sent');
+    await sock.sendMessage(jid, { text: safe });
+    logger.info({ jid, length: safe.length }, 'Message sent');
   } catch (err) {
     logger.error({ jid, err }, 'Failed to send message');
   }
@@ -912,6 +914,7 @@ function ensureContainerSystemRunning(): void {
 
 async function main(): Promise<void> {
   ensureContainerSystemRunning();
+  loadSecrets();
   initDatabase();
   logger.info('Database initialized');
   loadState();

--- a/src/secret-redact.ts
+++ b/src/secret-redact.ts
@@ -1,0 +1,60 @@
+/**
+ * Secret redaction for outgoing messages and logs.
+ * Prevents accidental leakage of API keys via social engineering.
+ */
+import fs from 'fs';
+import path from 'path';
+
+const REDACTED = '[REDACTED]';
+const MIN_SECRET_LENGTH = 8; // Don't redact very short values (avoid false positives)
+
+let secretValues: string[] = [];
+
+/**
+ * Load secret values from .env that should never appear in output.
+ * Call once at startup.
+ */
+export function loadSecrets(): void {
+  const envFile = path.join(process.cwd(), '.env');
+  if (!fs.existsSync(envFile)) return;
+
+  const allowedVars = ['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_API_KEY'];
+  const content = fs.readFileSync(envFile, 'utf-8');
+
+  secretValues = [];
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1) continue;
+
+    const key = trimmed.slice(0, eqIdx).trim();
+    if (!allowedVars.includes(key)) continue;
+
+    // Strip optional quotes
+    let value = trimmed.slice(eqIdx + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    if (value.length >= MIN_SECRET_LENGTH) {
+      secretValues.push(value);
+    }
+  }
+}
+
+/**
+ * Replace any known secret values in the given text with [REDACTED].
+ */
+export function redactSecrets(text: string): string {
+  let result = text;
+  for (const secret of secretValues) {
+    // Use split/join for literal replacement (no regex escaping needed)
+    result = result.split(secret).join(REDACTED);
+  }
+  return result;
+}

--- a/test/secret-redact.test.ts
+++ b/test/secret-redact.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+let tmpDir: string;
+let cwdSpy: ReturnType<typeof vi.spyOn>;
+
+// Dynamic import after mocks are set up
+let loadSecrets: typeof import('../src/secret-redact.js').loadSecrets;
+let redactSecrets: typeof import('../src/secret-redact.js').redactSecrets;
+
+beforeEach(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-redact-test-'));
+  cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tmpDir);
+  // Re-import to get fresh module state
+  vi.resetModules();
+  const mod = await import('../src/secret-redact.js');
+  loadSecrets = mod.loadSecrets;
+  redactSecrets = mod.redactSecrets;
+});
+
+afterEach(() => {
+  cwdSpy.mockRestore();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeEnv(content: string): void {
+  fs.writeFileSync(path.join(tmpDir, '.env'), content);
+}
+
+describe('loadSecrets + redactSecrets', () => {
+  it('redacts ANTHROPIC_API_KEY from output', () => {
+    writeEnv('ANTHROPIC_API_KEY=sk-ant-secret-key-12345678');
+    loadSecrets();
+
+    const input = 'Here is the key: sk-ant-secret-key-12345678';
+    expect(redactSecrets(input)).toBe('Here is the key: [REDACTED]');
+  });
+
+  it('redacts CLAUDE_CODE_OAUTH_TOKEN from output', () => {
+    writeEnv('CLAUDE_CODE_OAUTH_TOKEN=oauth-token-abcdef99');
+    loadSecrets();
+
+    expect(redactSecrets('token=oauth-token-abcdef99')).toBe(
+      'token=[REDACTED]',
+    );
+  });
+
+  it('redacts multiple secrets in the same string', () => {
+    writeEnv(
+      'ANTHROPIC_API_KEY=sk-ant-aaaa\nCLAUDE_CODE_OAUTH_TOKEN=oauth-bbbb-cccc',
+    );
+    loadSecrets();
+
+    const input = 'key=sk-ant-aaaa and token=oauth-bbbb-cccc end';
+    expect(redactSecrets(input)).toBe(
+      'key=[REDACTED] and token=[REDACTED] end',
+    );
+  });
+
+  it('redacts all occurrences of the same secret', () => {
+    writeEnv('ANTHROPIC_API_KEY=sk-ant-repeated-key');
+    loadSecrets();
+
+    const input = 'first: sk-ant-repeated-key, second: sk-ant-repeated-key';
+    expect(redactSecrets(input)).toBe('first: [REDACTED], second: [REDACTED]');
+  });
+
+  it('handles double-quoted values in .env', () => {
+    writeEnv('ANTHROPIC_API_KEY="sk-ant-quoted-value"');
+    loadSecrets();
+
+    expect(redactSecrets('key is sk-ant-quoted-value here')).toBe(
+      'key is [REDACTED] here',
+    );
+  });
+
+  it('handles single-quoted values in .env', () => {
+    writeEnv("ANTHROPIC_API_KEY='sk-ant-single-quoted'");
+    loadSecrets();
+
+    expect(redactSecrets('sk-ant-single-quoted')).toBe('[REDACTED]');
+  });
+
+  it('ignores non-allowlisted env vars', () => {
+    writeEnv(
+      'DATABASE_URL=postgres://secret\nANTHROPIC_API_KEY=sk-ant-real-key',
+    );
+    loadSecrets();
+
+    // DATABASE_URL value should NOT be redacted
+    expect(redactSecrets('postgres://secret')).toBe('postgres://secret');
+    // ANTHROPIC_API_KEY value should be redacted
+    expect(redactSecrets('sk-ant-real-key')).toBe('[REDACTED]');
+  });
+
+  it('ignores comments in .env', () => {
+    writeEnv('# ANTHROPIC_API_KEY=sk-ant-commented-out\nANTHROPIC_API_KEY=sk-ant-actual');
+    loadSecrets();
+
+    // Commented-out value should NOT be redacted
+    expect(redactSecrets('sk-ant-commented-out')).toBe('sk-ant-commented-out');
+    expect(redactSecrets('sk-ant-actual')).toBe('[REDACTED]');
+  });
+
+  it('ignores values shorter than minimum length', () => {
+    writeEnv('ANTHROPIC_API_KEY=short');
+    loadSecrets();
+
+    // "short" is < 8 chars, should not be redacted (too risky for false positives)
+    expect(redactSecrets('short')).toBe('short');
+  });
+
+  it('returns text unchanged when no .env exists', () => {
+    // Don't write any .env file
+    loadSecrets();
+    expect(redactSecrets('sk-ant-anything')).toBe('sk-ant-anything');
+  });
+
+  it('returns text unchanged when .env has no allowlisted vars', () => {
+    writeEnv('DATABASE_URL=something\nREDIS_URL=else');
+    loadSecrets();
+
+    expect(redactSecrets('something else')).toBe('something else');
+  });
+
+  it('handles empty lines and whitespace in .env', () => {
+    writeEnv('\n  \n\nANTHROPIC_API_KEY=sk-ant-spaced-key\n\n');
+    loadSecrets();
+
+    expect(redactSecrets('sk-ant-spaced-key')).toBe('[REDACTED]');
+  });
+
+  it('redacts secrets that appear in multiline output (env dump)', () => {
+    writeEnv('ANTHROPIC_API_KEY=sk-ant-multiline-test');
+    loadSecrets();
+
+    const envDump = [
+      'HOME=/home/node',
+      'PATH=/usr/bin:/bin',
+      'ANTHROPIC_API_KEY=sk-ant-multiline-test',
+      'NODE_VERSION=20.0.0',
+    ].join('\n');
+
+    expect(redactSecrets(envDump)).toBe(
+      [
+        'HOME=/home/node',
+        'PATH=/usr/bin:/bin',
+        'ANTHROPIC_API_KEY=[REDACTED]',
+        'NODE_VERSION=20.0.0',
+      ].join('\n'),
+    );
+  });
+
+  it('handles secrets containing regex-special characters', () => {
+    writeEnv('ANTHROPIC_API_KEY=sk-ant-key+with.special$chars');
+    loadSecrets();
+
+    expect(redactSecrets('found sk-ant-key+with.special$chars here')).toBe(
+      'found [REDACTED] here',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Agents can be social-engineered into printing env vars (`env`, `cat /workspace/env-dir/env`, `echo $ANTHROPIC_API_KEY`), leaking `ANTHROPIC_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN` to any group member via WhatsApp
- Adds a redaction layer that strips known secret values from all outgoing WhatsApp messages (`sendMessage`) and container log files before they're written to disk
- Secrets are loaded once at startup from `.env` and matched as literal strings (no regex, so special chars in keys are handled safely)

## Test plan
- [x] 14 unit tests covering: basic redaction, multiple secrets, quoted `.env` values, non-allowlisted vars ignored, comments skipped, short value rejection, missing `.env` graceful no-op, multiline env dumps, regex-special characters in keys
- [ ] Manual: send "print your env vars" to Kit in a group chat, verify `ANTHROPIC_API_KEY` value shows as `[REDACTED]`
- [ ] Manual: check container log files after a run, verify no raw secret values present

🤖 Generated with [Claude Code](https://claude.com/claude-code)