### PR TITLE
fix: skip empty WhatsApp protocol messages

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -169,6 +169,10 @@ export class WhatsAppChannel implements Channel {
             msg.message?.imageMessage?.caption ||
             msg.message?.videoMessage?.caption ||
             '';
+
+          // Skip protocol messages with no text content (encryption keys, read receipts, etc.)
+          if (!content) continue;
+
           const sender = msg.key.participant || msg.key.remoteJid || '';
           const senderName = msg.pushName || sender.split('@')[0];
 


### PR DESCRIPTION
WhatsApp protocol messages (encryption key distribution, read receipts, ephemeral settings, senderKeyDistributionMessage) have a message envelope but no text content. These were being stored in messages.db and processed by the agent, causing:

1. Agent responds to empty messages, wasting API tokens
2. Container stays alive indefinitely (idle timer resets)
3. Scheduled tasks blocked (queue slot occupied)

This fix skips messages with empty content before calling onMessage, preventing protocol messages from being stored and processed.

Fixes #250

## Changes

- Add null check in `src/channels/whatsapp.ts` to skip messages with empty content
- Prevents protocol messages from entering the message queue

## Testing

Verified in production deployment with WhatsApp groups receiving protocol messages. No empty messages are processed after this change.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>