### PR TITLE
fix: copy skill subdirectories recursively

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -134,12 +134,7 @@ function buildVolumeMounts(
       const srcDir = path.join(skillsSrc, skillDir);
       if (!fs.statSync(srcDir).isDirectory()) continue;
       const dstDir = path.join(skillsDst, skillDir);
-      fs.mkdirSync(dstDir, { recursive: true });
-      for (const file of fs.readdirSync(srcDir)) {
-        const srcFile = path.join(srcDir, file);
-        const dstFile = path.join(dstDir, file);
-        fs.copyFileSync(srcFile, dstFile);
-      }
+      fs.cpSync(srcDir, dstDir, { recursive: true });
     }
   }
   mounts.push({


### PR DESCRIPTION
copyFileSync crashes with EISDIR when a skill contains subdirectories like scripts/. Skills support nested folders (scripts/, examples/, templates/) per the Claude Code spec. Use fs.cpSync to handle the complete skill structure.