### PR TITLE
fix: use >= for timestamp comparison to prevent message loss at boundaries

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -243,7 +243,7 @@ export function getNewMessages(
   const sql = `
     SELECT id, chat_jid, sender, sender_name, content, timestamp
     FROM messages
-    WHERE timestamp > ? AND chat_jid IN (${placeholders}) AND content NOT LIKE ?
+    WHERE timestamp >= ? AND chat_jid IN (${placeholders}) AND content NOT LIKE ?
     ORDER BY timestamp
   `;
 


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

Messages arriving in the same second as the poll cursor are permanently skipped with strict `>` in `getNewMessages()`.

This PR changes the comparison to `>=` and adds a `processedIds` Set in `startMessageLoop` that filters out already-handled messages at the boundary timestamp. The set clears when the timestamp advances, keeping it bounded.

**db.ts**: `WHERE timestamp > ?` → `WHERE timestamp >= ?`
**index.ts**: Dedup guard using message IDs at the boundary second