### PR TITLE
feat: add proactive heartbeat system

### DIFF
--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -239,6 +239,66 @@ server.tool(
 );
 
 server.tool(
+  'configure_heartbeat',
+  `Enable or disable the heartbeat for a group. The heartbeat is a recurring background task that runs on a schedule.
+
+What the heartbeat does is controlled by the ## Heartbeat section in CLAUDE.md — edit that to customize behavior. The heartbeat also reads ## Goals from CLAUDE.md, so maintain your goals there.
+
+After enabling, edit your CLAUDE.md to add/update the ## Heartbeat and ## Goals sections to control what the heartbeat does.`,
+  {
+    enabled: z.boolean().describe('Whether to enable or disable the heartbeat'),
+    interval: z.string().default('1800000').describe('Schedule: milliseconds for interval type, or cron expression for cron type (default: "1800000" = 30 min)'),
+    schedule_type: z.enum(['cron', 'interval']).default('interval').describe('Type of schedule (default: "interval")'),
+    target_group_jid: z.string().optional().describe('(Main group only) JID of the group to configure. Defaults to current group.'),
+  },
+  async (args) => {
+    // Non-main groups can only configure themselves
+    const targetJid = isMain && args.target_group_jid ? args.target_group_jid : chatJid;
+
+    if (args.enabled && args.schedule_type === 'cron') {
+      try {
+        CronExpressionParser.parse(args.interval);
+      } catch {
+        return {
+          content: [{ type: 'text' as const, text: `Invalid cron expression: "${args.interval}". Use format like "0 */30 * * *" (every 30 min) or "0 9 * * *" (daily 9am).` }],
+          isError: true,
+        };
+      }
+    } else if (args.enabled && args.schedule_type === 'interval') {
+      const ms = parseInt(args.interval, 10);
+      if (isNaN(ms) || ms <= 0) {
+        return {
+          content: [{ type: 'text' as const, text: `Invalid interval: "${args.interval}". Must be positive milliseconds (e.g., "1800000" for 30 min).` }],
+          isError: true,
+        };
+      }
+    }
+
+    const data = {
+      type: 'configure_heartbeat',
+      enabled: args.enabled,
+      interval: args.interval,
+      heartbeat_schedule_type: args.schedule_type,
+      target_group_jid: targetJid,
+      groupFolder,
+      timestamp: new Date().toISOString(),
+    };
+
+    writeIpcFile(TASKS_DIR, data);
+
+    if (args.enabled) {
+      return {
+        content: [{ type: 'text' as const, text: `Heartbeat enabled (${args.schedule_type}: ${args.interval}). Edit ## Heartbeat and ## Goals in your CLAUDE.md to customize what the heartbeat does.` }],
+      };
+    } else {
+      return {
+        content: [{ type: 'text' as const, text: 'Heartbeat disabled. The recurring heartbeat task has been removed.' }],
+      };
+    }
+  },
+);
+
+server.tool(
   'register_group',
   `Register a new WhatsApp group so the agent can respond to messages there. Main group only.
 

--- a/groups/global/CLAUDE.md
+++ b/groups/global/CLAUDE.md
@@ -56,3 +56,19 @@ NEVER use markdown. Only use WhatsApp/Telegram formatting:
 - ```triple backticks``` for code
 
 No ## headings. No [links](url). No **double stars**.
+
+## Heartbeat
+
+When running as a heartbeat (scheduled background task):
+
+1. Review your ## Goals section for current priorities
+2. Pick the highest-priority actionable item and work on it
+3. Update ## Goals as you complete items or discover new ones
+4. Only message the group if there is meaningful progress to report
+5. If nothing is actionable, complete silently — do not send "nothing to report"
+
+## Goals
+
+Maintain this section with your current priorities and long-term objectives. Update it as you complete work or learn about new needs from conversations.
+
+- [ ] (Users and agents add goals here over time)

--- a/src/ipc-auth.test.ts
+++ b/src/ipc-auth.test.ts
@@ -56,7 +56,10 @@ beforeEach(() => {
     registerGroup: (jid, group) => {
       groups[jid] = group;
       setRegisteredGroup(jid, group);
-      // Mock the fs.mkdirSync that registerGroup does
+    },
+    updateGroup: (jid, group) => {
+      groups[jid] = group;
+      setRegisteredGroup(jid, group);
     },
     syncGroupMetadata: async () => {},
     getAvailableGroups: () => [],

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,12 @@ export interface ContainerConfig {
   timeout?: number; // Default: 300000 (5 minutes)
 }
 
+export interface HeartbeatConfig {
+  enabled: boolean;
+  interval: string;        // cron expression or ms interval
+  scheduleType: 'cron' | 'interval';
+}
+
 export interface RegisteredGroup {
   name: string;
   folder: string;
@@ -39,6 +45,7 @@ export interface RegisteredGroup {
   added_at: string;
   containerConfig?: ContainerConfig;
   requiresTrigger?: boolean; // Default: true for groups, false for solo chats
+  heartbeat?: HeartbeatConfig;
 }
 
 export interface NewMessage {


### PR DESCRIPTION
## Summary

- Makes heartbeats a first-class feature: **schedule** in group config (SQLite), **behavior** in CLAUDE.md
- Agent maintains `## Goals` in CLAUDE.md with long-term priorities; `## Heartbeat` section defines what happens each cycle
- Edits to CLAUDE.md take effect immediately on the next heartbeat — no DB changes needed
- `configure_heartbeat` MCP tool lets the agent enable/disable heartbeats per group
- `reconcileHeartbeats()` auto-creates/removes scheduled tasks on startup and when config changes

## Changes

| File | Change |
|------|--------|
| `src/types.ts` | Add `HeartbeatConfig` interface, add field to `RegisteredGroup` |
| `src/db.ts` | Add `heartbeat` column migration, update get/set to parse/serialize JSON |
| `src/task-scheduler.ts` | Add `buildHeartbeatPrompt()`, `reconcileHeartbeats()`, modify `runTask()` |
| `src/index.ts` | Call `reconcileHeartbeats()` on startup, add `updateGroup` IPC dep |
| `src/ipc.ts` | Add `configure_heartbeat` IPC handler with authorization |
| `container/agent-runner/src/ipc-mcp-stdio.ts` | Add `configure_heartbeat` MCP tool |
| `groups/global/CLAUDE.md` | Add `## Heartbeat` and `## Goals` sections |

## Test plan

- [ ] `npm run build` compiles cleanly
- [ ] Service starts without errors, no heartbeat tasks created when no groups have config
- [ ] `configure_heartbeat(enabled: true, interval: "1800000")` → heartbeat task appears in `list_tasks`
- [ ] Edit `## Heartbeat` in CLAUDE.md → next heartbeat uses updated prompt
- [ ] Disable heartbeat → task removed from DB
- [ ] Restart service → heartbeat tasks reconciled from stored config

🤖 Generated with [Claude Code](https://claude.com/claude-code)