### PR TITLE
feat: versioned DB migration framework + channel column

### DIFF
--- a/src/channels/whatsapp.test.ts
+++ b/src/channels/whatsapp.test.ts
@@ -108,6 +108,7 @@ function createTestOpts(overrides?: Partial<WhatsAppChannelOpts>): WhatsAppChann
         folder: 'test-group',
         trigger: '@Andy',
         added_at: '2024-01-01T00:00:00.000Z',
+        channel: 'whatsapp',
       },
     })),
     ...overrides,
@@ -550,6 +551,7 @@ describe('WhatsAppChannel', () => {
             folder: 'self-chat',
             trigger: '@Andy',
             added_at: '2024-01-01T00:00:00.000Z',
+            channel: 'whatsapp',
           },
         })),
       });

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -89,6 +89,7 @@ const testGroup: RegisteredGroup = {
   folder: 'test-group',
   trigger: '@Andy',
   added_at: new Date().toISOString(),
+  channel: 'whatsapp',
 };
 
 const testInput = {

--- a/src/ipc-auth.test.ts
+++ b/src/ipc-auth.test.ts
@@ -17,6 +17,7 @@ const MAIN_GROUP: RegisteredGroup = {
   folder: 'main',
   trigger: 'always',
   added_at: '2024-01-01T00:00:00.000Z',
+  channel: 'whatsapp',
 };
 
 const OTHER_GROUP: RegisteredGroup = {
@@ -24,6 +25,7 @@ const OTHER_GROUP: RegisteredGroup = {
   folder: 'other-group',
   trigger: '@Andy',
   added_at: '2024-01-01T00:00:00.000Z',
+  channel: 'whatsapp',
 };
 
 const THIRD_GROUP: RegisteredGroup = {
@@ -31,6 +33,7 @@ const THIRD_GROUP: RegisteredGroup = {
   folder: 'third-group',
   trigger: '@Andy',
   added_at: '2024-01-01T00:00:00.000Z',
+  channel: 'whatsapp',
 };
 
 let groups: Record<string, RegisteredGroup>;

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -171,6 +171,7 @@ export async function processTaskIpc(
     name?: string;
     folder?: string;
     trigger?: string;
+    channel?: string;
     requiresTrigger?: boolean;
     containerConfig?: RegisteredGroup['containerConfig'];
   },
@@ -366,6 +367,7 @@ export async function processTaskIpc(
           folder: data.folder,
           trigger: data.trigger,
           added_at: new Date().toISOString(),
+          channel: data.channel || 'whatsapp',
           containerConfig: data.containerConfig,
           requiresTrigger: data.requiresTrigger,
         });

--- a/src/routing.test.ts
+++ b/src/routing.test.ts
@@ -62,6 +62,7 @@ describe('getAvailableGroups', () => {
         folder: 'registered',
         trigger: '@Andy',
         added_at: '2024-01-01T00:00:00.000Z',
+        channel: 'whatsapp',
       },
     });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,7 @@ export interface RegisteredGroup {
   folder: string;
   trigger: string;
   added_at: string;
+  channel: string; // Channel that owns this group (e.g. 'whatsapp', 'telegram')
   containerConfig?: ContainerConfig;
   requiresTrigger?: boolean; // Default: true for groups, false for solo chats
 }


### PR DESCRIPTION
## Summary

- Replace ad-hoc `try/catch ALTER TABLE` migration pattern with a proper `schema_version` table and sequential migration runner
- Add `channel TEXT NOT NULL DEFAULT 'whatsapp'` column to `registered_groups` table, enabling multi-channel routing
- Add `channel: string` field to `RegisteredGroup` interface and update all accessors (`get`, `set`, `getAll`) and callers

## Details

**Migration framework** (`src/db.ts`):
- New `schema_version` table (single-row, version integer)
- `runMigrations()` applies pending migrations sequentially and bumps version
- Migration 1: `context_mode` column (previously ad-hoc try/catch)
- Migration 2: `channel` column on `registered_groups`

**Type changes** (`src/types.ts`):
- `RegisteredGroup.channel: string` — identifies the owning channel (e.g. `'whatsapp'`, `'telegram'`)

**IPC** (`src/ipc.ts`):
- `register_group` command accepts optional `channel` field, defaults to `'whatsapp'`

**Tests**:
- 4 new tests for channel storage, retrieval, multi-channel getAllRegisteredGroups, and migration idempotency
- All existing test fixtures updated with `channel: 'whatsapp'`
- **143/143 tests pass**

## Test plan

- [x] `npx tsc --noEmit` — compiles clean
- [x] `npx vitest run` — 143/143 pass (4 new + 139 existing)
- [ ] Verify existing DB auto-migrates on startup (channel defaults to `'whatsapp'`)
- [ ] Verify JSON migration path defaults channel to `'whatsapp'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)