### PR TITLE
Protect .env secrets from Claude Code

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Read(path:.env.example)"
+    ],
+    "deny": [
+      "Read(path:.env)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ groups/global/*
 *.keys.json
 .env
 
+# Claude Code local settings
+.claude/settings.local.json
+
 # OS
 .DS_Store
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,12 @@ npm run build        # Compile TypeScript
 ./container/build.sh # Rebuild agent container
 ```
 
+### Environment Variables
+
+- **Never** read or modify `.env` — it contains secrets and is denied in settings.
+- When a new environment variable is needed, add it to `.env.example` with an empty or placeholder value and a descriptive comment.
+- Tell the user to fill in the actual value in `.env`.
+
 Service management:
 ```bash
 launchctl load ~/Library/LaunchAgents/com.nanoclaw.plist


### PR DESCRIPTION
## Summary

- **Add `.claude/settings.json`** with a `deny` rule for reading `.env` and an explicit `allow` for `.env.example`
- **Add `.claude/settings.local.json` to `.gitignore`**
- **Add environment variables policy to `CLAUDE.md`** instructing the agent to use `.env.example` as a template instead of touching `.env`

## Why deny reading `.env`?

Claude Code can read any file in the project by default. Since `.env` contains real secrets (API keys, tokens, database credentials), a shared `settings.json` deny rule ensures that no contributor's Claude session can accidentally read, log, or leak secret values — regardless of their personal permission settings. The `allow` for `.env.example` gives the agent a safe way to understand which variables are needed without ever seeing real values.

## Why gitignore `settings.local.json`?

`settings.local.json` contains **personal permission grants** — tool calls a specific user has approved (e.g., `Bash(docker build:*)`, `WebFetch(domain:github.com)`). These are:

- **Machine-specific**: permissions depend on what tools/services are installed locally
- **Security-sensitive**: revealing which commands are pre-approved can expose a user's workflow and attack surface
- **Noisy in diffs**: every time a user approves a new tool call, the file changes — this would pollute commit history with irrelevant permission churn

The shared `settings.json` is the right place for team-wide rules (like the `.env` deny). Personal overrides belong in `settings.local.json`, which Claude Code already treats as local-only by convention.

## Test plan

- [x] Verify Claude Code refuses to read `.env` in a new session
- [x] Verify Claude Code can still read `.env.example`
- [x] Verify `settings.local.json` no longer shows up in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)