### PR TITLE
feat: Add Signal channel skill

### DIFF
--- a/.claude/skills/add-signal/SKILL.md
+++ b/.claude/skills/add-signal/SKILL.md
@@ -1,0 +1,1168 @@
+---
+name: add-signal
+description: Add Signal as a messaging channel using signal-cli. Can replace WhatsApp or run alongside it.
+---
+
+# Add Signal Channel
+
+Deploy Signal support in NanoClaw using the signal-cli REST API container. This skill creates the Signal channel implementation, configures the sidecar container, links the Signal account, wires everything into the main application, and optionally adds rich features (profile customisation, stickers, group management, IPC handlers for container agents).
+
+For architecture details and security considerations, see [docs/SIGNAL.md](../../../docs/SIGNAL.md).
+
+## Architecture
+
+NanoClaw uses a **Channel abstraction** (`Channel` interface in `src/types.ts`). The Signal channel follows the same pattern as WhatsApp and Telegram:
+
+| File | Purpose |
+|------|---------|
+| `src/types.ts` | `Channel` interface definition |
+| `src/channels/signal.ts` | `SignalChannel` class |
+| `src/signal/client.ts` | WebSocket (receiving) and REST (sending) client |
+| `src/config.ts` | Signal configuration exports |
+| `src/router.ts` | `findChannel()`, `routeOutbound()`, `formatOutbound()` |
+| `src/index.ts` | Orchestrator: creates channels, wires callbacks, starts subsystems |
+
+The channel implements `connect`, `sendMessage`, `ownsJid`, `disconnect`, and `setTyping`. Inbound messages are delivered via `onMessage` / `onChatMetadata` callbacks, and the existing message loop in `src/index.ts` picks them up automatically.
+
+## Phase 1: Collect Configuration
+
+Gather all required information before starting deployment.
+
+### Step 1: Detect container runtime
+
+```bash
+HAS_DOCKER=$(command -v docker >/dev/null 2>&1 && echo "yes" || echo "no")
+```
+
+- If Docker is not found, stop and tell the user they need Docker installed first. The signal-cli REST API runs as a Docker sidecar container.
+
+### Step 2: Ask preference questions
+
+Use `AskUserQuestion` with the applicable questions. Batch as many questions as possible into single `AskUserQuestion` calls (up to 4 per call) for a smoother experience.
+
+**First question batch:**
+
+```json
+[
+  {
+    "question": "What level of Signal integration do you need?",
+    "header": "Features",
+    "options": [
+      {"label": "Full features (Recommended)", "description": "Send/receive plus profile, stickers, group management, IPC handlers"},
+      {"label": "Basic channel only", "description": "Just send and receive messages"}
+    ],
+    "multiSelect": false
+  },
+  {
+    "question": "Should Signal replace WhatsApp or run alongside it?",
+    "header": "Mode",
+    "options": [
+      {"label": "Run alongside (Recommended)", "description": "Both Signal and WhatsApp channels active"},
+      {"label": "Replace WhatsApp", "description": "Signal becomes the only channel"}
+    ],
+    "multiSelect": false
+  },
+  {
+    "question": "Who should the bot respond to within registered chats?",
+    "header": "Sender filter",
+    "options": [
+      {"label": "Specific numbers only (Recommended)", "description": "Only approved phone numbers are processed within registered chats"},
+      {"label": "All members", "description": "Anyone in a registered chat can trigger the agent"}
+    ],
+    "multiSelect": false
+  }
+]
+```
+
+**Second question batch - Main channel setup:**
+
+> **Important: Your "main" channel is your admin control portal.**
+>
+> The main channel has elevated privileges:
+> - Can see messages from ALL other registered groups
+> - Can manage and delete tasks across all groups
+> - Can write to global memory that all groups can read
+> - Has read-write access to the entire NanoClaw project
+>
+> **Recommendation:** Use a DM with the bot's number (Note to Self equivalent) or a solo Signal group as your main channel. This ensures only you have admin control.
+
+```json
+[
+  {
+    "question": "Which setup will you use for your main channel?",
+    "header": "Main channel",
+    "options": [
+      {"label": "DM with a specific number (Recommended)", "description": "Your personal number messaging the bot. Only you have admin control."},
+      {"label": "Solo Signal group (just me)", "description": "A Signal group with only you in it."},
+      {"label": "Group with other people", "description": "Everyone in the group gets admin privileges (security implications)."}
+    ],
+    "multiSelect": false
+  }
+]
+```
+
+If they choose "Group with other people", ask a follow-up confirmation:
+
+```json
+[
+  {
+    "question": "Are you sure? Everyone in the group will be able to read messages from other chats, schedule tasks, and access mounted directories.",
+    "header": "Confirm",
+    "options": [
+      {"label": "Yes, I understand", "description": "Proceed with a shared admin group"},
+      {"label": "No, use a DM instead", "description": "Switch to a private DM as main channel"}
+    ],
+    "multiSelect": false
+  }
+]
+```
+
+### Step 3: Collect text inputs
+
+Ask for required text values based on Step 2 answers:
+
+**Always ask:**
+- Bot's phone number (E.164 format, e.g., `+61412345678`)
+
+**If main channel is "DM with a specific number":**
+- The phone number to use as the main channel DM (e.g., the user's personal number). The JID will be `signal:<phoneNumber>`.
+
+**If main channel is a group:**
+- Tell the user they'll select the group after Signal is linked (Step 13), since groups can't be queried until the account is connected.
+
+**If "Specific numbers only" was selected:**
+- Allowed sender numbers (comma-separated E.164)
+
+**If "Full features" was selected:**
+- Bot display name (optional, max 26 characters, e.g., "NanoClaw" or "Jarvis")
+- Bot status text (optional, max 140 characters)
+
+### Step 4: Configuration summary
+
+Display a summary table and confirm before deployment:
+
+> **Signal Channel Configuration**
+>
+> | Setting | Value |
+> |---------|-------|
+> | Runtime | Docker |
+> | Features | Full |
+> | Phone number | +61412345678 |
+> | Display name | Jarvis |
+> | Sender filter | All members |
+> | Mode | Run alongside WhatsApp |
+> | Main channel | DM with +61498765432 |
+>
+> Proceed with deployment?
+
+Once confirmed, execute all implementation steps without further interaction.
+
+## Phase 1.5: Pre-flight Checks
+
+Before starting implementation, check what already exists to avoid duplicate work or overwriting previous configuration.
+
+```bash
+# Check for existing Signal source files
+ls src/signal/client.ts src/channels/signal.ts src/ipc-signal.ts 2>/dev/null
+
+# Check for existing .env Signal configuration
+grep -E '^SIGNAL_' .env 2>/dev/null
+
+# Check for existing Signal registration in DB
+sqlite3 store/messages.db "SELECT jid FROM registered_groups WHERE jid LIKE 'signal:%'" 2>/dev/null
+
+# Check for existing docker-compose with signal-cli
+grep signal-cli docker-compose.yml 2>/dev/null
+
+# Check if signal-cli container is already running
+docker ps --filter "name=signal-cli" --format "{{.Names}}" 2>/dev/null
+
+# Check plist working directory matches current project
+grep WorkingDirectory ~/Library/LaunchAgents/com.nanoclaw.plist 2>/dev/null
+```
+
+Use these results to skip steps that are already complete:
+- If Signal source files exist, skip Steps 1-4 (file copies and config merge)
+- If `.env` already has `SIGNAL_ACCOUNT`, skip Step 9 (but verify values match Phase 1 answers)
+- If the DB already has a `signal:` registration, skip Step 12
+- If `docker-compose.yml` already has `signal-cli`, skip Step 6
+- If the signal-cli container is already running and healthy, skip Steps 6-7
+- If the plist `WorkingDirectory` doesn't match `pwd`, update it in Step 10
+
+## Phase 2: Implementation
+
+### Step 1: Install WebSocket Dependency
+
+```bash
+npm install ws @types/ws
+```
+
+### Step 2: Create Signal Client
+
+Copy `src/signal/client.ts` from the skill's source files into the project:
+
+```bash
+mkdir -p src/signal
+cp <skill>/src/signal/client.ts src/signal/client.ts
+cp <skill>/src/signal/poll-store.ts src/signal/poll-store.ts
+```
+
+`client.ts` handles all HTTP and WebSocket communication with the signal-cli REST API, including message sending (v1/v2), reactions, polls, stickers, group management, profile updates, typing indicators, receipts, and the WebSocket event stream.
+
+`poll-store.ts` provides an in-memory poll vote accumulator. Signal has no server-side vote aggregation, so NanoClaw must track votes itself by listening to `pollCreate`, `pollVote`, and `pollTerminate` WebSocket events. The store registers poll metadata when polls are created (either by the bot via IPC or by other users via the event stream), records per-voter selections as they arrive, and exposes aggregated results via `getPollResults()` and `getChatPolls()`. Votes are ephemeral and lost on process restart.
+
+### Step 3: Create Signal Channel
+
+Copy `src/channels/signal.ts` from the skill's source files:
+
+```bash
+mkdir -p src/channels
+cp <skill>/src/channels/signal.ts src/channels/signal.ts
+```
+
+`SignalChannel` implements the `Channel` interface (`connect`, `sendMessage`, `ownsJid`, `disconnect`, `setTyping`). It uses the WebSocket stream from `client.ts` for inbound messages and the REST API for outbound. Inbound messages are filtered by `SIGNAL_ALLOW_FROM` if configured, and delivered via the shared `onMessage` / `onChatMetadata` callbacks.
+
+### Step 4: Update Configuration
+
+Merge the contents of `src/config-signal.ts` into `src/config.ts` (add near other channel configuration exports):
+
+```bash
+cat <skill>/src/config-signal.ts  # review contents, then merge manually
+```
+
+### Step 5: Update Main Application
+
+Modify `src/index.ts` to introduce multi-channel support. **First, read the file** to check whether it already has a `channels: Channel[]` array (from a previous channel integration like Telegram). If it does, skip sub-steps 5.1 through 5.7 and only add the Signal-specific channel creation in the `main()` function.
+
+If the file still uses a single hardcoded WhatsApp channel, apply all sub-steps below to convert it to a `channels[]` array.
+
+**Patch approach:** Each sub-step describes the semantic location (function name, surrounding context) and shows the target code alongside the replacement. Always read `src/index.ts` first, then locate each patch point by intent rather than exact string match, since upstream may have changed formatting or variable names. The code blocks below are reference examples, not exact strings to match.
+
+#### 5.1. Add imports
+
+At the top of `src/index.ts`, add:
+
+```typescript
+import { SignalChannel } from './channels/signal.js';
+import { findChannel, formatOutbound } from './router.js';
+import { Channel } from './types.js';
+import {
+  SIGNAL_ACCOUNT,
+  SIGNAL_HTTP_HOST,
+  SIGNAL_HTTP_PORT,
+  SIGNAL_ALLOW_FROM,
+  SIGNAL_ONLY,
+} from './config.js';
+```
+
+Note: `formatOutbound` is already imported from `./router.js` in the existing code. Add `findChannel` to the existing import. Add `Channel` to the existing `./types.js` import (which currently imports `NewMessage` and `RegisteredGroup`).
+
+#### 5.2. Add channels array
+
+Replace the existing:
+
+```typescript
+let whatsapp: WhatsAppChannel;
+```
+
+with:
+
+```typescript
+let whatsapp: WhatsAppChannel;
+const channels: Channel[] = [];
+```
+
+#### 5.3. Update `processGroupMessages`
+
+The existing function has two direct `whatsapp` references that must use channel lookup instead.
+
+**Replace** the typing + send calls. Find this block (around the `await whatsapp.setTyping(chatJid, true)` call):
+
+```typescript
+  await whatsapp.setTyping(chatJid, true);
+```
+
+Replace with:
+
+```typescript
+  const channel = findChannel(channels, chatJid);
+  if (!channel) {
+    logger.warn({ chatJid }, 'No channel found for JID');
+    return true;
+  }
+  await channel.setTyping?.(chatJid, true);
+```
+
+Find the corresponding:
+
+```typescript
+  await whatsapp.setTyping(chatJid, false);
+```
+
+Replace with:
+
+```typescript
+  await channel.setTyping?.(chatJid, false);
+```
+
+**Replace** the send call inside the `onOutput` callback. Find:
+
+```typescript
+        await whatsapp.sendMessage(chatJid, `${ASSISTANT_NAME}: ${text}`);
+```
+
+Replace with:
+
+```typescript
+        const formatted = formatOutbound(text);
+        if (formatted) await channel.sendMessage(chatJid, formatted);
+```
+
+#### 5.4. Update `startMessageLoop`
+
+The message loop has a direct `whatsapp.setTyping` call when piping messages to an active container. Find:
+
+```typescript
+            whatsapp.setTyping(chatJid, true);
+```
+
+Replace with:
+
+```typescript
+            const pipeChannel = findChannel(channels, chatJid);
+            pipeChannel?.setTyping?.(chatJid, true);
+```
+
+#### 5.5. Update `getAvailableGroups`
+
+The existing filter only matches WhatsApp JIDs. Find:
+
+```typescript
+    .filter((c) => c.jid !== '__group_sync__' && c.jid.endsWith('@g.us'))
+```
+
+Replace with:
+
+```typescript
+    .filter((c) =>
+      c.jid !== '__group_sync__' &&
+      (c.jid.endsWith('@g.us') || c.jid.startsWith('signal:')),
+    )
+```
+
+#### 5.6. Update `main()` function
+
+The existing `main()` creates WhatsApp unconditionally and wires subsystems directly to it. Replace the channel creation and subsystem wiring section.
+
+**Replace** the WhatsApp creation block (from `whatsapp = new WhatsAppChannel({` through `await whatsapp.connect();`):
+
+```typescript
+  // Shared callbacks for all channels
+  const channelOpts = {
+    onMessage: (chatJid: string, msg: NewMessage) => storeMessage(msg),
+    onChatMetadata: (chatJid: string, timestamp: string, name?: string) =>
+      storeChatMetadata(chatJid, timestamp, name),
+    registeredGroups: () => registeredGroups,
+  };
+
+  // Create channels based on configuration
+  if (!SIGNAL_ONLY) {
+    whatsapp = new WhatsAppChannel(channelOpts);
+    channels.push(whatsapp);
+    await whatsapp.connect();
+  }
+
+  if (SIGNAL_ACCOUNT) {
+    const signal = new SignalChannel({
+      ...channelOpts,
+      account: SIGNAL_ACCOUNT,
+      httpHost: SIGNAL_HTTP_HOST,
+      httpPort: SIGNAL_HTTP_PORT,
+      allowFrom: SIGNAL_ALLOW_FROM,
+    });
+    channels.push(signal);
+    await signal.connect();
+  }
+
+  if (channels.length === 0) {
+    logger.error('No channels configured. Set SIGNAL_ACCOUNT or disable SIGNAL_ONLY.');
+    process.exit(1);
+  }
+```
+
+**Replace** the `startSchedulerLoop` call. The existing `sendMessage` callback is hardcoded to WhatsApp. Find:
+
+```typescript
+  startSchedulerLoop({
+    registeredGroups: () => registeredGroups,
+    getSessions: () => sessions,
+    queue,
+    onProcess: (groupJid, proc, containerName, groupFolder) => queue.registerProcess(groupJid, proc, containerName, groupFolder),
+    sendMessage: async (jid, rawText) => {
+      const text = formatOutbound(rawText);
+      if (text) await whatsapp.sendMessage(jid, text);
+    },
+  });
+```
+
+Replace with:
+
+```typescript
+  startSchedulerLoop({
+    registeredGroups: () => registeredGroups,
+    getSessions: () => sessions,
+    queue,
+    onProcess: (groupJid, proc, containerName, groupFolder) => queue.registerProcess(groupJid, proc, containerName, groupFolder),
+    sendMessage: async (jid, rawText) => {
+      const ch = findChannel(channels, jid);
+      if (!ch) { logger.warn({ jid }, 'No channel for scheduled message'); return; }
+      const text = formatOutbound(rawText);
+      if (text) await ch.sendMessage(jid, text);
+    },
+  });
+```
+
+**Replace** the `startIpcWatcher` call. The existing `sendMessage` callback is hardcoded to WhatsApp. Find:
+
+```typescript
+  startIpcWatcher({
+    sendMessage: (jid, text) => whatsapp.sendMessage(jid, text),
+    registeredGroups: () => registeredGroups,
+    registerGroup,
+    syncGroupMetadata: (force) => whatsapp.syncGroupMetadata(force),
+    getAvailableGroups,
+    writeGroupsSnapshot: (gf, im, ag, rj) => writeGroupsSnapshot(gf, im, ag, rj),
+  });
+```
+
+Replace with:
+
+```typescript
+  startIpcWatcher({
+    sendMessage: async (jid, text) => {
+      const ch = findChannel(channels, jid);
+      if (!ch) { logger.warn({ jid }, 'No channel for IPC message'); return; }
+      await ch.sendMessage(jid, text);
+    },
+    registeredGroups: () => registeredGroups,
+    registerGroup,
+    syncGroupMetadata: async (force) => {
+      // Only WhatsApp has group metadata sync; other channels discover groups inline
+      if (whatsapp) await whatsapp.syncGroupMetadata(force);
+    },
+    getAvailableGroups,
+    writeGroupsSnapshot: (gf, im, ag, rj) => writeGroupsSnapshot(gf, im, ag, rj),
+  });
+```
+
+#### 5.7. Update shutdown handler
+
+Find:
+
+```typescript
+  const shutdown = async (signal: string) => {
+    logger.info({ signal }, 'Shutdown signal received');
+    await queue.shutdown(10000);
+    await whatsapp.disconnect();
+    process.exit(0);
+  };
+```
+
+Replace with:
+
+```typescript
+  const shutdown = async (signal: string) => {
+    logger.info({ signal }, 'Shutdown signal received');
+    await queue.shutdown(10000);
+    for (const ch of channels) await ch.disconnect();
+    process.exit(0);
+  };
+```
+
+### Step 6: Start Signal Sidecar Container
+
+Pin to a specific version. Signal-cli must stay compatible with Signal's servers. The `MODE=json-rpc` environment variable is required for WebSocket message streaming.
+
+Check whether `docker-compose.yml` exists first. If it does, add the `signal-cli` service to the existing file rather than overwriting it.
+
+**Important:** The container must be named `signal-cli` (not `nanoclaw-signal-cli` or any `nanoclaw-*` name) because the NanoClaw startup code kills all Docker containers matching the `nanoclaw-*` prefix as orphaned agent containers. This naming convention applies to all sidecar containers that should persist across restarts.
+
+```yaml
+services:
+  signal-cli:
+    image: bbernhard/signal-cli-rest-api:0.97
+    container_name: signal-cli
+    environment:
+      - MODE=json-rpc
+    volumes:
+      - signal-cli-data:/home/.local/share/signal-cli
+    ports:
+      - "8080:8080"
+    restart: unless-stopped
+
+volumes:
+  signal-cli-data:
+```
+
+```bash
+docker compose up -d signal-cli
+```
+
+### Step 7: Wait for Container Readiness
+
+```bash
+until curl -sf http://localhost:8080/v1/health > /dev/null 2>&1; do
+  echo "Waiting for signal-cli to start..."
+  sleep 2
+done
+echo "signal-cli is ready"
+```
+
+### Step 8: Link Signal Account
+
+Detect the machine's local IP address to build the QR code URL:
+
+```bash
+LOCAL_IP=$(ipconfig getifaddr en0 2>/dev/null || hostname -I 2>/dev/null | awk '{print $1}')
+SIGNAL_PORT=$(grep SIGNAL_HTTP_PORT .env 2>/dev/null | cut -d= -f2 || echo 8080)
+echo "http://${LOCAL_IP}:${SIGNAL_PORT}/v1/qrcodelink?device_name=nanoclaw"
+```
+
+Tell the user, substituting the detected IP and port into the URL:
+
+> Link your Signal account:
+> 1. Open **http://LOCAL_IP:PORT/v1/qrcodelink?device_name=nanoclaw** in any browser (phone or computer)
+> 2. Open Signal on your phone > **Settings** > **Linked Devices** > **Link New Device**
+> 3. Scan the QR code shown in the browser
+>
+> The QR code expires quickly. Refresh if it fails.
+
+Wait for the user to confirm they've linked the account, then verify in container logs:
+
+```bash
+docker logs signal-cli 2>&1 | tail -20
+```
+
+Look for "Successfully linked" or similar confirmation.
+
+**If linking fails:**
+1. Restart the container and generate a fresh QR code
+2. Ensure the Signal app is updated to the latest version
+3. If the account already has 4 linked devices, the user must unlink one first (Signal Settings > Linked Devices)
+4. If repeated failures occur, ask the user to confirm the linking worked before continuing
+
+### Step 9: Update Environment
+
+Add to `.env` (use the phone number collected in Phase 1):
+
+```bash
+SIGNAL_ACCOUNT=+61412345678
+SIGNAL_HTTP_HOST=127.0.0.1
+SIGNAL_HTTP_PORT=8080
+```
+
+If "Replace WhatsApp" was selected, also add:
+
+```bash
+SIGNAL_ONLY=true
+```
+
+If "Specific numbers only" was selected, also add:
+
+```bash
+SIGNAL_ALLOW_FROM=+61412345678,+61498765432
+```
+
+Sync to container environment:
+
+```bash
+mkdir -p data/env
+cp .env data/env/env
+```
+
+### Step 10: Update launchd Environment (macOS)
+
+The launchd plist doesn't read `.env` files. Add these keys to `~/Library/LaunchAgents/com.nanoclaw.plist` inside `EnvironmentVariables`:
+
+```xml
+<key>SIGNAL_ACCOUNT</key>
+<string>+61412345678</string>
+<key>SIGNAL_HTTP_HOST</key>
+<string>127.0.0.1</string>
+<key>SIGNAL_HTTP_PORT</key>
+<string>8080</string>
+```
+
+Add `SIGNAL_ONLY` and `SIGNAL_ALLOW_FROM` keys if those variables were configured in Step 10.
+
+### Step 11: Build and Restart
+
+```bash
+npm run build
+```
+
+Verify build succeeded before continuing. If build fails, fix errors before proceeding.
+
+```bash
+launchctl unload ~/Library/LaunchAgents/com.nanoclaw.plist
+launchctl load ~/Library/LaunchAgents/com.nanoclaw.plist
+```
+
+### Step 12: Register Main Channel
+
+Use the main channel type and phone number collected in Phase 1, Step 2-3.
+
+#### 12a. Get the main channel JID
+
+**For DM** (collected in Phase 1):
+
+The JID is `signal:<phoneNumber>` using the phone number already collected (e.g. `signal:+61412345678`).
+
+**For group** (selected in Phase 1):
+
+Query the signal-cli REST API to list available groups:
+
+```bash
+SIGNAL_ACCOUNT=$(grep SIGNAL_ACCOUNT .env | cut -d= -f2)
+curl -s "http://localhost:8080/v1/groups/${SIGNAL_ACCOUNT}" | python3 -m json.tool
+```
+
+Show the group names and IDs to the user and ask them to pick one. If no groups appear, tell the user to send a message in their Signal group first, then re-query.
+
+#### 12b. Write the registration
+
+Once you have the JID, write to `data/registered_groups.json`. Create the file if it doesn't exist, or merge into it if it does.
+
+```bash
+mkdir -p data
+```
+
+For DMs (no trigger prefix needed), set `requiresTrigger` to `false`:
+
+```json
+{
+  "signal:+61412345678": {
+    "name": "main",
+    "folder": "main",
+    "trigger": "@ASSISTANT_NAME",
+    "added_at": "CURRENT_ISO_TIMESTAMP",
+    "requiresTrigger": false
+  }
+}
+```
+
+For groups, keep `requiresTrigger` as `true` (default) unless it's a solo group where the user wants all messages processed:
+
+```json
+{
+  "signal:group:<groupId>": {
+    "name": "main",
+    "folder": "main",
+    "trigger": "@ASSISTANT_NAME",
+    "added_at": "CURRENT_ISO_TIMESTAMP",
+    "requiresTrigger": false
+  }
+}
+```
+
+Replace `ASSISTANT_NAME` with the configured assistant name (check `src/config.ts` for the current value).
+
+Ensure the groups folder exists:
+
+```bash
+mkdir -p groups/main/logs
+```
+
+#### 12c. Rebuild and restart
+
+```bash
+npm run build
+launchctl unload ~/Library/LaunchAgents/com.nanoclaw.plist
+launchctl load ~/Library/LaunchAgents/com.nanoclaw.plist
+```
+
+> **Note:** Use `unload`/`load` (not `kickstart -k`) whenever the plist XML has been modified (e.g. new environment variables in Step 10). `kickstart -k` only restarts the process without re-reading the plist definition.
+
+### Step 13: Test
+
+Tell the user (using the configured assistant name):
+
+> Send a message to your registered Signal chat:
+> - **Main channel**: No prefix needed, just send `hello`
+> - **Other chats**: `@AssistantName hello`
+>
+> Check logs: `tail -f logs/nanoclaw.log`
+
+## Phase 3: Enhanced Features (Full features mode only)
+
+**Skip this entire phase if "Basic channel only" was selected in Phase 1.**
+
+### Step 1: Set Initial Profile
+
+If the user provided a display name or status text:
+
+```bash
+SIGNAL_ACCOUNT=$(grep SIGNAL_ACCOUNT .env | cut -d= -f2)
+curl -X PUT "http://localhost:8080/v1/profiles/${SIGNAL_ACCOUNT}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "YOUR_BOT_NAME",
+    "about": "YOUR_STATUS_TEXT"
+  }'
+```
+
+Replace `YOUR_BOT_NAME` and `YOUR_STATUS_TEXT` with the user's values from Phase 1.
+
+
+### Step 2: Add IPC Handlers
+
+> Signal IPC handlers follow a two-tier security model: messaging enhancements (reactions, polls, stickers) are available to all registered chats, while account-level actions (profile updates, group management) are restricted to the main group only.
+
+Copy `src/ipc-signal.ts` from the skill's source files into the project as a standalone module:
+
+```bash
+cp <skill>/src/ipc-signal.ts src/ipc-signal.ts
+```
+
+The file exports a `handleSignalIpc` function that handles all Signal IPC cases. Import and call it from the `default:` case in the `processTaskIpc` switch block in `src/ipc.ts`:
+
+```typescript
+// At the top of src/ipc.ts, add:
+import { handleSignalIpc } from './ipc-signal.js';
+
+// Replace the default: case with:
+default: {
+  const registeredGroupsMap = deps.registeredGroups();
+  const handled = await handleSignalIpc(
+    data as Parameters<typeof handleSignalIpc>[0],
+    sourceGroup,
+    isMain,
+    registeredGroupsMap,
+    DATA_DIR,
+  );
+  if (!handled) {
+    logger.warn({ type: data.type }, 'Unknown IPC task type');
+  }
+  break;
+}
+```
+
+This approach keeps the Signal IPC handlers in their own module rather than inlining hundreds of lines into the existing switch block.
+
+The file includes:
+
+**Message reference validation (`validateMessageReference`):**
+
+IPC cases that target specific messages (`signal_react`, `signal_remove_reaction`, `signal_delete_message`, `signal_send_receipt`, `signal_edit_message`) validate that the provided author/timestamp pair exists in the messages database before executing. This prevents the agent from hallucinating phone numbers or timestamps. The validation queries the DB directly (not the snapshot file), so it always has the latest data including outbound messages sent during the current session. Three validation modes are supported:
+
+- `exact`: Both `sender` and `source_timestamp` must match (used for reactions)
+- `own`: `source_timestamp` must match a message where `is_from_me` is true (used for edit/delete)
+- `any`: `source_timestamp` must match any message (used for receipts)
+
+If validation fails, the IPC case logs a warning and breaks without calling the Signal API. The agent sees no response, which is the same behaviour as other IPC failures.
+
+**Important:** The validation function imports `getRecentMessages` from `./db.js`. Ensure this import is added when merging into `src/ipc.ts`.
+
+**Messaging IPC (all groups, scoped to own chats via `authorizeSignalChat`):**
+- `signal_react`, `signal_remove_reaction` (validated: exact)
+- `signal_create_poll`, `signal_close_poll`, `signal_vote_poll`, `signal_get_poll_results`
+- `signal_typing`, `signal_send_sticker`, `signal_list_sticker_packs`
+- `signal_send_receipt` (validated: any), `signal_delete_message` (validated: own)
+
+The `signal_create_poll` handler registers new polls in the in-memory poll store so that incoming votes can be tracked. The `signal_get_poll_results` handler reads from the poll store and writes aggregated results to the IPC responses directory using a caller-provided `responseId` for deterministic file lookup.
+
+**Admin IPC (main channel only):**
+- `update_signal_profile`
+- `signal_create_group`, `signal_update_group`
+- `signal_add_group_members`, `signal_remove_group_members`, `signal_quit_group`
+
+### Step 3: Enable Message Timestamps
+
+The container agent needs message timestamps back from `send_message` so it can edit/delete its own messages.
+
+**3.1. Update `Channel` interface in `src/types.ts`:**
+
+Change `sendMessage` to return an optional timestamp:
+
+```typescript
+sendMessage(jid: string, text: string): Promise<{ timestamp?: number } | void>;
+```
+
+**3.2. Update `routeOutbound` in `src/router.ts`:**
+
+The `routeOutbound` function calls `channel.sendMessage()`, so its return type must match. Change:
+
+```typescript
+): Promise<void> {
+```
+
+to:
+
+```typescript
+): Promise<{ timestamp?: number } | void> {
+```
+
+**3.3. Update `SignalChannel.sendMessage` in `src/channels/signal.ts`:**
+
+Change from `Promise<void>` to `Promise<{ timestamp?: number }>` and return the result from `sendMessageExtended`:
+
+```typescript
+async sendMessage(jid: string, text: string): Promise<{ timestamp?: number }> {
+  if (!this.connected) {
+    this.outgoingQueue.push({ jid, text });
+    return {};
+  }
+  try {
+    return await this.sendMessageExtended(jid, text);
+  } catch (err) {
+    this.outgoingQueue.push({ jid, text });
+    return {};
+  }
+}
+```
+
+**3.4. Update IPC watcher dep in `src/ipc.ts`:**
+
+Change the `sendMessage` type to return the timestamp:
+
+```typescript
+sendMessage: (jid: string, text: string) => Promise<{ timestamp?: number } | void>;
+```
+
+And in the message handler, capture the result, store the outbound message in the DB (so validation can verify it), and write the timestamp back:
+
+```typescript
+const sendResult = await deps.sendMessage(data.chatJid, data.text);
+
+// Store outbound message in DB so validation can verify it
+const outboundTs = (sendResult && 'timestamp' in sendResult) ? sendResult.timestamp : undefined;
+const outboundId = outboundTs ? String(outboundTs) : `out-${Date.now()}`;
+const outboundSender = data.chatJid.startsWith('signal:') ? SIGNAL_ACCOUNT : ASSISTANT_NAME;
+storeMessage({
+  id: outboundId,
+  chat_jid: data.chatJid,
+  sender: outboundSender,
+  sender_name: ASSISTANT_NAME,
+  content: data.text,
+  timestamp: new Date().toISOString(),
+  source_timestamp: outboundTs,
+  is_from_me: true,
+});
+
+// Append to the live snapshot so the container agent can see
+// its own messages via get_recent_messages
+const snapshotPath = path.join(ipcBaseDir, sourceGroup, 'recent_messages.json');
+try {
+  const snapshot = JSON.parse(fs.readFileSync(snapshotPath, 'utf-8'));
+  snapshot.messages.push({
+    source_timestamp: outboundTs ?? null,
+    sender_id: outboundSender,
+    sender_name: ASSISTANT_NAME,
+    content: data.text.slice(0, 200),
+    timestamp: new Date().toISOString(),
+    is_from_me: true,
+  });
+  fs.writeFileSync(snapshotPath, JSON.stringify(snapshot, null, 2));
+} catch {
+  // Snapshot may not exist yet; non-fatal
+}
+
+// Write timestamp back to agent if responseId was provided
+if (data.responseId && sendResult && 'timestamp' in sendResult) {
+  const responsesDir = path.join(ipcBaseDir, sourceGroup, 'responses');
+  fs.mkdirSync(responsesDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(responsesDir, `${data.responseId}.json`),
+    JSON.stringify({ timestamp: sendResult.timestamp }),
+  );
+}
+```
+
+**Note:** Import `storeMessage` from `./db.js` at the top of `src/ipc.ts`.
+
+**3.5. Update IPC watcher callback in `src/index.ts`:**
+
+The `sendMessage` callback in `startIpcWatcher` must return the channel result:
+
+```typescript
+sendMessage: async (jid, text) => {
+  const ch = findChannel(channels, jid);
+  if (!ch) { logger.warn({ jid }, 'No channel for IPC message'); return; }
+  return await ch.sendMessage(jid, text);
+},
+```
+
+Now the chat context changes:
+
+**3.6. Add `chatName` and `responses/` directory to `src/container-runner.ts`:**
+
+Find the `ContainerInput` interface and add `chatName`:
+
+```typescript
+export interface ContainerInput {
+  prompt: string;
+  sessionId?: string;
+  groupFolder: string;
+  chatJid: string;
+  chatName?: string;  // <-- add this
+  isMain: boolean;
+  isScheduledTask?: boolean;
+  secrets?: Record<string, string>;
+}
+```
+
+Also find the IPC directory creation block (where `messages/`, `tasks/`, and `input/` subdirectories are created with `mkdirSync`) and add a `responses/` directory alongside them:
+
+```typescript
+fs.mkdirSync(path.join(groupIpcDir, 'responses'), { recursive: true });
+```
+
+This directory must exist before the container starts because the agent's `send_message` tool polls it for timestamp responses.
+
+**3.7. Pass `chatName` from the orchestrator in `src/index.ts`:**
+
+Find the `runContainerAgent` call in the `runAgent` function and add `chatName: group.name`:
+
+```typescript
+const output = await runContainerAgent(
+  group,
+  {
+    prompt,
+    sessionId,
+    groupFolder: group.folder,
+    chatJid,
+    chatName: group.name,  // <-- add this
+    isMain,
+  },
+  ...
+```
+
+**3.8. Add `chatName` to `ContainerInput` in `container/agent-runner/src/index.ts` and pass it as env var:**
+
+Add `chatName?: string` to the `ContainerInput` interface (same as 3a), then find the MCP server env block and add `NANOCLAW_CHAT_NAME`:
+
+```typescript
+env: {
+  NANOCLAW_CHAT_JID: containerInput.chatJid,
+  NANOCLAW_CHAT_NAME: containerInput.chatName || containerInput.groupFolder,  // <-- add this
+  NANOCLAW_GROUP_FOLDER: containerInput.groupFolder,
+  NANOCLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
+},
+```
+
+**3.9. Read the env var in `container/agent-runner/src/ipc-mcp-stdio.ts`:**
+
+Add after the existing `CHAT_JID` line:
+
+```typescript
+const chatJid = process.env.NANOCLAW_CHAT_JID!;
+const CHAT_JID = chatJid;
+const chatName = process.env.NANOCLAW_CHAT_NAME || '';  // <-- add this
+const groupFolder = process.env.NANOCLAW_GROUP_FOLDER!;
+const isMain = process.env.NANOCLAW_IS_MAIN === '1';
+```
+
+### Step 4: Add Agent MCP Tools
+
+The container agent needs MCP tools to invoke Signal features via IPC. Merge the tool registrations from `<skill>/src/mcp-signal-tools.ts` into `container/agent-runner/src/ipc-mcp-stdio.ts` before the `// Start the stdio transport` line.
+
+**Important:** Do NOT copy `mcp-signal-tools.ts` into `container/agent-runner/src/` as a standalone file. It is a code snippet that references variables (`server`, `z`, `CHAT_JID`, `writeIpcFile`, etc.) from `ipc-mcp-stdio.ts` without its own imports, so TypeScript will fail to compile it as a separate module. Read it as a reference and inline the tool registrations directly into `ipc-mcp-stdio.ts`.
+
+The file contains:
+
+- **Updated `send_message`** - replaces the existing tool to support timestamp responses (needed for edit/delete). The agent sends a `responseId` and polls for the host to write back the sent message timestamp.
+- **`get_chat_info`** - exposes chat name, JID, group folder, and main channel status
+- **`get_recent_messages`** - reads from a `recent_messages.json` snapshot for sender phone numbers and source timestamps
+- **Signal messaging tools (all groups):** `signal_react`, `signal_remove_reaction`, `signal_create_poll`, `signal_close_poll`, `signal_get_poll_results`, `signal_typing`, `signal_send_sticker`, `signal_list_sticker_packs`, `signal_send_receipt`, `signal_delete_message`, `signal_edit_message`, `signal_download_attachment`, `signal_send_with_preview`
+- **Admin tools (main channel only):** `signal_update_profile`, `signal_create_group`
+
+All messaging MCP tools include `chatJid: CHAT_JID` in the IPC payload so the host-side handler can verify the action targets a chat owned by the calling group. All `recipient` parameters default to `CHAT_JID` so the agent doesn't need to look up the JID. The `get_recent_messages` tool reads from a `recent_messages.json` snapshot written by the host before each container spawn, providing deterministic sender phone numbers and source timestamps that the agent must use instead of guessing.
+
+### Step 4a: Add Message Metadata to Types and Router
+
+The agent needs sender phone numbers and numeric timestamps in the message XML for Signal tools. Add optional fields to the `NewMessage` interface in `src/types.ts`:
+
+```typescript
+export interface NewMessage {
+  id: string;
+  chat_jid: string;
+  sender: string;
+  sender_name: string;
+  sender_id?: string;        // Raw identifier (phone number for Signal)
+  content: string;
+  timestamp: string;
+  source_timestamp?: number;  // Original numeric timestamp from platform
+  is_from_me?: boolean;
+}
+```
+
+Update `formatMessages()` in `src/router.ts` to include the new fields as XML attributes when present:
+
+```typescript
+export function formatMessages(messages: NewMessage[]): string {
+  const lines = messages.map((m) => {
+    const attrs = [
+      `sender="${escapeXml(m.sender_name)}"`,
+      `time="${m.timestamp}"`,
+    ];
+    if (m.sender_id) attrs.push(`sender_id="${escapeXml(m.sender_id)}"`);
+    if (m.source_timestamp) attrs.push(`source_timestamp="${m.source_timestamp}"`);
+    return `<message ${attrs.join(' ')}>${escapeXml(m.content)}</message>`;
+  });
+  return `<messages>\n${lines.join('\n')}\n</messages>`;
+}
+```
+
+### Step 4b: Add Recent Messages Snapshot
+
+Add a `getRecentMessages` function to `src/db.ts` to query the last N messages for a chat:
+
+```typescript
+export function getRecentMessages(
+  chatJid: string,
+  limit = 50,
+): Array<{ id: string; sender: string; sender_name: string; content: string; timestamp: string; is_from_me: number }> {
+  const sql = `
+    SELECT id, sender, sender_name, content, timestamp, is_from_me
+    FROM messages
+    WHERE chat_jid = ?
+    ORDER BY timestamp DESC
+    LIMIT ?
+  `;
+  const rows = db.prepare(sql).all(chatJid, limit) as Array<{
+    id: string; sender: string; sender_name: string; content: string; timestamp: string; is_from_me: number;
+  }>;
+  return rows.reverse();
+}
+```
+
+Add a `writeMessagesSnapshot` function to `src/container-runner.ts` (following the same pattern as `writeGroupsSnapshot`):
+
+```typescript
+export function writeMessagesSnapshot(
+  groupFolder: string,
+  messages: Array<{
+    id: string;
+    sender: string;
+    sender_name: string;
+    content: string;
+    timestamp: string;
+    is_from_me: number;
+  }>,
+): void {
+  const groupIpcDir = path.join(DATA_DIR, 'ipc', groupFolder);
+  fs.mkdirSync(groupIpcDir, { recursive: true });
+
+  const file = path.join(groupIpcDir, 'recent_messages.json');
+  fs.writeFileSync(
+    file,
+    JSON.stringify(
+      {
+        messages: messages.map((m) => ({
+          source_timestamp: Number(m.id) || null,
+          sender_id: m.sender,
+          sender_name: m.sender_name,
+          content: m.content.slice(0, 200),
+          timestamp: m.timestamp,
+          is_from_me: Boolean(m.is_from_me),
+        })),
+        lastSync: new Date().toISOString(),
+      },
+      null,
+      2,
+    ),
+  );
+}
+```
+
+Call it in `src/index.ts` alongside the other snapshots, right after `writeGroupsSnapshot`:
+
+```typescript
+writeMessagesSnapshot(group.folder, getRecentMessages(chatJid));
+```
+
+### Step 4c: Update Global CLAUDE.md
+
+Add these sections to `groups/global/CLAUDE.md` so the agent knows the correct patterns:
+
+```markdown
+## Group Registration
+
+When registering new groups, ALWAYS use the `mcp__nanoclaw__register_group` tool. NEVER write directly to `registered_groups.json` or the database. The IPC tool updates the running process in-memory, so the bot starts responding immediately without a restart.
+
+## Signal Tools: Required Lookup
+
+When using signal_react, signal_remove_reaction, signal_delete_message, signal_send_receipt, signal_edit_message, or signal_close_poll, you MUST call get_recent_messages first to look up the exact sender_id (phone number) and source_timestamp (numeric millisecond timestamp). NEVER guess or fabricate phone numbers or timestamps. These values come from the database and are the only way to target the correct message. The host validates all message references against the snapshot and silently rejects any that don't match.
+```
+
+### Step 5: Rebuild Container and Restart
+
+```bash
+npm run build
+./container/build.sh
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+```
+
+### Step 6: Verify Enhancements
+
+Tell the user:
+
+> Signal enhanced features are now available. The agent can use typing indicators, stickers, group management, and profile updates via IPC.
+>
+> Check logs: `tail -f logs/nanoclaw.log`
+
+## Troubleshooting
+
+### Container not starting
+
+```bash
+docker logs signal-cli
+```
+
+Common issues:
+- Port 8080 in use: Change `SIGNAL_HTTP_PORT` in `.env`, the launchd plist, and the container port mapping (`-p <new-port>:8080`)
+- Volume permissions: Ensure container can write to data directory
+
+### Account not linking
+
+1. Verify container is running: `docker ps | grep signal-cli`
+2. Test QR endpoint: `curl -sf http://${LOCAL_IP}:8080/v1/qrcodelink?device_name=nanoclaw -o /dev/null && echo "OK" || echo "FAIL"` (where `LOCAL_IP` is from `ipconfig getifaddr en0`)
+3. Restart container if endpoint fails
+4. Ensure Signal app is up to date
+
+### Messages not received
+
+1. Check container logs for "Successfully linked"
+2. Verify chat is registered: `sqlite3 store/messages.db "SELECT * FROM registered_groups WHERE jid LIKE 'signal:%'"`
+3. Check `SIGNAL_ALLOW_FROM` if configured
+4. Check NanoClaw logs: `tail -f logs/nanoclaw.log`
+
+### Profile update fails
+
+```bash
+curl -X PUT "http://localhost:8080/v1/profiles/+YOUR_NUMBER" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Test"}'
+```
+
+### Sticker packs empty
+
+Sticker packs must be installed on the Signal account first. Install them via the Signal app on your phone.
+
+### IPC handlers not working
+
+1. Check build succeeded: `npm run build`
+2. Check NanoClaw restarted: `launchctl list | grep nanoclaw`
+3. Check logs for IPC errors: `grep -i "ipc" logs/nanoclaw.log | tail -20`
+
+For additional troubleshooting (WebSocket issues, rate limiting, keeping signal-cli updated), see [docs/SIGNAL.md](../../../docs/SIGNAL.md).
+
+## Environment Variables
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `SIGNAL_ACCOUNT` | Bot's phone number (E.164) | Required |
+| `SIGNAL_HTTP_HOST` | signal-cli container HTTP host | `127.0.0.1` |
+| `SIGNAL_HTTP_PORT` | signal-cli container HTTP port | `8080` |
+| `SIGNAL_ALLOW_FROM` | Comma-separated allowed numbers | All |
+| `SIGNAL_ONLY` | `true` to disable WhatsApp | `false` |

--- a/.claude/skills/add-signal/src/channels/signal.ts
+++ b/.claude/skills/add-signal/src/channels/signal.ts
@@ -1,0 +1,591 @@
+/**
+ * Signal Channel for NanoClaw
+ * Uses signal-cli REST API container for Signal messaging
+ */
+import { ASSISTANT_NAME } from '../config.js';
+import { logger } from '../logger.js';
+import {
+  signalCheck,
+  signalSendV2,
+  signalSetTyping,
+  signalCreatePoll,
+  signalClosePoll,
+  signalReact,
+  signalRemoveReaction,
+  signalDeleteMessage,
+  signalSendReceipt,
+  signalListGroups,
+  signalGetGroupInfo,
+  signalGetContacts,
+  streamSignalEvents,
+  SignalWsEvent,
+  SignalMention,
+  SignalGroup,
+} from '../signal/client.js';
+import { registerPoll, recordVote, closePollState } from '../signal/poll-store.js';
+import { Channel, NewMessage, OnChatMetadata, OnInboundMessage, RegisteredGroup } from '../types.js';
+
+// Signal envelope types from signal-cli
+interface SignalEnvelope {
+  source?: string;
+  sourceNumber?: string;
+  sourceUuid?: string;
+  sourceName?: string;
+  timestamp?: number;
+  dataMessage?: SignalDataMessage;
+  editMessage?: {
+    targetSentTimestamp: number;
+    dataMessage: SignalDataMessage;
+  };
+  syncMessage?: unknown;
+}
+
+interface SignalAttachment {
+  id?: string;
+  contentType?: string;
+  filename?: string;
+  size?: number;
+  voiceNote?: boolean;
+}
+
+interface SignalDataMessage {
+  message?: string;
+  timestamp?: number;
+  groupInfo?: {
+    groupId?: string;
+    groupName?: string;
+  };
+  attachments?: SignalAttachment[];
+  reaction?: {
+    emoji: string;
+    targetAuthor: string;
+    targetAuthorNumber?: string;
+    targetSentTimestamp: number;
+    isRemove: boolean;
+  };
+  pollCreate?: {
+    question?: string;
+    options?: string[];
+    allowMultiple?: boolean;
+  };
+  pollVote?: {
+    authorNumber?: string;
+    targetSentTimestamp?: number;
+    optionIndexes?: number[];
+  };
+  pollTerminate?: {
+    targetSentTimestamp?: number;
+  };
+  quote?: {
+    text?: string;
+  };
+  mentions?: Array<{
+    start?: number;
+    length?: number;
+    uuid?: string;
+    number?: string;
+    name?: string;
+  }>;
+}
+
+interface SignalReceivePayload {
+  envelope?: SignalEnvelope;
+  exception?: { message?: string };
+}
+
+export interface SignalChannelOpts {
+  onMessage: OnInboundMessage;
+  onChatMetadata: OnChatMetadata;
+  registeredGroups: () => Record<string, RegisteredGroup>;
+  account: string;
+  httpHost?: string;
+  httpPort?: number;
+  allowFrom?: string[];
+}
+
+export class SignalChannel implements Channel {
+  name = 'signal';
+
+
+  private opts: SignalChannelOpts;
+  private baseUrl: string;
+  private connected = false;
+  private abortController: AbortController | null = null;
+  private outgoingQueue: Array<{ jid: string; text: string }> = [];
+  private flushing = false;
+  private contactNames: Map<string, string> = new Map();
+  private contactRefreshTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(opts: SignalChannelOpts) {
+    this.opts = opts;
+    const host = opts.httpHost || '127.0.0.1';
+    const port = opts.httpPort || 8080;
+    this.baseUrl = `http://${host}:${port}`;
+  }
+
+  async connect(): Promise<void> {
+    logger.info({ baseUrl: this.baseUrl }, 'Connecting to signal-cli container...');
+
+    await this.waitForReady(30_000);
+
+    this.connected = true;
+    logger.info('Connected to Signal');
+
+    // Load contact names for sender resolution
+    await this.refreshContacts();
+    this.contactRefreshTimer = setInterval(() => {
+      this.refreshContacts().catch((err) =>
+        logger.debug({ err }, 'Failed to refresh Signal contacts'),
+      );
+    }, 24 * 60 * 60 * 1000);
+
+    // Sync group metadata so orchestrator discovers Signal groups at startup
+    try {
+      const groups = await signalListGroups({ baseUrl: this.baseUrl, account: this.opts.account });
+      const now = new Date().toISOString();
+      for (const group of groups) {
+        if (group.isMember && group.internalId) {
+          const signalJid = `signal:group:${group.internalId}`;
+          this.opts.onChatMetadata(signalJid, now, group.name);
+        }
+      }
+      logger.info({ count: groups.filter((g) => g.isMember).length }, 'Signal groups synced on startup');
+    } catch (err) {
+      logger.warn({ err }, 'Failed to sync Signal groups on startup');
+    }
+
+    // Flush any messages queued while disconnected
+    this.flushOutgoingQueue().catch((err) =>
+      logger.error({ err }, 'Failed to flush Signal outgoing queue'),
+    );
+
+    this.startEventLoop();
+  }
+
+  private async refreshContacts(): Promise<void> {
+    try {
+      const contacts = await signalGetContacts({ baseUrl: this.baseUrl, account: this.opts.account });
+      this.contactNames.clear();
+      for (const c of contacts) {
+        if (c.number) {
+          const displayName = c.profileName || c.name;
+          if (displayName) this.contactNames.set(c.number, displayName);
+        }
+      }
+      logger.debug({ count: this.contactNames.size }, 'Signal contact names loaded');
+    } catch (err) {
+      logger.debug({ err }, 'Failed to load Signal contacts');
+    }
+  }
+
+  private async waitForReady(timeoutMs: number): Promise<void> {
+    const startTime = Date.now();
+    const pollInterval = 500;
+
+    while (Date.now() - startTime < timeoutMs) {
+      const check = await signalCheck(this.baseUrl, 2000);
+      if (check.ok) {
+        logger.debug('signal-cli container is ready');
+        return;
+      }
+      logger.debug({ error: check.error }, 'Waiting for signal-cli container...');
+      await new Promise((r) => setTimeout(r, pollInterval));
+    }
+
+    throw new Error(`signal-cli container not reachable within ${timeoutMs}ms`);
+  }
+
+  private startEventLoop(): void {
+    this.abortController = new AbortController();
+
+    const runLoop = async () => {
+      let reconnectAttempts = 0;
+      while (this.connected && !this.abortController?.signal.aborted) {
+        try {
+          await streamSignalEvents({
+            baseUrl: this.baseUrl,
+            account: this.opts.account,
+            abortSignal: this.abortController?.signal,
+            onEvent: (event) => this.handleEvent(event),
+          });
+          reconnectAttempts = 0; // Reset backoff on clean disconnect
+        } catch (err) {
+          if (this.abortController?.signal.aborted) {
+            break;
+          }
+          const delay = Math.min(5000 * Math.pow(2, reconnectAttempts), 60_000);
+          reconnectAttempts++;
+          logger.error({ err, retryIn: delay }, 'Signal WebSocket stream error, reconnecting...');
+          await new Promise((r) => setTimeout(r, delay));
+        }
+      }
+    };
+
+    runLoop().catch((err) => {
+      logger.error({ err }, 'Signal event loop failed');
+    });
+  }
+
+  private handleEvent(event: SignalWsEvent): void {
+    if (event.event !== 'receive' || !event.data) return;
+
+    let payload: SignalReceivePayload;
+    try {
+      payload = JSON.parse(event.data);
+    } catch {
+      logger.error('Failed to parse Signal event');
+      return;
+    }
+
+    if (payload.exception?.message) {
+      logger.error({ message: payload.exception.message }, 'Signal receive exception');
+      return;
+    }
+
+    const envelope = payload.envelope;
+    if (!envelope) return;
+    if (envelope.syncMessage) return;
+
+    // Edits arrive as envelope.editMessage, not envelope.dataMessage
+    const isEdit = Boolean(envelope.editMessage);
+    const dataMessage = isEdit ? envelope.editMessage!.dataMessage : envelope.dataMessage;
+    if (!dataMessage) return;
+
+    const senderNumber = envelope.sourceNumber || envelope.source;
+    if (!senderNumber) return;
+
+    if (this.normalizePhone(senderNumber) === this.normalizePhone(this.opts.account)) return;
+
+    if (this.opts.allowFrom && this.opts.allowFrom.length > 0) {
+      const normalized = this.normalizePhone(senderNumber);
+      const allowed = this.opts.allowFrom.some(
+        (num) => this.normalizePhone(num) === normalized,
+      );
+      if (!allowed) {
+        logger.debug({ sender: senderNumber }, 'Blocked message from non-allowed sender');
+        return;
+      }
+    }
+
+    const groupId = dataMessage.groupInfo?.groupId;
+    const groupName = dataMessage.groupInfo?.groupName;
+    const isGroup = Boolean(groupId);
+    const chatJid = isGroup ? `signal:group:${groupId}` : `signal:${senderNumber}`;
+
+    const timestamp = new Date(
+      (envelope.timestamp || dataMessage.timestamp || Date.now()),
+    ).toISOString();
+
+    const chatName = isGroup ? (groupName || `Group ${groupId?.slice(0, 8)}`) : (envelope.sourceName || senderNumber);
+    this.opts.onChatMetadata(chatJid, timestamp, chatName);
+
+    const groups = this.opts.registeredGroups();
+    if (!groups[chatJid]) {
+      logger.debug({ chatJid }, 'Message from unregistered chat, ignoring');
+      return;
+    }
+
+    // -- Reaction events --
+    if (dataMessage.reaction) {
+      const r = dataMessage.reaction;
+      const targetAuthorName = this.resolveContactName(r.targetAuthor || r.targetAuthorNumber || 'unknown');
+      const reactionContent = r.isRemove
+        ? `[Removed ${r.emoji} reaction from message by ${targetAuthorName}]`
+        : `[Reacted ${r.emoji} to message from ${targetAuthorName}]`;
+
+      const senderName = this.resolveContactName(senderNumber) || envelope.sourceName || senderNumber;
+      this.opts.onMessage(chatJid, {
+        id: String(envelope.timestamp || Date.now()),
+        chat_jid: chatJid,
+        sender: senderNumber,
+        sender_name: senderName,
+        content: reactionContent,
+        timestamp,
+        is_from_me: false,
+      });
+      return;
+    }
+
+    // -- Poll events: register metadata and accumulate votes --
+    if (dataMessage.pollCreate) {
+      const pc = dataMessage.pollCreate;
+      if (pc.question && pc.options) {
+        const ts = envelope.timestamp || dataMessage.timestamp || Date.now();
+        registerPoll(chatJid, senderNumber, ts, pc.question, pc.options);
+        logger.info({ chatJid, question: pc.question }, 'Signal poll registered from create event');
+      }
+      return;
+    }
+
+    if (dataMessage.pollVote) {
+      const pv = dataMessage.pollVote;
+      if (pv.targetSentTimestamp && pv.optionIndexes) {
+        const recorded = recordVote(
+          chatJid,
+          pv.targetSentTimestamp,
+          senderNumber,
+          envelope.sourceName || senderNumber,
+          pv.optionIndexes,
+        );
+        if (recorded) {
+          logger.info({ chatJid, voter: senderNumber, options: pv.optionIndexes }, 'Signal poll vote recorded');
+        } else {
+          logger.debug({ chatJid, targetTs: pv.targetSentTimestamp }, 'Poll vote for unknown poll (missed create event)');
+        }
+      }
+      return;
+    }
+
+    if (dataMessage.pollTerminate) {
+      const pt = dataMessage.pollTerminate;
+      if (pt.targetSentTimestamp) {
+        closePollState(chatJid, pt.targetSentTimestamp);
+        logger.info({ chatJid, pollTs: pt.targetSentTimestamp }, 'Signal poll closed via terminate event');
+      }
+      return;
+    }
+
+    // -- Attachment placeholders --
+    let attachmentPrefix = '';
+    if (dataMessage.attachments && dataMessage.attachments.length > 0) {
+      const labels = dataMessage.attachments.map((att) => {
+        const ct = att.contentType || '';
+        const fname = att.filename || '';
+        const idSuffix = att.id ? ` | id:${att.id}` : '';
+        if (ct === 'audio/aac' && !fname) return `[Voice note${idSuffix}]`;
+        if (ct.startsWith('image/')) return `[Image: ${fname || 'photo'}${idSuffix}]`;
+        if (ct.startsWith('video/')) return `[Video: ${fname || 'clip'}${idSuffix}]`;
+        if (ct.startsWith('audio/')) return `[Audio: ${fname || 'audio'}${idSuffix}]`;
+        return `[Document: ${fname || 'file'}${idSuffix}]`;
+      });
+      attachmentPrefix = labels.join(' ') + '\n';
+    }
+
+    let messageText = (isEdit ? '[Edited] ' : '') + attachmentPrefix + (dataMessage.message || '');
+
+    // Signal mentions replace the mention text with U+FFFC (Object Replacement Character).
+    // Reconstruct the actual text by substituting each mention placeholder with @name.
+    // Process mentions in reverse order so string indices stay valid.
+    if (dataMessage.mentions && dataMessage.mentions.length > 0) {
+      const sorted = [...dataMessage.mentions].sort(
+        (a, b) => (b.start ?? 0) - (a.start ?? 0),
+      );
+      for (const mention of sorted) {
+        const start = mention.start ?? 0;
+        const length = mention.length ?? 1;
+        // If the mention targets the bot's own number, use the assistant name
+        // so the trigger pattern (@McClaw) matches correctly.
+        const isSelf = mention.number && this.normalizePhone(mention.number) === this.normalizePhone(this.opts.account);
+        const name = isSelf ? ASSISTANT_NAME : (mention.name || mention.number || 'unknown');
+        messageText =
+          messageText.slice(0, start) +
+          `@${name}` +
+          messageText.slice(start + length);
+      }
+    }
+
+    messageText = messageText.trim();
+    const quoteText = dataMessage.quote?.text?.trim() || '';
+    const content = messageText || quoteText;
+
+    if (!content) {
+      logger.debug({ chatJid }, 'Empty message, ignoring');
+      return;
+    }
+
+    const senderName = this.resolveContactName(senderNumber) || envelope.sourceName || senderNumber;
+
+    const sourceTs = envelope.timestamp || dataMessage.timestamp || Date.now();
+    this.opts.onMessage(chatJid, {
+      id: String(sourceTs),
+      chat_jid: chatJid,
+      sender: senderNumber,
+      sender_name: senderName,
+      sender_id: senderNumber,
+      content,
+      timestamp,
+      source_timestamp: sourceTs,
+      is_from_me: false,
+    });
+  }
+
+  private normalizePhone(phone: string): string {
+    return phone.replace(/[^\d+]/g, '');
+  }
+
+  private resolveContactName(phoneOrUuid: string): string | undefined {
+    return this.contactNames.get(phoneOrUuid) || this.contactNames.get(this.normalizePhone(phoneOrUuid));
+  }
+
+  async sendMessage(jid: string, text: string): Promise<{ timestamp?: number }> {
+    if (!this.connected) {
+      this.outgoingQueue.push({ jid, text });
+      logger.info({ jid, length: text.length, queueSize: this.outgoingQueue.length }, 'Signal disconnected, message queued');
+      return {};
+    }
+    try {
+      return await this.sendMessageExtended(jid, text);
+    } catch (err) {
+      // If send fails, queue it for retry on reconnect
+      this.outgoingQueue.push({ jid, text });
+      logger.warn({ jid, err, queueSize: this.outgoingQueue.length }, 'Failed to send Signal message, queued');
+      return {};
+    }
+  }
+
+  async sendMessageExtended(
+    jid: string,
+    text: string,
+    options?: {
+      attachments?: string[];
+      quoteTimestamp?: number;
+      quoteAuthor?: string;
+      quoteMessage?: string;
+      mentions?: SignalMention[];
+      editTimestamp?: number;
+      viewOnce?: boolean;
+    },
+  ): Promise<{ timestamp?: number }> {
+    const target = this.jidToTarget(jid);
+
+    const result = await signalSendV2({
+      baseUrl: this.baseUrl,
+      account: this.opts.account,
+      recipients: target.type === 'dm' ? [target.id] : undefined,
+      groupId: target.type === 'group' ? target.id : undefined,
+      message: text,
+      textMode: 'styled',
+      attachments: options?.attachments,
+      quoteTimestamp: options?.quoteTimestamp,
+      quoteAuthor: options?.quoteAuthor,
+      quoteMessage: options?.quoteMessage,
+      mentions: options?.mentions,
+      editTimestamp: options?.editTimestamp,
+      viewOnce: options?.viewOnce,
+    });
+
+    logger.info({ jid, length: text.length }, 'Signal message sent');
+    return result;
+  }
+
+  private async flushOutgoingQueue(): Promise<void> {
+    if (this.flushing || this.outgoingQueue.length === 0) return;
+    this.flushing = true;
+    try {
+      logger.info({ count: this.outgoingQueue.length }, 'Flushing Signal outgoing queue');
+      while (this.outgoingQueue.length > 0) {
+        const item = this.outgoingQueue.shift()!;
+        await this.sendMessage(item.jid, item.text);
+      }
+    } finally {
+      this.flushing = false;
+    }
+  }
+
+  async createPoll(jid: string, question: string, answers: string[], allowMultiple = false): Promise<string | undefined> {
+    if (!this.connected) { logger.warn({ jid }, 'Signal not connected'); return undefined; }
+    try {
+      const target = this.jidToTarget(jid);
+      const result = await signalCreatePoll({ baseUrl: this.baseUrl, account: this.opts.account, recipient: target.id, question, answers, allowMultipleSelections: allowMultiple });
+      logger.info({ jid, question }, 'Signal poll created');
+      return result.pollTimestamp;
+    } catch (err) { logger.error({ jid, err }, 'Failed to create Signal poll'); throw err; }
+  }
+
+  async closePoll(jid: string, pollTimestamp: string): Promise<void> {
+    if (!this.connected) { logger.warn({ jid }, 'Signal not connected'); return; }
+    try {
+      const target = this.jidToTarget(jid);
+      await signalClosePoll({ baseUrl: this.baseUrl, account: this.opts.account, recipient: target.id, pollTimestamp });
+      logger.info({ jid, pollTimestamp }, 'Signal poll closed');
+    } catch (err) { logger.error({ jid, err }, 'Failed to close Signal poll'); throw err; }
+  }
+
+  async react(jid: string, targetAuthor: string, targetTimestamp: number, reaction: string): Promise<void> {
+    if (!this.connected) { logger.warn({ jid }, 'Signal not connected'); return; }
+    try {
+      const target = this.jidToTarget(jid);
+      await signalReact({ baseUrl: this.baseUrl, account: this.opts.account, recipient: target.id, targetAuthor, targetTimestamp, reaction });
+      logger.info({ jid, reaction }, 'Signal reaction sent');
+    } catch (err) { logger.error({ jid, err }, 'Failed to send Signal reaction'); throw err; }
+  }
+
+  async removeReaction(jid: string, targetAuthor: string, targetTimestamp: number, reaction: string): Promise<void> {
+    if (!this.connected) { logger.warn({ jid }, 'Signal not connected'); return; }
+    try {
+      const target = this.jidToTarget(jid);
+      await signalRemoveReaction({ baseUrl: this.baseUrl, account: this.opts.account, recipient: target.id, targetAuthor, targetTimestamp, reaction });
+      logger.info({ jid, reaction }, 'Signal reaction removed');
+    } catch (err) { logger.error({ jid, err }, 'Failed to remove Signal reaction'); throw err; }
+  }
+
+  async deleteMessage(jid: string, timestamp: number): Promise<void> {
+    if (!this.connected) { logger.warn({ jid }, 'Signal not connected'); return; }
+    try {
+      const target = this.jidToTarget(jid);
+      await signalDeleteMessage({ baseUrl: this.baseUrl, account: this.opts.account, recipient: target.id, timestamp });
+      logger.info({ jid, timestamp }, 'Signal message deleted');
+    } catch (err) { logger.error({ jid, err }, 'Failed to delete Signal message'); throw err; }
+  }
+
+  async sendReceipt(jid: string, timestamp: number, type: 'read' | 'viewed' = 'read'): Promise<void> {
+    if (!this.connected) return;
+    try {
+      const target = this.jidToTarget(jid);
+      await signalSendReceipt({ baseUrl: this.baseUrl, account: this.opts.account, recipient: target.id, timestamp, receiptType: type });
+    } catch (err) { logger.debug({ jid, err }, 'Failed to send Signal receipt'); }
+  }
+
+  async listGroups(): Promise<SignalGroup[]> {
+    if (!this.connected) return [];
+    try {
+      return await signalListGroups({ baseUrl: this.baseUrl, account: this.opts.account });
+    } catch (err) { logger.error({ err }, 'Failed to list Signal groups'); throw err; }
+  }
+
+  async getGroupInfo(groupId: string): Promise<SignalGroup | null> {
+    if (!this.connected) return null;
+    try {
+      return await signalGetGroupInfo({ baseUrl: this.baseUrl, account: this.opts.account, groupId });
+    } catch (err) { logger.error({ groupId, err }, 'Failed to get Signal group info'); throw err; }
+  }
+
+  private jidToTarget(jid: string): { type: 'group' | 'dm'; id: string } {
+    if (jid.startsWith('signal:group:')) {
+      // JIDs use the internal_id (raw base64 from signal-cli WebSocket events).
+      // The REST API expects "group." + base64(internal_id) (double-encoded).
+      const internalId = jid.replace('signal:group:', '');
+      const restApiId = `group.${Buffer.from(internalId).toString('base64')}`;
+      return { type: 'group', id: restApiId };
+    }
+    if (jid.startsWith('signal:')) return { type: 'dm', id: jid.replace('signal:', '') };
+    return { type: 'dm', id: jid };
+  }
+
+  isConnected(): boolean { return this.connected; }
+  ownsJid(jid: string): boolean { return jid.startsWith('signal:'); }
+
+  async disconnect(): Promise<void> {
+    this.connected = false;
+    this.abortController?.abort();
+    if (this.contactRefreshTimer) {
+      clearInterval(this.contactRefreshTimer);
+      this.contactRefreshTimer = null;
+    }
+    logger.info('Disconnected from Signal');
+  }
+
+  async setTyping(jid: string, isTyping: boolean): Promise<void> {
+    if (!this.connected) return;
+    try {
+      const target = this.jidToTarget(jid);
+      await signalSetTyping({
+        baseUrl: this.baseUrl,
+        account: this.opts.account,
+        recipient: target.id,
+        isTyping,
+        timeoutMs: 5000,
+      });
+    } catch (err) { logger.debug({ jid, err }, 'Failed to send typing indicator'); }
+  }
+}

--- a/.claude/skills/add-signal/src/config-signal.ts
+++ b/.claude/skills/add-signal/src/config-signal.ts
@@ -1,0 +1,10 @@
+// Merge into src/config.ts (add near other channel configuration exports)
+
+// --- Signal configuration ---
+export const SIGNAL_ACCOUNT = process.env.SIGNAL_ACCOUNT || '';
+export const SIGNAL_HTTP_HOST = process.env.SIGNAL_HTTP_HOST || '127.0.0.1';
+export const SIGNAL_HTTP_PORT = parseInt(process.env.SIGNAL_HTTP_PORT || '8080', 10);
+export const SIGNAL_ALLOW_FROM = process.env.SIGNAL_ALLOW_FROM
+  ? process.env.SIGNAL_ALLOW_FROM.split(',').map(s => s.trim())
+  : [];
+export const SIGNAL_ONLY = process.env.SIGNAL_ONLY === 'true';

--- a/.claude/skills/add-signal/src/index-signal.ts
+++ b/.claude/skills/add-signal/src/index-signal.ts
@@ -1,0 +1,61 @@
+// Merge into src/index.ts
+// These snippets show what to add/modify in the main orchestrator.
+
+// --- 1. Add imports (at the top, with other imports) ---
+
+import { SignalChannel } from './channels/signal.js';
+import {
+  SIGNAL_ACCOUNT,
+  SIGNAL_HTTP_HOST,
+  SIGNAL_HTTP_PORT,
+  SIGNAL_ALLOW_FROM,
+  SIGNAL_ONLY,
+} from './config.js';
+
+// --- 2. Ensure channels array exists (near existing whatsapp variable) ---
+
+// let whatsapp: WhatsAppChannel;
+// const channels: Channel[] = [];
+
+// --- 3. Channel initialisation in main() ---
+// Replace the unconditional WhatsApp setup with conditional:
+
+if (!SIGNAL_ONLY) {
+  whatsapp = new WhatsAppChannel(channelOpts);
+  channels.push(whatsapp);
+  await whatsapp.connect();
+}
+
+if (SIGNAL_ACCOUNT) {
+  const signal = new SignalChannel({
+    ...channelOpts,
+    account: SIGNAL_ACCOUNT,
+    httpHost: SIGNAL_HTTP_HOST,
+    httpPort: SIGNAL_HTTP_PORT,
+    allowFrom: SIGNAL_ALLOW_FROM,
+  });
+  channels.push(signal);
+  await signal.connect();
+}
+
+if (channels.length === 0) {
+  logger.error('No channels configured. Set SIGNAL_ACCOUNT or disable SIGNAL_ONLY.');
+  process.exit(1);
+}
+
+// --- 4. Update getAvailableGroups filter to include Signal ---
+// Add c.jid.startsWith('signal:') to the filter:
+
+.filter((c) =>
+  c.jid !== '__group_sync__' &&
+  (c.jid.endsWith('@g.us') || c.jid.startsWith('signal:')),
+)
+
+// --- 5. Update shutdown handler to disconnect all channels ---
+
+const shutdown = async (signal: string) => {
+  logger.info({ signal }, 'Shutdown signal received');
+  await queue.shutdown(10000);
+  for (const ch of channels) await ch.disconnect();
+  process.exit(0);
+};

--- a/.claude/skills/add-signal/src/ipc-signal.ts
+++ b/.claude/skills/add-signal/src/ipc-signal.ts
@@ -1,0 +1,583 @@
+// Signal IPC handlers - merge into src/ipc.ts
+// Add these cases to the switch (data.type) block in processTaskIpc,
+// before the `default:` case.
+
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import type { RegisteredGroup } from './types.js';
+import { getRecentMessages } from './db.js';
+import { logger } from './logger.js';
+import {
+  SIGNAL_ACCOUNT,
+  SIGNAL_HTTP_HOST,
+  SIGNAL_HTTP_PORT,
+} from './config.js';
+import {
+  signalReact,
+  signalRemoveReaction,
+  signalCreatePoll,
+  signalClosePoll,
+  signalVotePoll,
+  signalSetTyping,
+  signalSendSticker,
+  signalListStickerPacks,
+  signalSendReceipt,
+  signalDeleteMessage,
+  signalUpdateProfile,
+  signalCreateGroup,
+  signalUpdateGroup,
+  signalAddGroupMembers,
+  signalRemoveGroupMembers,
+  signalQuitGroup,
+  signalSendV2,
+  signalDownloadAttachment,
+} from './signal/client.js';
+
+const SIGNAL_BASE_URL = `http://${SIGNAL_HTTP_HOST}:${SIGNAL_HTTP_PORT}`;
+
+/**
+ * Query the messages database to verify that a given (sender, timestamp)
+ * pair actually exists. This turns the "call get_recent_messages first"
+ * instruction into a hard gate: if the agent fabricates a phone number or
+ * timestamp, the IPC call is rejected before it reaches the Signal API.
+ *
+ * Validation modes:
+ * - 'exact': Match both sender and source_timestamp (reactions)
+ * - 'own':   Match source_timestamp where is_from_me is true (edit, delete)
+ * - 'any':   Match source_timestamp for any sender (receipts)
+ *
+ * Returns null on success, or an error string describing why validation failed.
+ */
+type ValidationMode = 'exact' | 'own' | 'any';
+
+function validateMessageReference(
+  chatJid: string,
+  targetAuthor: string | undefined,
+  targetTimestamp: number | undefined,
+  mode: ValidationMode = 'exact',
+): string | null {
+  if (!targetTimestamp) {
+    return 'Missing targetTimestamp';
+  }
+  if (mode === 'exact' && !targetAuthor) {
+    return 'Missing targetAuthor (required for exact match)';
+  }
+
+  const messages = getRecentMessages(chatJid, 100);
+
+  const match = messages.find((m) => {
+    const msgTimestamp = Number(m.id) || null;
+    if (msgTimestamp !== targetTimestamp) return false;
+    switch (mode) {
+      case 'exact': return m.sender === targetAuthor;
+      case 'own':   return m.is_from_me === 1;
+      case 'any':   return true;
+    }
+  });
+
+  if (!match) {
+    const context = mode === 'exact' ? `author="${targetAuthor}" ` : mode === 'own' ? 'own message ' : '';
+    return `No ${context}message found with timestamp=${targetTimestamp} in chat ${chatJid}. The agent must call get_recent_messages first and use exact values.`;
+  }
+
+  return null;
+}
+
+/**
+ * Convert a NanoClaw JID or raw recipient to the format signal-cli REST API expects.
+ * - signal:group:XXXBASE64XXX -> group.BASE64(XXXBASE64XXX) (double-encoded)
+ * - signal:+1234567890 -> +1234567890
+ * - already in group.X or phone format -> pass through
+ */
+function jidToRecipient(jidOrRecipient: string): string {
+  if (jidOrRecipient.startsWith('signal:group:')) {
+    const internalId = jidOrRecipient.replace('signal:group:', '');
+    return `group.${Buffer.from(internalId).toString('base64')}`;
+  }
+  if (jidOrRecipient.startsWith('signal:')) {
+    return jidOrRecipient.replace('signal:', '');
+  }
+  return jidOrRecipient;
+}
+
+// Additional fields for the processTaskIpc data parameter type:
+export interface SignalIpcData {
+  about?: string;
+  recipient?: string;
+  targetAuthor?: string;
+  targetTimestamp?: number;
+  reaction?: string;
+  timestamp?: number;
+  question?: string;
+  answers?: string[];
+  allowMultipleSelections?: boolean;
+  pollTimestamp?: string;
+  votes?: number[];
+  isTyping?: boolean;
+  packId?: string;
+  stickerId?: number;
+  groupId?: string;
+  groupName?: string;
+  name?: string;
+  description?: string;
+  avatarBase64?: string;
+  members?: string[];
+  receiptType?: string;
+  chatJid?: string;
+  responseId?: string;
+  openOnly?: boolean;
+  attachmentId?: string;
+  filename?: string;
+  originalTimestamp?: number;
+  newText?: string;
+  message?: string;
+  url?: string;
+  title?: string;
+  thumbnailBase64?: string;
+}
+
+/**
+ * Verify a non-main group can act on the given chatJid.
+ * Enforces the same authorisation pattern as the existing message IPC handler:
+ * main can target any chat, non-main can only target chats belonging to their
+ * own group folder.
+ */
+export function authorizeSignalChat(
+  data: { chatJid?: string },
+  sourceGroup: string,
+  isMain: boolean,
+  registeredGroups: Record<string, RegisteredGroup>,
+): boolean {
+  if (isMain) return true;
+  if (!data.chatJid) {
+    logger.warn({ sourceGroup }, 'Signal IPC missing chatJid from non-main group');
+    return false;
+  }
+  const target = registeredGroups[data.chatJid];
+  if (!target || target.folder !== sourceGroup) {
+    logger.warn({ chatJid: data.chatJid, sourceGroup }, 'Unauthorized Signal IPC attempt blocked');
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Handle Signal IPC cases. Call from the processTaskIpc switch block.
+ * Returns true if the case was handled, false if it should fall through.
+ */
+export async function handleSignalIpc(
+  data: SignalIpcData & { type: string },
+  sourceGroup: string,
+  isMain: boolean,
+  registeredGroups: Record<string, RegisteredGroup>,
+  dataDir: string,
+): Promise<boolean> {
+  switch (data.type) {
+    // --- Signal messaging IPC (all groups, scoped to own chats) ---
+
+    case 'signal_react':
+      if (!authorizeSignalChat(data, sourceGroup, isMain, registeredGroups)) break;
+      if (data.recipient && data.targetAuthor && data.targetTimestamp && data.reaction) {
+        const reactErr = validateMessageReference(data.chatJid || '', data.targetAuthor, data.targetTimestamp, 'exact');
+        if (reactErr) { logger.warn({ err: reactErr, type: 'signal_react' }, 'Message reference validation failed'); break; }
+        try {
+          await signalReact({
+            baseUrl: SIGNAL_BASE_URL,
+            account: SIGNAL_ACCOUNT,
+            recipient: jidToRecipient(data.recipient!),
+            targetAuthor: data.targetAuthor,
+            targetTimestamp: data.targetTimestamp,
+            reaction: data.reaction,
+          });
+          logger.info({ recipient: data.recipient, reaction: data.reaction }, 'Signal reaction sent via IPC');
+        } catch (err) {
+          logger.error({ err }, 'Failed to send Signal reaction via IPC');
+        }
+      }
+      break;
+
+    case 'signal_remove_reaction':
+      if (!authorizeSignalChat(data, sourceGroup, isMain, registeredGroups)) break;
+      if (data.recipient && data.targetAuthor && data.targetTimestamp && data.reaction) {
+        const removeReactErr = validateMessageReference(data.chatJid || '', data.targetAuthor, data.targetTimestamp, 'exact');
+        if (removeReactErr) { logger.warn({ err: removeReactErr, type: 'signal_remove_reaction' }, 'Message reference validation failed'); break; }
+        try {
+          await signalRemoveReaction({
+            baseUrl: SIGNAL_BASE_URL,
+            account: SIGNAL_ACCOUNT,
+            recipient: jidToRecipient(data.recipient!),
+            targetAuthor: data.targetAuthor,
+            targetTimestamp: data.targetTimestamp,
+            reaction: data.reaction,
+          });
+          logger.info({ recipient: data.recipient, reaction: data.reaction }, 'Signal reaction removed via IPC');
+        } catch (err) {
+          logger.error({ err }, 'Failed to remove Signal reaction via IPC');
+        }
+      }
+      break;
+
+    case 'signal_create_poll':
+      if (!authorizeSignalChat(data, sourceGroup, isMain, registeredGroups)) break;
+      if (data.recipient && data.question && data.answers) {
+        try {
+          const pollResult = await signalCreatePoll({
+            baseUrl: SIGNAL_BASE_URL,
+            account: SIGNAL_ACCOUNT,
+            recipient: jidToRecipient(data.recipient!),
+            question: data.question,
+            answers: data.answers,
+            allowMultipleSelections: data.allowMultipleSelections ?? true,
+          });
+          // Register in poll store so votes can be tracked
+          if (data.chatJid && pollResult.pollTimestamp) {
+            const { registerPoll } = await import('./signal/poll-store.js');
+            registerPoll(data.chatJid, SIGNAL_ACCOUNT, parseInt(pollResult.pollTimestamp, 10), data.question, data.answers);
+          }
+          logger.info({ recipient: data.recipient, question: data.question }, 'Signal poll created via IPC');
+        } catch (err) {
+          logger.error({ err }, 'Failed to create Signal poll via IPC');
+        }
+      }
+      break;
+
+    case 'signal_close_poll':
+      if (!authorizeSignalChat(data, sourceGroup, isMain, registeredGroups)) break;
+      if (data.recipient && data.pollTimestamp) {
+        try {
+          await signalClosePoll({
+            baseUrl: SIGNAL_BASE_URL,
+            account: SIGNAL_ACCOUNT,
+            recipient: jidToRecipient(data.recipient!),
+            pollTimestamp: data.pollTimestamp,
+          });
+          logger.info({ recipient: data.recipient, pollTimestamp: data.pollTimestamp }, 'Signal poll closed via IPC');
+        } catch (err) {
+          logger.error({ err }, 'Failed to close Signal poll via IPC');
+        }
+      }
+      break;
+
+    case 'signal_vote_poll':
+      if (!authorizeSignalChat(data, sourceGroup, isMain, registeredGroups)) break;
+      if (data.recipient && data.pollTimestamp && data.votes) {
+        try {
+          await signalVotePoll({
+            baseUrl: SIGNAL_BASE_URL,
+            account: SIGNAL_ACCOUNT,
+            recipient: jidToRecipient(data.recipient!),
+            pollTimestamp: data.pollTimestamp,
+            pollAuthor: SIGNAL_ACCOUNT,
+            selectedAnswers: data.votes || [],
+          });
+          logger.info({ recipient: data.recipient, votes: data.votes }, 'Signal poll vote submitted via IPC');
+        } catch (err) {
+          logger.error({ err }, 'Failed to vote on Signal poll via IPC');
+        }
+      }
+      break;
+
+    case 'signal_typing':
+      if (!authorizeSignalChat(data, sourceGroup, isMain, registeredGroups)) break;
+      if (data.recipient && typeof data.isTyping === 'boolean') {
+        try {
+          await signalSetTyping({
+            baseUrl: SIGNAL_BASE_URL,
+            account: SIGNAL_ACCOUNT,
+            recipient: jidToRecipient(data.recipient!),
+            isTyping: data.isTyping,
+          });
+          logger.info({ recipient: data.recipient, isTyping: data.isTyping }, 'Signal typing indicator set via IPC');
+        } catch (err) {
+          logger.error({ err }, 'Failed to set Signal typing indicator via IPC');
+        }
+      }
+      break;
+
+    case 'signal_send_sticker':
+      if (!authorizeSignalChat(data, sourceGroup, isMain, registeredGroups)) break;
+      if (data.recipient && data.packId && typeof data.stickerId === 'number') {
+        try {
+          await signalSendSticker({
+            baseUrl: SIGNAL_BASE_URL,
+            account: SIGNAL_ACCOUNT,
+            recipient: jidToRecipient(data.recipient!),
+            packId: data.packId,
+            stickerId: data.stickerId,
+          });
+          logger.info({ recipient: data.recipient, packId: data.packId, stickerId: data.stickerId }, 'Signal sticker sent via IPC');
+        } catch (err) {
+          logger.error({ err }, 'Failed to send Signal sticker via IPC');
+        }
+      }
+      break;
+
+    case 'signal_list_sticker_packs':
+      try {
+        const packs = await signalListStickerPacks({
+          baseUrl: SIGNAL_BASE_URL,
+          account: SIGNAL_ACCOUNT,
+        });
+        const responseFile = path.join(dataDir, 'ipc', sourceGroup, 'responses', `stickers-${Date.now()}.json`);
+        fs.mkdirSync(path.dirname(responseFile), { recursive: true });
+        fs.writeFileSync(responseFile, JSON.stringify(packs, null, 2));
+        logger.info({ count: packs.length, responseFile }, 'Signal sticker packs listed via IPC');
+      } catch (err) {
+        logger.error({ err }, 'Failed to list Signal sticker packs via IPC');
+      }
+      break;
+
+    case 'signal_send_receipt':
+      if (!authorizeSignalChat(data, sourceGroup, isMain, registeredGroups)) break;
+      if (data.recipient && data.timestamp) {
+        // Receipts target other people's messages, so validate timestamp exists for any sender
+        const receiptErr = validateMessageReference(data.chatJid || '', undefined, data.timestamp, 'any');
+        if (receiptErr) { logger.warn({ err: receiptErr, type: 'signal_send_receipt' }, 'Message reference validation failed'); break; }
+        try {
+          await signalSendReceipt({
+            baseUrl: SIGNAL_BASE_URL,
+            account: SIGNAL_ACCOUNT,
+            recipient: jidToRecipient(data.recipient!),
+            timestamp: data.timestamp,
+            receiptType: (data.receiptType as 'read' | 'viewed') || 'read',
+          });
+          logger.info({ recipient: data.recipient }, 'Signal receipt sent via IPC');
+        } catch (err) {
+          logger.error({ err }, 'Failed to send Signal receipt via IPC');
+        }
+      }
+      break;
+
+    case 'signal_delete_message':
+      if (!authorizeSignalChat(data, sourceGroup, isMain, registeredGroups)) break;
+      if (data.recipient && data.timestamp) {
+        const deleteErr = validateMessageReference(data.chatJid || '', undefined, data.timestamp, 'own');
+        if (deleteErr) { logger.warn({ err: deleteErr, type: 'signal_delete_message' }, 'Message reference validation failed'); break; }
+        try {
+          await signalDeleteMessage({
+            baseUrl: SIGNAL_BASE_URL,
+            account: SIGNAL_ACCOUNT,
+            recipient: jidToRecipient(data.recipient!),
+            timestamp: data.timestamp,
+          });
+          logger.info({ recipient: data.recipient, timestamp: data.timestamp }, 'Signal message deleted via IPC');
+        } catch (err) {
+          logger.error({ err }, 'Failed to delete Signal message via IPC');
+        }
+      }
+      break;
+
+    // --- Signal admin IPC (main channel only) ---
+
+    case 'update_signal_profile':
+      if (!isMain) {
+        logger.warn({ sourceGroup }, 'Unauthorized update_signal_profile attempt blocked');
+        break;
+      }
+      if (data.name || data.about || data.avatarBase64) {
+        try {
+          await signalUpdateProfile({
+            baseUrl: SIGNAL_BASE_URL,
+            account: SIGNAL_ACCOUNT,
+            name: data.name,
+            about: data.about,
+            avatarBase64: data.avatarBase64,
+          });
+          logger.info({ name: data.name, about: data.about }, 'Signal profile updated via IPC');
+        } catch (err) {
+          logger.error({ err }, 'Failed to update Signal profile via IPC');
+        }
+      }
+      break;
+
+    case 'signal_create_group':
+      if (!isMain) {
+        logger.warn({ sourceGroup }, 'Unauthorized signal_create_group attempt blocked');
+        break;
+      }
+      if (data.groupName && data.members) {
+        try {
+          const result = await signalCreateGroup({
+            baseUrl: SIGNAL_BASE_URL,
+            account: SIGNAL_ACCOUNT,
+            name: data.groupName,
+            members: data.members,
+            description: data.description,
+          });
+          logger.info({ groupName: data.groupName, groupId: result.groupId }, 'Signal group created via IPC');
+        } catch (err) {
+          logger.error({ err }, 'Failed to create Signal group via IPC');
+        }
+      }
+      break;
+
+    case 'signal_update_group':
+      if (!isMain) {
+        logger.warn({ sourceGroup }, 'Unauthorized signal_update_group attempt blocked');
+        break;
+      }
+      if (data.groupId) {
+        try {
+          await signalUpdateGroup({
+            baseUrl: SIGNAL_BASE_URL,
+            account: SIGNAL_ACCOUNT,
+            groupId: data.groupId,
+            name: data.groupName,
+            description: data.description,
+            avatarBase64: data.avatarBase64,
+          });
+          logger.info({ groupId: data.groupId }, 'Signal group updated via IPC');
+        } catch (err) {
+          logger.error({ err }, 'Failed to update Signal group via IPC');
+        }
+      }
+      break;
+
+    case 'signal_add_group_members':
+      if (!isMain) {
+        logger.warn({ sourceGroup }, 'Unauthorized signal_add_group_members attempt blocked');
+        break;
+      }
+      if (data.groupId && data.members) {
+        try {
+          await signalAddGroupMembers({
+            baseUrl: SIGNAL_BASE_URL,
+            account: SIGNAL_ACCOUNT,
+            groupId: data.groupId,
+            members: data.members,
+          });
+          logger.info({ groupId: data.groupId, members: data.members }, 'Signal group members added via IPC');
+        } catch (err) {
+          logger.error({ err }, 'Failed to add Signal group members via IPC');
+        }
+      }
+      break;
+
+    case 'signal_remove_group_members':
+      if (!isMain) {
+        logger.warn({ sourceGroup }, 'Unauthorized signal_remove_group_members attempt blocked');
+        break;
+      }
+      if (data.groupId && data.members) {
+        try {
+          await signalRemoveGroupMembers({
+            baseUrl: SIGNAL_BASE_URL,
+            account: SIGNAL_ACCOUNT,
+            groupId: data.groupId,
+            members: data.members,
+          });
+          logger.info({ groupId: data.groupId, members: data.members }, 'Signal group members removed via IPC');
+        } catch (err) {
+          logger.error({ err }, 'Failed to remove Signal group members via IPC');
+        }
+      }
+      break;
+
+    case 'signal_quit_group':
+      if (!isMain) {
+        logger.warn({ sourceGroup }, 'Unauthorized signal_quit_group attempt blocked');
+        break;
+      }
+      if (data.groupId) {
+        try {
+          await signalQuitGroup({
+            baseUrl: SIGNAL_BASE_URL,
+            account: SIGNAL_ACCOUNT,
+            groupId: data.groupId,
+          });
+          logger.info({ groupId: data.groupId }, 'Left Signal group via IPC');
+        } catch (err) {
+          logger.error({ err }, 'Failed to leave Signal group via IPC');
+        }
+      }
+      break;
+
+    case 'signal_get_poll_results': {
+      if (!authorizeSignalChat(data, sourceGroup, isMain, registeredGroups)) break;
+      const { getPollResults, getChatPolls } = await import('./signal/poll-store.js');
+
+      let pollData: unknown;
+      if (data.pollTimestamp) {
+        pollData = getPollResults(data.chatJid || '', parseInt(data.pollTimestamp, 10));
+      } else {
+        pollData = getChatPolls(data.chatJid || '', data.openOnly ?? false);
+      }
+
+      const responseId = data.responseId || `poll-results-${Date.now()}`;
+      const responseFile = path.join(dataDir, 'ipc', sourceGroup, 'responses', `${responseId}.json`);
+      fs.mkdirSync(path.dirname(responseFile), { recursive: true });
+      fs.writeFileSync(responseFile, JSON.stringify(pollData, null, 2));
+      logger.info({ sourceGroup, responseFile }, 'Signal poll results written via IPC');
+      break;
+    }
+
+    case 'signal_download_attachment': {
+      if (!authorizeSignalChat(data, sourceGroup, isMain, registeredGroups)) break;
+      if (data.attachmentId) {
+        try {
+          const buffer = await signalDownloadAttachment(SIGNAL_BASE_URL, data.attachmentId);
+          const filename = path.basename(data.filename || `attachment-${data.attachmentId}`);
+          const responseFile = path.join(dataDir, 'ipc', sourceGroup, 'responses', filename);
+          fs.mkdirSync(path.dirname(responseFile), { recursive: true });
+          fs.writeFileSync(responseFile, buffer);
+          logger.info({ attachmentId: data.attachmentId, responseFile }, 'Signal attachment downloaded via IPC');
+        } catch (err) {
+          logger.error({ err }, 'Failed to download Signal attachment via IPC');
+        }
+      }
+      break;
+    }
+
+    case 'signal_edit_message':
+      if (!authorizeSignalChat(data, sourceGroup, isMain, registeredGroups)) break;
+      if (data.recipient && data.originalTimestamp && data.newText) {
+        const editErr = validateMessageReference(data.chatJid || '', undefined, data.originalTimestamp, 'own');
+        if (editErr) { logger.warn({ err: editErr, type: 'signal_edit_message' }, 'Message reference validation failed'); break; }
+        try {
+          const editRecipient = jidToRecipient(data.recipient);
+          await signalSendV2({
+            baseUrl: SIGNAL_BASE_URL,
+            account: SIGNAL_ACCOUNT,
+            recipients: editRecipient.startsWith('group.') ? undefined : [editRecipient],
+            groupId: editRecipient.startsWith('group.') ? editRecipient : undefined,
+            message: data.newText,
+            editTimestamp: data.originalTimestamp,
+          });
+          logger.info({ recipient: data.recipient, originalTimestamp: data.originalTimestamp }, 'Signal message edited via IPC');
+        } catch (err) {
+          logger.error({ err }, 'Failed to edit Signal message via IPC');
+        }
+      }
+      break;
+
+    case 'signal_send_with_preview':
+      if (!authorizeSignalChat(data, sourceGroup, isMain, registeredGroups)) break;
+      if (data.recipient && data.message && data.url) {
+        try {
+          const previewRecipient = jidToRecipient(data.recipient);
+          await signalSendV2({
+            baseUrl: SIGNAL_BASE_URL,
+            account: SIGNAL_ACCOUNT,
+            recipients: previewRecipient.startsWith('group.') ? undefined : [previewRecipient],
+            groupId: previewRecipient.startsWith('group.') ? previewRecipient : undefined,
+            message: data.message,
+            linkPreview: {
+              url: data.url,
+              title: data.title,
+              description: data.description,
+              base64_thumbnail: data.thumbnailBase64,
+            },
+          });
+          logger.info({ recipient: data.recipient, url: data.url }, 'Signal message with preview sent via IPC');
+        } catch (err) {
+          logger.error({ err }, 'Failed to send Signal message with preview via IPC');
+        }
+      }
+      break;
+
+    default:
+      return false;
+  }
+
+  return true;
+}

--- a/.claude/skills/add-signal/src/mcp-signal-tools.ts
+++ b/.claude/skills/add-signal/src/mcp-signal-tools.ts
@@ -1,0 +1,430 @@
+// Signal MCP tools for the container agent
+// Merge into container/agent-runner/src/ipc-mcp-stdio.ts before the stdio transport startup line.
+//
+// Prerequisites (already available in ipc-mcp-stdio.ts):
+//   - server, z, writeIpcFile, TASKS_DIR, MESSAGES_DIR, RESPONSES_DIR, IPC_DIR
+//   - path, fs
+//   - chatJid / CHAT_JID, chatName, groupFolder, isMain
+//
+// The updated send_message tool replaces the existing one to support
+// timestamp responses (needed for edit/delete).
+
+// -- Updated send_message (replaces existing) --
+
+server.tool(
+  'send_message',
+  "Send a message to the user or group immediately while you're still running. Returns the message timestamp which can be used with signal_edit_message or signal_delete_message.",
+  {
+    text: z.string().describe('The message text to send'),
+    sender: z.string().optional().describe('Your role/identity name (e.g. "Researcher"). When set, messages appear from a dedicated bot in Telegram.'),
+  },
+  async (args) => {
+    const responseId = `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const data: Record<string, string | undefined> = {
+      type: 'message',
+      chatJid,
+      text: args.text,
+      sender: args.sender || undefined,
+      groupFolder,
+      responseId,
+      timestamp: new Date().toISOString(),
+    };
+
+    writeIpcFile(MESSAGES_DIR, data);
+
+    // Wait for the host to write back the sent message timestamp
+    const responsePath = path.join(RESPONSES_DIR, `${responseId}.json`);
+    const maxWait = 10000;
+    const start = Date.now();
+    while (Date.now() - start < maxWait) {
+      try {
+        const result = fs.readFileSync(responsePath, 'utf-8');
+        fs.unlinkSync(responsePath);
+        const parsed = JSON.parse(result);
+        return { content: [{ type: 'text' as const, text: `Message sent. Timestamp: ${parsed.timestamp}` }] };
+      } catch {
+        await new Promise((r) => setTimeout(r, 200));
+      }
+    }
+    return { content: [{ type: 'text' as const, text: 'Message sent (timestamp unavailable).' }] };
+  },
+);
+
+// -- Context tools --
+
+server.tool(
+  'get_chat_info',
+  'Get metadata about the current chat (name, JID, group folder, whether this is the main channel).',
+  {},
+  async () => {
+    return {
+      content: [{
+        type: 'text' as const,
+        text: JSON.stringify({ chatJid: CHAT_JID, chatName, groupFolder, isMain }, null, 2),
+      }],
+    };
+  },
+);
+
+server.tool(
+  'get_recent_messages',
+  'Get recent messages in this chat with their sender phone numbers and source timestamps. Use this to find the correct target_author and target_timestamp values for signal_react, signal_remove_reaction, signal_delete_message, and similar tools.',
+  {
+    limit: z.number().optional().default(20).describe('Number of recent messages to return (default 20, max 50)'),
+  },
+  async (args) => {
+    const file = path.join(IPC_DIR, 'recent_messages.json');
+    try {
+      const data = JSON.parse(fs.readFileSync(file, 'utf-8'));
+      const messages = data.messages.slice(-(args.limit || 20));
+      return { content: [{ type: 'text' as const, text: JSON.stringify(messages, null, 2) }] };
+    } catch {
+      return { content: [{ type: 'text' as const, text: 'No recent messages available.' }] };
+    }
+  },
+);
+
+// -- Signal messaging tools (all groups) --
+
+server.tool(
+  'signal_react',
+  'React to a Signal message with an emoji. Call get_recent_messages first to look up the correct sender_id and source_timestamp. The host validates these values against the message snapshot and rejects fabricated references.',
+  {
+    recipient: z.string().default(CHAT_JID).describe('The recipient JID (defaults to current chat)'),
+    target_author: z.string().describe('Phone number of the message author (sender_id from get_recent_messages)'),
+    target_timestamp: z.number().describe('Numeric millisecond timestamp of the message (source_timestamp from get_recent_messages)'),
+    reaction: z.string().describe('Emoji reaction (e.g., "👍")'),
+  },
+  async (args) => {
+    writeIpcFile(TASKS_DIR, {
+      type: 'signal_react',
+      recipient: args.recipient,
+      targetAuthor: args.target_author,
+      targetTimestamp: args.target_timestamp,
+      reaction: args.reaction,
+      chatJid: CHAT_JID,
+      timestamp: new Date().toISOString(),
+    });
+    return { content: [{ type: 'text' as const, text: `Reaction ${args.reaction} sent.` }] };
+  },
+);
+
+server.tool(
+  'signal_remove_reaction',
+  'Remove a reaction from a Signal message. Call get_recent_messages first to look up the correct sender_id and source_timestamp. The host validates these values against the message snapshot and rejects fabricated references.',
+  {
+    recipient: z.string().default(CHAT_JID).describe('The recipient JID (defaults to current chat)'),
+    target_author: z.string().describe('Phone number of the message author (sender_id from get_recent_messages)'),
+    target_timestamp: z.number().describe('Numeric millisecond timestamp of the message (source_timestamp from get_recent_messages)'),
+    reaction: z.string().describe('The emoji reaction to remove'),
+  },
+  async (args) => {
+    writeIpcFile(TASKS_DIR, {
+      type: 'signal_remove_reaction',
+      recipient: args.recipient,
+      targetAuthor: args.target_author,
+      targetTimestamp: args.target_timestamp,
+      reaction: args.reaction,
+      chatJid: CHAT_JID,
+      timestamp: new Date().toISOString(),
+    });
+    return { content: [{ type: 'text' as const, text: `Reaction ${args.reaction} removed.` }] };
+  },
+);
+
+server.tool(
+  'signal_create_poll',
+  'Create a poll in a Signal chat.',
+  {
+    recipient: z.string().default(CHAT_JID).describe('The recipient JID (defaults to current chat)'),
+    question: z.string().describe('Poll question'),
+    answers: z.array(z.string()).describe('Poll answer options'),
+    allow_multiple: z.boolean().default(true).describe('Allow selecting multiple answers'),
+  },
+  async (args) => {
+    writeIpcFile(TASKS_DIR, {
+      type: 'signal_create_poll',
+      recipient: args.recipient,
+      question: args.question,
+      answers: args.answers,
+      allowMultipleSelections: args.allow_multiple,
+      chatJid: CHAT_JID,
+      timestamp: new Date().toISOString(),
+    });
+    return { content: [{ type: 'text' as const, text: `Poll created: ${args.question}` }] };
+  },
+);
+
+server.tool(
+  'signal_close_poll',
+  'Close an existing Signal poll. Call get_recent_messages first to find the poll message source_timestamp.',
+  {
+    recipient: z.string().default(CHAT_JID).describe('The recipient JID (defaults to current chat)'),
+    poll_timestamp: z.string().describe('Source timestamp of the poll message (from get_recent_messages)'),
+  },
+  async (args) => {
+    writeIpcFile(TASKS_DIR, {
+      type: 'signal_close_poll',
+      recipient: args.recipient,
+      pollTimestamp: args.poll_timestamp,
+      chatJid: CHAT_JID,
+      timestamp: new Date().toISOString(),
+    });
+    return { content: [{ type: 'text' as const, text: 'Poll closed.' }] };
+  },
+);
+
+server.tool(
+  'signal_get_poll_results',
+  'Get current vote tallies for Signal polls in this chat. Returns voter names and selected options. Can query a specific poll by timestamp or list all polls. Note: only tracks votes received while NanoClaw is running.',
+  {
+    poll_timestamp: z.string().optional().describe('Timestamp of a specific poll. Omit to get all polls.'),
+    open_only: z.boolean().default(false).describe('If true, only return polls that are still open'),
+  },
+  async (args) => {
+    const responseId = `poll-results-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    writeIpcFile(TASKS_DIR, {
+      type: 'signal_get_poll_results',
+      pollTimestamp: args.poll_timestamp,
+      openOnly: args.open_only,
+      chatJid: CHAT_JID,
+      responseId,
+      timestamp: new Date().toISOString(),
+    });
+
+    // Poll for the response file written by the host
+    const responsePath = path.join(RESPONSES_DIR, `${responseId}.json`);
+    const maxWait = 5000;
+    const start = Date.now();
+    while (Date.now() - start < maxWait) {
+      try {
+        const data = fs.readFileSync(responsePath, 'utf-8');
+        fs.unlinkSync(responsePath);
+        return { content: [{ type: 'text' as const, text: data }] };
+      } catch {
+        await new Promise((r) => setTimeout(r, 200));
+      }
+    }
+    return { content: [{ type: 'text' as const, text: 'Poll results not available (timeout or no polls tracked).' }], isError: true };
+  },
+);
+
+server.tool(
+  'signal_typing',
+  'Set typing indicator on or off in a Signal chat.',
+  {
+    recipient: z.string().default(CHAT_JID).describe('The recipient JID (defaults to current chat)'),
+    is_typing: z.boolean().describe('true to start typing, false to stop'),
+  },
+  async (args) => {
+    writeIpcFile(TASKS_DIR, {
+      type: 'signal_typing',
+      recipient: args.recipient,
+      isTyping: args.is_typing,
+      chatJid: CHAT_JID,
+      timestamp: new Date().toISOString(),
+    });
+    return { content: [{ type: 'text' as const, text: args.is_typing ? 'Typing indicator started.' : 'Typing indicator stopped.' }] };
+  },
+);
+
+server.tool(
+  'signal_send_sticker',
+  'Send a sticker to a Signal chat.',
+  {
+    recipient: z.string().default(CHAT_JID).describe('The recipient JID (defaults to current chat)'),
+    pack_id: z.string().describe('Sticker pack ID'),
+    sticker_id: z.number().describe('Sticker index within the pack'),
+  },
+  async (args) => {
+    writeIpcFile(TASKS_DIR, {
+      type: 'signal_send_sticker',
+      recipient: args.recipient,
+      packId: args.pack_id,
+      stickerId: args.sticker_id,
+      chatJid: CHAT_JID,
+      timestamp: new Date().toISOString(),
+    });
+    return { content: [{ type: 'text' as const, text: 'Sticker sent.' }] };
+  },
+);
+
+server.tool(
+  'signal_list_sticker_packs',
+  'List installed Signal sticker packs.',
+  {},
+  async () => {
+    writeIpcFile(TASKS_DIR, {
+      type: 'signal_list_sticker_packs',
+      timestamp: new Date().toISOString(),
+    });
+    return { content: [{ type: 'text' as const, text: 'Sticker pack list requested. Check responses directory.' }] };
+  },
+);
+
+server.tool(
+  'signal_send_receipt',
+  'Send a read or viewed receipt for a Signal message. Call get_recent_messages first to look up the correct source_timestamp. The host validates the timestamp exists in the message snapshot and rejects fabricated references.',
+  {
+    recipient: z.string().default(CHAT_JID).describe('The recipient JID (defaults to current chat)'),
+    message_timestamp: z.number().describe('Numeric millisecond timestamp of the message (source_timestamp from get_recent_messages)'),
+    receipt_type: z.enum(['read', 'viewed']).default('read').describe('Receipt type'),
+  },
+  async (args) => {
+    writeIpcFile(TASKS_DIR, {
+      type: 'signal_send_receipt',
+      recipient: args.recipient,
+      timestamp: args.message_timestamp,
+      receiptType: args.receipt_type,
+      chatJid: CHAT_JID,
+      submittedAt: new Date().toISOString(),
+    });
+    return { content: [{ type: 'text' as const, text: 'Receipt sent.' }] };
+  },
+);
+
+server.tool(
+  'signal_delete_message',
+  'Delete a Signal message for everyone (remote delete). Call get_recent_messages first to look up the correct source_timestamp. The host validates the timestamp exists as your own message and rejects fabricated references.',
+  {
+    recipient: z.string().default(CHAT_JID).describe('The recipient JID (defaults to current chat)'),
+    message_timestamp: z.number().describe('Numeric millisecond timestamp of the message (source_timestamp from get_recent_messages)'),
+  },
+  async (args) => {
+    writeIpcFile(TASKS_DIR, {
+      type: 'signal_delete_message',
+      recipient: args.recipient,
+      timestamp: args.message_timestamp,
+      chatJid: CHAT_JID,
+      submittedAt: new Date().toISOString(),
+    });
+    return { content: [{ type: 'text' as const, text: 'Message deletion requested.' }] };
+  },
+);
+
+server.tool(
+  'signal_edit_message',
+  'Edit a previously sent Signal message by replacing its content. Use the timestamp returned by send_message for your own messages, or source_timestamp from get_recent_messages. The host validates the timestamp exists as your own message and rejects fabricated references.',
+  {
+    recipient: z.string().default(CHAT_JID).describe('The recipient JID (defaults to current chat)'),
+    original_timestamp: z.number().describe('Numeric millisecond timestamp of the original message'),
+    new_text: z.string().describe('The replacement message text'),
+  },
+  async (args) => {
+    writeIpcFile(TASKS_DIR, {
+      type: 'signal_edit_message',
+      recipient: args.recipient,
+      originalTimestamp: args.original_timestamp,
+      newText: args.new_text,
+      chatJid: CHAT_JID,
+      timestamp: new Date().toISOString(),
+    });
+    return { content: [{ type: 'text' as const, text: 'Message edit requested.' }] };
+  },
+);
+
+server.tool(
+  'signal_download_attachment',
+  'Download an attachment from an inbound Signal message. The attachment ID is provided in the message content as [Image: photo.jpg | id:abc123]. Returns the file path where the attachment was saved.',
+  {
+    attachment_id: z.string().describe('Attachment ID from the inbound message placeholder'),
+    filename: z.string().describe('Filename to save the attachment as'),
+  },
+  async (args) => {
+    const responseId = `attachment-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    writeIpcFile(TASKS_DIR, {
+      type: 'signal_download_attachment',
+      attachmentId: args.attachment_id,
+      filename: args.filename,
+      chatJid: CHAT_JID,
+      responseId,
+      timestamp: new Date().toISOString(),
+    });
+
+    const responsePath = path.join(RESPONSES_DIR, path.basename(args.filename));
+    const maxWait = 15000;
+    const start = Date.now();
+    while (Date.now() - start < maxWait) {
+      try {
+        fs.statSync(responsePath);
+        return { content: [{ type: 'text' as const, text: `Attachment saved to ${responsePath}` }] };
+      } catch {
+        await new Promise((r) => setTimeout(r, 500));
+      }
+    }
+    return { content: [{ type: 'text' as const, text: 'Attachment download timed out.' }], isError: true };
+  },
+);
+
+server.tool(
+  'signal_send_with_preview',
+  'Send a Signal message with a rich link preview (title, description, optional thumbnail).',
+  {
+    recipient: z.string().default(CHAT_JID).describe('The recipient JID (defaults to current chat)'),
+    message: z.string().describe('The message text'),
+    url: z.string().describe('The URL to preview'),
+    title: z.string().optional().describe('Preview title'),
+    description: z.string().optional().describe('Preview description'),
+    thumbnail_base64: z.string().optional().describe('Base64-encoded thumbnail image'),
+  },
+  async (args) => {
+    writeIpcFile(TASKS_DIR, {
+      type: 'signal_send_with_preview',
+      recipient: args.recipient,
+      message: args.message,
+      url: args.url,
+      title: args.title,
+      description: args.description,
+      thumbnailBase64: args.thumbnail_base64,
+      chatJid: CHAT_JID,
+      timestamp: new Date().toISOString(),
+    });
+    return { content: [{ type: 'text' as const, text: 'Message with link preview sent.' }] };
+  },
+);
+
+// -- Admin tools (main channel only) --
+
+server.tool(
+  'signal_update_profile',
+  'Update the bot\'s Signal profile name or status text. Main group only.',
+  {
+    name: z.string().optional().describe('Display name (max 26 chars)'),
+    about: z.string().optional().describe('Status text (max 140 chars)'),
+  },
+  async (args) => {
+    if (!isMain) {
+      return { content: [{ type: 'text' as const, text: 'Only the main group can update the bot profile.' }], isError: true };
+    }
+    writeIpcFile(TASKS_DIR, {
+      type: 'update_signal_profile',
+      name: args.name,
+      about: args.about,
+      timestamp: new Date().toISOString(),
+    });
+    return { content: [{ type: 'text' as const, text: 'Profile update requested.' }] };
+  },
+);
+
+server.tool(
+  'signal_create_group',
+  'Create a new Signal group. Main group only.',
+  {
+    group_name: z.string().describe('Name for the new group'),
+    members: z.array(z.string()).describe('Phone numbers to add (E.164 format)'),
+    description: z.string().optional().describe('Group description'),
+  },
+  async (args) => {
+    if (!isMain) {
+      return { content: [{ type: 'text' as const, text: 'Only the main group can create Signal groups.' }], isError: true };
+    }
+    writeIpcFile(TASKS_DIR, {
+      type: 'signal_create_group',
+      groupName: args.group_name,
+      members: args.members,
+      description: args.description,
+      timestamp: new Date().toISOString(),
+    });
+    return { content: [{ type: 'text' as const, text: `Group "${args.group_name}" creation requested.` }] };
+  },
+);

--- a/.claude/skills/add-signal/src/signal/client.ts
+++ b/.claude/skills/add-signal/src/signal/client.ts
@@ -1,0 +1,937 @@
+/**
+ * Signal-cli JSON-RPC client
+ * Communicates with signal-cli REST API container over HTTP
+ */
+export interface SignalWsEvent {
+  event?: string;
+  data?: string;
+  id?: string;
+}
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+function normalizeBaseUrl(url: string): string {
+  const trimmed = url.trim();
+  if (!trimmed) {
+    throw new Error('Signal base URL is required');
+  }
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed.replace(/\/+$/, '');
+  }
+  return `http://${trimmed}`.replace(/\/+$/, '');
+}
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Mention in a message */
+export interface SignalMention {
+  start: number;
+  length: number;
+  author: string;
+}
+
+/** Link preview for rich URLs */
+export interface SignalLinkPreview {
+  url: string;
+  title?: string;
+  description?: string;
+  base64_thumbnail?: string;
+}
+
+/** Options for sending a message */
+export interface SignalSendOpts {
+  baseUrl: string;
+  account: string;
+  recipients?: string[];
+  groupId?: string;
+  message: string;
+  textMode?: 'normal' | 'styled';
+  attachments?: string[];
+  quoteTimestamp?: number;
+  quoteAuthor?: string;
+  quoteMessage?: string;
+  mentions?: SignalMention[];
+  editTimestamp?: number;
+  linkPreview?: SignalLinkPreview;
+  viewOnce?: boolean;
+  timeoutMs?: number;
+}
+
+/**
+ * Send a message using the REST v2 API with styled text support.
+ * Styling: *italic*, **bold**, ~strikethrough~, `monospace`, ||spoiler||
+ */
+export async function signalSendV2(opts: SignalSendOpts): Promise<{ timestamp?: number }> {
+  const baseUrl = normalizeBaseUrl(opts.baseUrl);
+  const body: Record<string, unknown> = {
+    number: opts.account,
+    message: opts.message,
+    text_mode: opts.textMode || 'styled',
+  };
+
+  if (opts.groupId) {
+    body.recipients = [opts.groupId];
+  } else if (opts.recipients) {
+    body.recipients = opts.recipients;
+  }
+
+  if (opts.attachments && opts.attachments.length > 0) {
+    body.base64_attachments = opts.attachments;
+  }
+
+  if (opts.quoteTimestamp) {
+    body.quote_timestamp = opts.quoteTimestamp;
+    if (opts.quoteAuthor) body.quote_author = opts.quoteAuthor;
+    if (opts.quoteMessage) body.quote_message = opts.quoteMessage;
+  }
+
+  if (opts.mentions && opts.mentions.length > 0) {
+    body.mentions = opts.mentions;
+  }
+
+  if (opts.editTimestamp) {
+    body.edit_timestamp = opts.editTimestamp;
+  }
+
+  if (opts.linkPreview) {
+    body.link_preview = opts.linkPreview;
+  }
+
+  if (opts.viewOnce) {
+    body.view_once = true;
+  }
+
+  const res = await fetchWithTimeout(
+    `${baseUrl}/v2/send`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+    opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Signal v2 send failed (${res.status}): ${text}`);
+  }
+
+  const result = await res.json() as { timestamp?: string };
+  return { timestamp: result.timestamp ? Number(result.timestamp) : undefined };
+}
+
+/**
+ * React to a message with an emoji.
+ */
+export async function signalReact(opts: {
+  baseUrl: string;
+  account: string;
+  recipient: string;
+  targetAuthor: string;
+  targetTimestamp: number;
+  reaction: string;
+  timeoutMs?: number;
+}): Promise<void> {
+  const baseUrl = normalizeBaseUrl(opts.baseUrl);
+  const body = {
+    recipient: opts.recipient,
+    target_author: opts.targetAuthor,
+    timestamp: opts.targetTimestamp,
+    reaction: opts.reaction,
+  };
+
+  const res = await fetchWithTimeout(
+    `${baseUrl}/v1/reactions/${encodeURIComponent(opts.account)}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+    opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Signal react failed (${res.status}): ${text}`);
+  }
+}
+
+/**
+ * Remove a reaction from a message.
+ */
+export async function signalRemoveReaction(opts: {
+  baseUrl: string;
+  account: string;
+  recipient: string;
+  targetAuthor: string;
+  targetTimestamp: number;
+  reaction: string;
+  timeoutMs?: number;
+}): Promise<void> {
+  const baseUrl = normalizeBaseUrl(opts.baseUrl);
+  const body = {
+    recipient: opts.recipient,
+    target_author: opts.targetAuthor,
+    timestamp: opts.targetTimestamp,
+    reaction: opts.reaction,
+  };
+
+  const res = await fetchWithTimeout(
+    `${baseUrl}/v1/reactions/${encodeURIComponent(opts.account)}`,
+    {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+    opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Signal remove reaction failed (${res.status}): ${text}`);
+  }
+}
+
+/**
+ * Delete a message for everyone (remote delete).
+ */
+export async function signalDeleteMessage(opts: {
+  baseUrl: string;
+  account: string;
+  recipient: string;
+  timestamp: number;
+  timeoutMs?: number;
+}): Promise<void> {
+  const baseUrl = normalizeBaseUrl(opts.baseUrl);
+  const body = {
+    recipient: opts.recipient,
+    timestamp: opts.timestamp,
+  };
+
+  const res = await fetchWithTimeout(
+    `${baseUrl}/v1/remote-delete/${encodeURIComponent(opts.account)}`,
+    {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+    opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Signal delete message failed (${res.status}): ${text}`);
+  }
+}
+
+/**
+ * Send a read receipt for a message.
+ */
+export async function signalSendReceipt(opts: {
+  baseUrl: string;
+  account: string;
+  recipient: string;
+  timestamp: number;
+  receiptType?: 'read' | 'viewed';
+  timeoutMs?: number;
+}): Promise<void> {
+  const baseUrl = normalizeBaseUrl(opts.baseUrl);
+  const body = {
+    recipient: opts.recipient,
+    timestamp: opts.timestamp,
+    receipt_type: opts.receiptType || 'read',
+  };
+
+  const res = await fetchWithTimeout(
+    `${baseUrl}/v1/receipts/${encodeURIComponent(opts.account)}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+    opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Signal send receipt failed (${res.status}): ${text}`);
+  }
+}
+
+/** Group information */
+export interface SignalGroup {
+  id: string;
+  internalId: string;
+  name: string;
+  description?: string;
+  isMember: boolean;
+  isBlocked: boolean;
+  members: string[];
+  admins: string[];
+}
+
+/**
+ * List all groups the account is a member of.
+ */
+export async function signalListGroups(opts: {
+  baseUrl: string;
+  account: string;
+  timeoutMs?: number;
+}): Promise<SignalGroup[]> {
+  const baseUrl = normalizeBaseUrl(opts.baseUrl);
+
+  const res = await fetchWithTimeout(
+    `${baseUrl}/v1/groups/${encodeURIComponent(opts.account)}`,
+    { method: 'GET' },
+    opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Signal list groups failed (${res.status}): ${text}`);
+  }
+
+  const groups = await res.json() as Array<{
+    id?: string;
+    internal_id?: string;
+    name?: string;
+    description?: string;
+    blocked?: boolean;
+    members?: string[];
+    admins?: string[];
+  }>;
+
+  return groups.map((g) => ({
+    id: g.id || g.internal_id || '',
+    internalId: g.internal_id || '',
+    name: g.name || '',
+    description: g.description,
+    isMember: true,
+    isBlocked: g.blocked ?? false,
+    members: g.members || [],
+    admins: g.admins || [],
+  }));
+}
+
+/**
+ * Get detailed information about a specific group.
+ */
+export async function signalGetGroupInfo(opts: {
+  baseUrl: string;
+  account: string;
+  groupId: string;
+  timeoutMs?: number;
+}): Promise<SignalGroup> {
+  const baseUrl = normalizeBaseUrl(opts.baseUrl);
+
+  const res = await fetchWithTimeout(
+    `${baseUrl}/v1/groups/${encodeURIComponent(opts.account)}/${encodeURIComponent(opts.groupId)}`,
+    { method: 'GET' },
+    opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Signal get group info failed (${res.status}): ${text}`);
+  }
+
+  const g = await res.json() as {
+    id?: string;
+    internal_id?: string;
+    name?: string;
+    description?: string;
+    blocked?: boolean;
+    members?: string[];
+    admins?: string[];
+  };
+
+  return {
+    id: g.id || g.internal_id || '',
+    internalId: g.internal_id || '',
+    name: g.name || '',
+    description: g.description,
+    isMember: true,
+    isBlocked: g.blocked ?? false,
+    members: g.members || [],
+    admins: g.admins || [],
+  };
+}
+
+/**
+ * Create a poll in a group or DM.
+ */
+export async function signalCreatePoll(
+  opts: {
+    baseUrl: string;
+    account: string;
+    recipient: string;
+    question: string;
+    answers: string[];
+    allowMultipleSelections?: boolean;
+    timeoutMs?: number;
+  },
+): Promise<{ pollTimestamp?: string }> {
+  const baseUrl = normalizeBaseUrl(opts.baseUrl);
+  const body = {
+    recipient: opts.recipient,
+    question: opts.question,
+    answers: opts.answers,
+    allow_multiple_selections: opts.allowMultipleSelections ?? true,
+  };
+
+  const res = await fetchWithTimeout(
+    `${baseUrl}/v1/polls/${encodeURIComponent(opts.account)}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+    opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Signal create poll failed (${res.status}): ${text}`);
+  }
+
+  const result = await res.json() as { timestamp?: string };
+  return { pollTimestamp: result.timestamp };
+}
+
+/**
+ * Close an existing poll.
+ */
+export async function signalClosePoll(
+  opts: {
+    baseUrl: string;
+    account: string;
+    recipient: string;
+    pollTimestamp: string;
+    timeoutMs?: number;
+  },
+): Promise<void> {
+  const baseUrl = normalizeBaseUrl(opts.baseUrl);
+  const body = {
+    recipient: opts.recipient,
+    poll_timestamp: opts.pollTimestamp,
+  };
+
+  const res = await fetchWithTimeout(
+    `${baseUrl}/v1/polls/${encodeURIComponent(opts.account)}`,
+    {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+    opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Signal close poll failed (${res.status}): ${text}`);
+  }
+}
+
+export async function signalCheck(
+  baseUrl: string,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<{ ok: boolean; error?: string }> {
+  const normalized = normalizeBaseUrl(baseUrl);
+  try {
+    const res = await fetchWithTimeout(
+      `${normalized}/v1/health`,
+      { method: 'GET' },
+      timeoutMs,
+    );
+    if (!res.ok) {
+      return { ok: false, error: `HTTP ${res.status}` };
+    }
+    return { ok: true };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+/**
+ * Stream events from signal-cli via WebSocket.
+ * Used with bbernhard/signal-cli-rest-api in json-rpc mode.
+ * Calls onEvent for each received message.
+ */
+export async function streamSignalEvents(params: {
+  baseUrl: string;
+  account?: string;
+  abortSignal?: AbortSignal;
+  onEvent: (event: SignalWsEvent) => void;
+}): Promise<void> {
+  const { default: WebSocket } = await import('ws');
+  const baseUrl = normalizeBaseUrl(params.baseUrl);
+
+  // Convert http:// to ws:// for WebSocket connection
+  const wsUrl = baseUrl.replace(/^http/, 'ws');
+  const account = params.account ? encodeURIComponent(params.account) : '';
+  const url = `${wsUrl}/v1/receive/${account}`;
+
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+
+    const cleanup = () => {
+      if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+        ws.close();
+      }
+    };
+
+    if (params.abortSignal) {
+      params.abortSignal.addEventListener('abort', cleanup);
+    }
+
+    ws.on('open', () => {
+      // Connection established, messages will arrive via 'message' event
+    });
+
+    ws.on('message', (data: Buffer) => {
+      try {
+        const message = JSON.parse(data.toString());
+        params.onEvent({
+          event: 'receive',
+          data: JSON.stringify(message),
+        });
+      } catch {
+        // Ignore parse errors
+      }
+    });
+
+    ws.on('error', (err: Error) => {
+      cleanup();
+      reject(new Error(`Signal WebSocket error: ${err.message}`));
+    });
+
+    ws.on('close', () => {
+      if (params.abortSignal) {
+        params.abortSignal.removeEventListener('abort', cleanup);
+      }
+      resolve();
+    });
+  });
+}
+
+/**
+ * Download an attachment by ID. Returns the raw file content as a Buffer.
+ */
+export async function signalDownloadAttachment(
+  baseUrl: string,
+  attachmentId: string,
+  timeoutMs = 30_000,
+): Promise<Buffer> {
+  const normalized = normalizeBaseUrl(baseUrl);
+  const res = await fetchWithTimeout(
+    `${normalized}/v1/attachments/${encodeURIComponent(attachmentId)}`,
+    { method: 'GET' },
+    timeoutMs,
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Signal download attachment failed (${res.status}): ${text}`);
+  }
+
+  const arrayBuf = await res.arrayBuffer();
+  return Buffer.from(arrayBuf);
+}
+
+/** Contact information from signal-cli */
+export interface SignalContact {
+  number: string;
+  name?: string;
+  profileName?: string;
+}
+
+/**
+ * List all known contacts for the account.
+ */
+export async function signalGetContacts(opts: {
+  baseUrl: string;
+  account: string;
+  timeoutMs?: number;
+}): Promise<SignalContact[]> {
+  const baseUrl = normalizeBaseUrl(opts.baseUrl);
+
+  const res = await fetchWithTimeout(
+    `${baseUrl}/v1/contacts/${encodeURIComponent(opts.account)}`,
+    { method: 'GET' },
+    opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Signal get contacts failed (${res.status}): ${text}`);
+  }
+
+  const contacts = await res.json() as Array<{
+    number?: string;
+    name?: string;
+    profile_name?: string;
+  }>;
+
+  return contacts.map((c) => ({
+    number: c.number || '',
+    name: c.name,
+    profileName: c.profile_name,
+  }));
+}
+
+// -- Enhanced features (Full features mode) --
+
+/**
+ * Set typing indicator on/off via REST API.
+ */
+export async function signalSetTyping(opts: {
+  baseUrl: string;
+  account: string;
+  recipient: string;
+  isTyping: boolean;
+  timeoutMs?: number;
+}): Promise<void> {
+  const baseUrl = normalizeBaseUrl(opts.baseUrl);
+  const body = { recipient: opts.recipient };
+
+  const res = await fetchWithTimeout(
+    `${baseUrl}/v1/typing-indicator/${encodeURIComponent(opts.account)}`,
+    {
+      method: opts.isTyping ? 'PUT' : 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+    opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Signal typing indicator failed (${res.status}): ${text}`);
+  }
+}
+
+/**
+ * Vote on an existing poll.
+ */
+export async function signalVotePoll(opts: {
+  baseUrl: string;
+  account: string;
+  recipient: string;
+  pollTimestamp: string;
+  pollAuthor: string;
+  selectedAnswers: number[];
+  timeoutMs?: number;
+}): Promise<void> {
+  const baseUrl = normalizeBaseUrl(opts.baseUrl);
+  const body = {
+    recipient: opts.recipient,
+    poll_timestamp: opts.pollTimestamp,
+    poll_author: opts.pollAuthor,
+    selected_answers: opts.selectedAnswers,
+  };
+
+  const res = await fetchWithTimeout(
+    `${baseUrl}/v1/polls/${encodeURIComponent(opts.account)}/vote`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+    opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Signal vote poll failed (${res.status}): ${text}`);
+  }
+}
+
+/** Sticker pack info */
+export interface SignalStickerPack {
+  packId: string;
+  url?: string;
+  installed?: boolean;
+  title?: string;
+  author?: string;
+}
+
+/**
+ * List installed sticker packs.
+ */
+export async function signalListStickerPacks(opts: {
+  baseUrl: string;
+  account: string;
+  timeoutMs?: number;
+}): Promise<SignalStickerPack[]> {
+  const baseUrl = normalizeBaseUrl(opts.baseUrl);
+
+  const res = await fetchWithTimeout(
+    `${baseUrl}/v1/sticker-packs/${encodeURIComponent(opts.account)}`,
+    { method: 'GET' },
+    opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Signal list sticker packs failed (${res.status}): ${text}`);
+  }
+
+  const packs = await res.json() as Array<{
+    pack_id?: string;
+    url?: string;
+    installed?: boolean;
+    title?: string;
+    author?: string;
+  }>;
+
+  return packs.map((p) => ({
+    packId: p.pack_id || '',
+    url: p.url,
+    installed: p.installed,
+    title: p.title,
+    author: p.author,
+  }));
+}
+
+/**
+ * Send a sticker.
+ */
+export async function signalSendSticker(opts: {
+  baseUrl: string;
+  account: string;
+  recipient: string;
+  packId: string;
+  stickerId: number;
+  timeoutMs?: number;
+}): Promise<void> {
+  const baseUrl = normalizeBaseUrl(opts.baseUrl);
+  const body = {
+    recipients: [opts.recipient],
+    sticker: `${opts.packId}:${opts.stickerId}`,
+  };
+
+  const res = await fetchWithTimeout(
+    `${baseUrl}/v2/send`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ number: opts.account, ...body }),
+    },
+    opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Signal send sticker failed (${res.status}): ${text}`);
+  }
+}
+
+/**
+ * Create a new Signal group.
+ */
+export async function signalCreateGroup(opts: {
+  baseUrl: string;
+  account: string;
+  name: string;
+  members: string[];
+  description?: string;
+  timeoutMs?: number;
+}): Promise<{ groupId: string }> {
+  const baseUrl = normalizeBaseUrl(opts.baseUrl);
+  const body: Record<string, unknown> = {
+    name: opts.name,
+    members: opts.members,
+  };
+  if (opts.description) body.description = opts.description;
+
+  const res = await fetchWithTimeout(
+    `${baseUrl}/v1/groups/${encodeURIComponent(opts.account)}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+    opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Signal create group failed (${res.status}): ${text}`);
+  }
+
+  const result = await res.json() as { id?: string };
+  return { groupId: result.id || '' };
+}
+
+/**
+ * Update a Signal group's name, description, or avatar.
+ */
+export async function signalUpdateGroup(opts: {
+  baseUrl: string;
+  account: string;
+  groupId: string;
+  name?: string;
+  description?: string;
+  avatarBase64?: string;
+  timeoutMs?: number;
+}): Promise<void> {
+  const baseUrl = normalizeBaseUrl(opts.baseUrl);
+  const body: Record<string, unknown> = {};
+  if (opts.name) body.name = opts.name;
+  if (opts.description) body.description = opts.description;
+  if (opts.avatarBase64) body.base64_avatar = opts.avatarBase64;
+
+  if (Object.keys(body).length === 0) return;
+
+  const res = await fetchWithTimeout(
+    `${baseUrl}/v1/groups/${encodeURIComponent(opts.account)}/${encodeURIComponent(opts.groupId)}`,
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+    opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Signal update group failed (${res.status}): ${text}`);
+  }
+}
+
+/**
+ * Add members to a Signal group.
+ */
+export async function signalAddGroupMembers(opts: {
+  baseUrl: string;
+  account: string;
+  groupId: string;
+  members: string[];
+  timeoutMs?: number;
+}): Promise<void> {
+  const baseUrl = normalizeBaseUrl(opts.baseUrl);
+  const body = { members: opts.members };
+
+  const res = await fetchWithTimeout(
+    `${baseUrl}/v1/groups/${encodeURIComponent(opts.account)}/${encodeURIComponent(opts.groupId)}/members`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+    opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Signal add group members failed (${res.status}): ${text}`);
+  }
+}
+
+/**
+ * Remove members from a Signal group.
+ */
+export async function signalRemoveGroupMembers(opts: {
+  baseUrl: string;
+  account: string;
+  groupId: string;
+  members: string[];
+  timeoutMs?: number;
+}): Promise<void> {
+  const baseUrl = normalizeBaseUrl(opts.baseUrl);
+  const body = { members: opts.members };
+
+  const res = await fetchWithTimeout(
+    `${baseUrl}/v1/groups/${encodeURIComponent(opts.account)}/${encodeURIComponent(opts.groupId)}/members`,
+    {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+    opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Signal remove group members failed (${res.status}): ${text}`);
+  }
+}
+
+/**
+ * Leave a Signal group.
+ */
+export async function signalQuitGroup(opts: {
+  baseUrl: string;
+  account: string;
+  groupId: string;
+  timeoutMs?: number;
+}): Promise<void> {
+  const baseUrl = normalizeBaseUrl(opts.baseUrl);
+
+  const res = await fetchWithTimeout(
+    `${baseUrl}/v1/groups/${encodeURIComponent(opts.account)}/${encodeURIComponent(opts.groupId)}/quit`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    },
+    opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Signal quit group failed (${res.status}): ${text}`);
+  }
+}
+
+/**
+ * Update the bot's Signal profile (name, about text, avatar).
+ */
+export async function signalUpdateProfile(opts: {
+  baseUrl: string;
+  account: string;
+  name?: string;
+  about?: string;
+  avatarBase64?: string;
+  timeoutMs?: number;
+}): Promise<void> {
+  const baseUrl = normalizeBaseUrl(opts.baseUrl);
+  const body: Record<string, unknown> = {};
+
+  if (opts.name) body.name = opts.name;
+  if (opts.about) body.about = opts.about;
+  if (opts.avatarBase64) body.base64_avatar = opts.avatarBase64;
+
+  if (Object.keys(body).length === 0) {
+    return;
+  }
+
+  const res = await fetchWithTimeout(
+    `${baseUrl}/v1/profiles/${encodeURIComponent(opts.account)}`,
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+    opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Signal update profile failed (${res.status}): ${text}`);
+  }
+}

--- a/.claude/skills/add-signal/src/signal/poll-store.ts
+++ b/.claude/skills/add-signal/src/signal/poll-store.ts
@@ -1,0 +1,140 @@
+/**
+ * In-memory poll vote accumulator.
+ * Tracks poll metadata and per-voter selections from WebSocket events.
+ * Votes are ephemeral and lost on process restart.
+ */
+
+export interface PollVoter {
+  number: string;
+  name: string;
+  optionIndexes: number[];
+  updatedAt: string;
+}
+
+export interface PollState {
+  chatJid: string;
+  authorNumber: string;
+  createdTimestamp: number;
+  question: string;
+  options: string[];
+  voters: Map<string, PollVoter>; // keyed by normalised phone number
+  closed: boolean;
+}
+
+export interface PollResults {
+  chatJid: string;
+  authorNumber: string;
+  createdTimestamp: number;
+  question: string;
+  options: Array<{ index: number; text: string; count: number; voters: string[] }>;
+  totalVoters: number;
+  closed: boolean;
+}
+
+/** Singleton poll store, keyed by "<chatJid>:<createdTimestamp>" */
+const polls = new Map<string, PollState>();
+
+function pollKey(chatJid: string, timestamp: number): string {
+  return `${chatJid}:${timestamp}`;
+}
+
+function normalizePhone(phone: string): string {
+  return phone.replace(/[^\d+]/g, '');
+}
+
+/** Register a poll when we create one or see a pollCreate event. */
+export function registerPoll(
+  chatJid: string,
+  authorNumber: string,
+  createdTimestamp: number,
+  question: string,
+  options: string[],
+): void {
+  const key = pollKey(chatJid, createdTimestamp);
+  if (!polls.has(key)) {
+    polls.set(key, {
+      chatJid,
+      authorNumber,
+      createdTimestamp,
+      question,
+      options,
+      voters: new Map(),
+      closed: false,
+    });
+  }
+}
+
+/** Record a vote. Replaces the voter's previous selection (Signal behaviour). */
+export function recordVote(
+  chatJid: string,
+  targetTimestamp: number,
+  voterNumber: string,
+  voterName: string,
+  optionIndexes: number[],
+): boolean {
+  const key = pollKey(chatJid, targetTimestamp);
+  const poll = polls.get(key);
+  if (!poll) return false;
+
+  poll.voters.set(normalizePhone(voterNumber), {
+    number: voterNumber,
+    name: voterName,
+    optionIndexes,
+    updatedAt: new Date().toISOString(),
+  });
+  return true;
+}
+
+/** Mark a poll as closed. */
+export function closePollState(chatJid: string, timestamp: number): void {
+  const key = pollKey(chatJid, timestamp);
+  const poll = polls.get(key);
+  if (poll) poll.closed = true;
+}
+
+/** Get aggregated results for a specific poll. */
+export function getPollResults(chatJid: string, timestamp: number): PollResults | null {
+  const key = pollKey(chatJid, timestamp);
+  const poll = polls.get(key);
+  if (!poll) return null;
+  return aggregatePoll(poll);
+}
+
+/** Get all polls for a chat, optionally filtered to open only. */
+export function getChatPolls(chatJid: string, openOnly = false): PollResults[] {
+  const results: PollResults[] = [];
+  for (const poll of polls.values()) {
+    if (poll.chatJid !== chatJid) continue;
+    if (openOnly && poll.closed) continue;
+    results.push(aggregatePoll(poll));
+  }
+  return results.sort((a, b) => b.createdTimestamp - a.createdTimestamp);
+}
+
+function aggregatePoll(poll: PollState): PollResults {
+  const optionResults = poll.options.map((text, index) => ({
+    index,
+    text,
+    count: 0,
+    voters: [] as string[],
+  }));
+
+  for (const voter of poll.voters.values()) {
+    for (const idx of voter.optionIndexes) {
+      if (idx >= 0 && idx < optionResults.length) {
+        optionResults[idx].count++;
+        optionResults[idx].voters.push(voter.name || voter.number);
+      }
+    }
+  }
+
+  return {
+    chatJid: poll.chatJid,
+    authorNumber: poll.authorNumber,
+    createdTimestamp: poll.createdTimestamp,
+    question: poll.question,
+    options: optionResults,
+    totalVoters: poll.voters.size,
+    closed: poll.closed,
+  };
+}


### PR DESCRIPTION
## Summary

Adds Signal as a messaging channel for nanoclaw using the signal-cli REST API. This skill provides everything needed to send and receive Signal messages through the bot framework.

- **Channel implementation** (`channels/signal.ts`): Core Signal channel with message sending, receiving, group support, and attachment handling
- **Client library** (`signal/client.ts`): Typed wrapper around the signal-cli REST API covering messages, groups, contacts, and attachments
- **IPC handlers** (`ipc-signal.ts`): Inter-process communication handlers for Signal operations
- **MCP tools** (`mcp-signal-tools.ts`): Model Context Protocol tool definitions for Signal messaging capabilities
- **Poll tracking** (`signal/poll-store.ts`): Persistent store for tracking message polling state across restarts
- **Configuration** (`config-signal.ts`): Signal-specific configuration schema and defaults
- **Entry point** (`index-signal.ts`): Channel registration and initialisation

## Test plan

- [ ] Verify the PR diff contains only the 8 add-signal skill files
- [ ] Review signal-cli REST API integration patterns in `client.ts`
- [ ] Test Signal messaging functionality with a running signal-cli instance