### PR TITLE
fix: exclude test files from agent-runner production build

### DIFF
--- a/container/agent-runner/tsconfig.json
+++ b/container/agent-runner/tsconfig.json
@@ -11,5 +11,5 @@
     "declaration": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Type of Change

- [x] **Simplification** - reduces or simplifies source code

## Description

Adds `"src/**/*.test.ts"` to the `exclude` array in `container/agent-runner/tsconfig.json`.

Without this, test files get compiled during the production container build. If vitest (or any test-only dependency) isn't installed in the production image, this causes compilation errors.