### PR TITLE
ci: add workflow_dispatch trigger to token count workflow

### DIFF
--- a/.github/workflows/update-tokens.yml
+++ b/.github/workflows/update-tokens.yml
@@ -1,6 +1,7 @@
 name: Update token count
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths: ['src/**', 'container/**', 'launchd/**', 'CLAUDE.md']


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger so the token count workflow can be run manually
- Useful for testing and on-demand badge updates

## Test plan
- [ ] After merge, trigger manually via `gh workflow run "Update token count"` and verify it completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)