### PR TITLE
Fix unhandled promise rejections that can crash the process

### DIFF
--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -76,7 +76,9 @@ export class GroupQueue {
       return;
     }
 
-    this.runForGroup(groupJid, 'messages');
+    this.runForGroup(groupJid, 'messages').catch((err) =>
+      logger.error({ groupJid, err }, 'Unhandled error in runForGroup'),
+    );
   }
 
   enqueueTask(groupJid: string, taskId: string, fn: () => Promise<void>): void {
@@ -109,7 +111,9 @@ export class GroupQueue {
     }
 
     // Run immediately
-    this.runTask(groupJid, { id: taskId, groupJid, fn });
+    this.runTask(groupJid, { id: taskId, groupJid, fn }).catch((err) =>
+      logger.error({ groupJid, taskId, err }, 'Unhandled error in runTask'),
+    );
   }
 
   registerProcess(groupJid: string, proc: ChildProcess, containerName: string, groupFolder?: string): void {
@@ -248,13 +252,17 @@ export class GroupQueue {
     // Tasks first (they won't be re-discovered from SQLite like messages)
     if (state.pendingTasks.length > 0) {
       const task = state.pendingTasks.shift()!;
-      this.runTask(groupJid, task);
+      this.runTask(groupJid, task).catch((err) =>
+        logger.error({ groupJid, taskId: task.id, err }, 'Unhandled error in runTask (drain)'),
+      );
       return;
     }
 
     // Then pending messages
     if (state.pendingMessages) {
-      this.runForGroup(groupJid, 'drain');
+      this.runForGroup(groupJid, 'drain').catch((err) =>
+        logger.error({ groupJid, err }, 'Unhandled error in runForGroup (drain)'),
+      );
       return;
     }
 
@@ -273,9 +281,13 @@ export class GroupQueue {
       // Prioritize tasks over messages
       if (state.pendingTasks.length > 0) {
         const task = state.pendingTasks.shift()!;
-        this.runTask(nextJid, task);
+        this.runTask(nextJid, task).catch((err) =>
+          logger.error({ groupJid: nextJid, taskId: task.id, err }, 'Unhandled error in runTask (waiting)'),
+        );
       } else if (state.pendingMessages) {
-        this.runForGroup(nextJid, 'drain');
+        this.runForGroup(nextJid, 'drain').catch((err) =>
+          logger.error({ groupJid: nextJid, err }, 'Unhandled error in runForGroup (waiting)'),
+        );
       }
       // If neither pending, skip this group
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -361,7 +361,9 @@ async function startMessageLoop(): Promise<void> {
               messagesToSend[messagesToSend.length - 1].timestamp;
             saveState();
             // Show typing indicator while the container processes the piped message
-            whatsapp.setTyping(chatJid, true);
+            whatsapp.setTyping(chatJid, true).catch((err) =>
+              logger.warn({ chatJid, err }, 'Failed to set typing indicator'),
+            );
           } else {
             // No active container — enqueue for a new one
             queue.enqueueMessageCheck(chatJid);
@@ -502,7 +504,10 @@ async function main(): Promise<void> {
   });
   queue.setProcessMessagesFn(processGroupMessages);
   recoverPendingMessages();
-  startMessageLoop();
+  startMessageLoop().catch((err) => {
+    logger.fatal({ err }, 'Message loop crashed unexpectedly');
+    process.exit(1);
+  });
 }
 
 // Guard: only run when executed directly, not when imported by tests


### PR DESCRIPTION
## Problem

Fixes #221. Several async calls are fire-and-forget without `.catch()` handlers. When WhatsApp disconnects or containers fail unexpectedly, these produce unhandled rejections.

The `unhandledRejection` handler in `logger.ts` exists but only logs — it doesn't identify *where* the rejection originated. These fixes add explicit `.catch()` at each call site so errors include full context (groupJid, taskId).

## Changes

**`src/index.ts`**
- `whatsapp.setTyping(chatJid, true)` (line 364) — fire-and-forget in the message loop. If WhatsApp disconnects mid-processing, this rejects with no handler. Added `.catch()` with warn-level log.
- `startMessageLoop()` (line 505) — called without `await` in `main()`. If the loop throws after its first yield, the rejection escapes `main().catch()`. Added `.catch()` that logs fatal + exits.

**`src/group-queue.ts`**
- `runForGroup()` and `runTask()` — called without `await` in 5 places (`enqueueMessageCheck`, `enqueueTask`, `drainGroup`, `drainWaiting`). These have internal try/catch but if the catch block itself throws, the rejection is unhandled. Added `.catch()` to all 5 call sites.

## Testing

- `npx tsc --noEmit` — clean
- `npx vitest run` — 139/139 tests pass
- No new dependencies