### PR TITLE
fix: add git pull --rebase before push in token count workflow

### DIFF
--- a/.github/workflows/update-tokens.yml
+++ b/.github/workflows/update-tokens.yml
@@ -37,4 +37,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit -m "docs: update token count to ${{ steps.tokens.outputs.badge }}"
+          git pull --rebase
           git push


### PR DESCRIPTION
## Summary
- Adds `git pull --rebase` before `git push` in the token count workflow
- Prevents push failures when remote has newer commits since the workflow's checkout

## Test plan
- [ ] Re-run the token count workflow after merge and verify it completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)