### PR TITLE
feat: add structured memory system with FTS5 search

### DIFF
--- a/groups/global/CLAUDE.md
+++ b/groups/global/CLAUDE.md
@@ -38,14 +38,55 @@ When working as a sub-agent or teammate, only use `send_message` if instructed t
 
 Files you create are saved in `/workspace/group/`. Use this for notes, research, or anything that should persist.
 
-## Memory
+## Memory System
 
-The `conversations/` folder contains searchable history of past conversations. Use this to recall context from previous sessions.
+Your workspace has a structured memory system:
 
-When you learn something important:
-- Create files for structured data (e.g., `customers.md`, `preferences.md`)
-- Split files larger than 500 lines into folders
-- Keep an index in your memory for the files you create
+```
+/workspace/group/
+  memory/
+    facts.md         ← permanent facts (preferences, contacts, decisions)
+    daily/
+      YYYY-MM-DD.md  ← daily event log (append-only)
+  conversations/     ← archived conversation transcripts
+```
+
+### Rules
+
+- **NEVER store memory in CLAUDE.md.** CLAUDE.md is for identity and instructions only.
+- Use `memory/facts.md` for permanent facts. Use `memory/daily/` for daily event logs.
+- Use `mcp__nanoclaw__memory_search` to search your memory and past conversations before answering questions about past events or user preferences. Don't guess — search first if unsure.
+
+### Writing to `memory/facts.md`
+
+Distill facts — don't store raw quotes. "User said they changed their mind about MongoDB" → update the decision entry.
+
+**Format:**
+```markdown
+- [YYYY-MM-DD] [confidence] Distilled fact
+  source: daily/YYYY-MM-DD.md#section-anchor
+```
+
+**Confidence levels:**
+- `user-stated` — User explicitly said this. Ground truth.
+- `user-confirmed` — Agent asked, user confirmed.
+- `agent-observed` — Pattern noticed across multiple episodes. Include episode count.
+- `agent-inferred` — Single inference from context. May be wrong.
+
+**Conflict handling:**
+- When a fact changes, add `supersedes:` noting the old value and date.
+- If unsure which version is correct, flag both with `⚠️ CONFLICTING:` — don't silently pick one.
+- Higher-confidence sources override lower ones (`user-stated` > `agent-inferred`).
+
+**Capacity:** Max ~50 entries. When full, demote `agent-inferred` entries first, then consolidate.
+
+### Writing to `memory/daily/YYYY-MM-DD.md`
+
+Log important events, decisions, and action items — not chitchat. Use markdown anchors (## headers) so facts.md can reference specific sections with `#section-anchor`.
+
+### Episodic traceability
+
+Daily logs are the evidence base. Before modifying a fact, read the source episode for context. Every fact must include a `source:` line pointing to the daily log episode(s) it was extracted from.
 
 ## Message Formatting
 

--- a/groups/main/CLAUDE.md
+++ b/groups/main/CLAUDE.md
@@ -36,12 +36,9 @@ When working as a sub-agent or teammate, only use `send_message` if instructed t
 
 ## Memory
 
-The `conversations/` folder contains searchable history of past conversations. Use this to recall context from previous sessions.
+See the Memory System section in global CLAUDE.md for full conventions.
 
-When you learn something important:
-- Create files for structured data (e.g., `customers.md`, `preferences.md`)
-- Split files larger than 500 lines into folders
-- Keep an index in your memory for the files you create
+Your memory lives in `memory/` — use `memory/facts.md` for permanent facts and `memory/daily/` for daily logs. Use `mcp__nanoclaw__memory_search` to search past conversations and facts. Never store memory notes in this CLAUDE.md file.
 
 ## WhatsApp Formatting (and other messaging apps)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ import {
 } from './db.js';
 import { GroupQueue } from './group-queue.js';
 import { startIpcWatcher } from './ipc.js';
+import { startMemoryIndexer } from './memory-indexer.js';
 import { formatMessages, formatOutbound } from './router.js';
 import { startSchedulerLoop } from './task-scheduler.js';
 import { NewMessage, RegisteredGroup } from './types.js';
@@ -492,6 +493,7 @@ async function main(): Promise<void> {
     getAvailableGroups,
     writeGroupsSnapshot: (gf, im, ag, rj) => writeGroupsSnapshot(gf, im, ag, rj),
   });
+  startMemoryIndexer();
   queue.setProcessMessagesFn(processGroupMessages);
   recoverPendingMessages();
   startMessageLoop();

--- a/src/memory-indexer.ts
+++ b/src/memory-indexer.ts
@@ -1,0 +1,222 @@
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+
+import { GROUPS_DIR } from './config.js';
+import {
+  deleteMemoryChunksByFile,
+  MemoryChunk,
+  upsertMemoryChunk,
+} from './db.js';
+import { logger } from './logger.js';
+
+const INDEX_INTERVAL = 30_000; // 30 seconds
+const TARGET_CHUNK_TOKENS = 400; // ~400 tokens per chunk
+const CHARS_PER_TOKEN = 4; // rough estimate
+const TARGET_CHUNK_CHARS = TARGET_CHUNK_TOKENS * CHARS_PER_TOKEN;
+
+// Track file mtimes to avoid re-indexing unchanged files
+const fileMtimes = new Map<string, number>();
+
+let running = false;
+
+export function startMemoryIndexer(): void {
+  if (running) return;
+  running = true;
+  logger.info('Memory indexer started');
+  indexLoop();
+}
+
+function indexLoop(): void {
+  try {
+    indexAllGroups();
+  } catch (err) {
+    logger.error({ err }, 'Memory indexer error');
+  }
+  setTimeout(indexLoop, INDEX_INTERVAL);
+}
+
+function indexAllGroups(): void {
+  let groupDirs: string[];
+  try {
+    groupDirs = fs
+      .readdirSync(GROUPS_DIR)
+      .filter((f) => {
+        const fullPath = path.join(GROUPS_DIR, f);
+        return fs.statSync(fullPath).isDirectory();
+      });
+  } catch {
+    return;
+  }
+
+  for (const groupFolder of groupDirs) {
+    const groupPath = path.join(GROUPS_DIR, groupFolder);
+    const dirsToIndex = [
+      path.join(groupPath, 'memory'),
+      path.join(groupPath, 'conversations'),
+    ];
+
+    for (const dir of dirsToIndex) {
+      if (!fs.existsSync(dir)) continue;
+      indexDirectory(dir, groupFolder);
+    }
+  }
+}
+
+function indexDirectory(dir: string, groupFolder: string): void {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      indexDirectory(fullPath, groupFolder);
+      continue;
+    }
+
+    if (!entry.name.endsWith('.md') && !entry.name.endsWith('.txt')) continue;
+
+    try {
+      const stat = fs.statSync(fullPath);
+      const mtime = stat.mtimeMs;
+      const cached = fileMtimes.get(fullPath);
+
+      if (cached && cached >= mtime) continue; // unchanged
+
+      indexFile(fullPath, groupFolder);
+      fileMtimes.set(fullPath, mtime);
+    } catch {
+      // file may have been deleted between readdir and stat
+    }
+  }
+}
+
+function indexFile(filePath: string, groupFolder: string): void {
+  const content = fs.readFileSync(filePath, 'utf-8');
+  if (!content.trim()) return;
+
+  // Relative path from groups dir for storage
+  const sourceFile = path.relative(GROUPS_DIR, filePath);
+
+  // Delete existing chunks for this file before re-indexing
+  deleteMemoryChunksByFile(sourceFile, groupFolder);
+
+  const chunks = chunkText(content);
+  const now = new Date().toISOString();
+
+  for (const chunk of chunks) {
+    const id = crypto
+      .createHash('sha256')
+      .update(`${groupFolder}:${sourceFile}:${chunk.lineStart}:${chunk.lineEnd}`)
+      .digest('hex')
+      .slice(0, 16);
+
+    const memChunk: MemoryChunk = {
+      id,
+      group_folder: groupFolder,
+      source_file: sourceFile,
+      content: chunk.text,
+      line_start: chunk.lineStart,
+      line_end: chunk.lineEnd,
+      created_at: now,
+      updated_at: now,
+    };
+
+    upsertMemoryChunk(memChunk);
+  }
+
+  logger.debug(
+    { file: sourceFile, groupFolder, chunks: chunks.length },
+    'Indexed memory file',
+  );
+}
+
+interface TextChunk {
+  text: string;
+  lineStart: number;
+  lineEnd: number;
+}
+
+function chunkText(content: string): TextChunk[] {
+  const paragraphs = content.split(/\n\n+/);
+  const chunks: TextChunk[] = [];
+  let currentText = '';
+  let currentLineStart = 1;
+  let lineCounter = 1;
+
+  for (const para of paragraphs) {
+    const paraLines = para.split('\n').length;
+    const paraStart = lineCounter;
+
+    if (currentText.length + para.length > TARGET_CHUNK_CHARS && currentText) {
+      // Flush current chunk
+      chunks.push({
+        text: currentText.trim(),
+        lineStart: currentLineStart,
+        lineEnd: lineCounter - 1,
+      });
+      currentText = '';
+      currentLineStart = paraStart;
+    }
+
+    // If a single paragraph exceeds target, split it
+    if (para.length > TARGET_CHUNK_CHARS * 1.5) {
+      if (currentText) {
+        chunks.push({
+          text: currentText.trim(),
+          lineStart: currentLineStart,
+          lineEnd: paraStart - 1,
+        });
+        currentText = '';
+      }
+
+      const lines = para.split('\n');
+      let subChunk = '';
+      let subStart = paraStart;
+
+      for (let i = 0; i < lines.length; i++) {
+        if (subChunk.length + lines[i].length > TARGET_CHUNK_CHARS && subChunk) {
+          chunks.push({
+            text: subChunk.trim(),
+            lineStart: subStart,
+            lineEnd: paraStart + i - 1,
+          });
+          subChunk = '';
+          subStart = paraStart + i;
+        }
+        subChunk += (subChunk ? '\n' : '') + lines[i];
+      }
+
+      if (subChunk.trim()) {
+        chunks.push({
+          text: subChunk.trim(),
+          lineStart: subStart,
+          lineEnd: paraStart + lines.length - 1,
+        });
+      }
+
+      currentLineStart = paraStart + paraLines;
+    } else {
+      currentText += (currentText ? '\n\n' : '') + para;
+    }
+
+    lineCounter = paraStart + paraLines;
+    // Account for the blank line(s) between paragraphs
+    lineCounter++;
+  }
+
+  if (currentText.trim()) {
+    chunks.push({
+      text: currentText.trim(),
+      lineStart: currentLineStart,
+      lineEnd: lineCounter - 1,
+    });
+  }
+
+  return chunks;
+}


### PR DESCRIPTION
## Summary

- Replace unbounded CLAUDE.md memory growth with a two-layer memory system: structured facts (`memory/facts.md`) + daily event logs (`memory/daily/`), searchable via a new `memory_search` MCP tool backed by SQLite FTS5
- Add memory conventions to agent instructions with confidence scoring, conflict handling, episodic traceability, and denoising rules
- Create a background memory indexer that polls memory and conversation files every 30s, chunks them into ~400-token segments, and indexes into FTS5

### Changes

**Phase 1 — Foundation:**
- `groups/global/CLAUDE.md` / `groups/main/CLAUDE.md` — Replace old memory section with structured memory system conventions
- `container/agent-runner/src/index.ts` — Enhanced PreCompact hook extracts memory-worthy items (preferences, decisions, "I'll remember" patterns) into `memory/daily/YYYY-MM-DD.md` via regex

**Phase 2 — Smart Retrieval:**
- `src/db.ts` — Added `memory_chunks` table + `memory_chunks_fts` FTS5 virtual table, `searchMemory()`, `upsertMemoryChunk()`, `deleteMemoryChunksByFile()`
- `src/memory-indexer.ts` — New file: polls `groups/*/memory/**` and `groups/*/conversations/**`, chunks text, upserts into SQLite FTS5
- `src/ipc.ts` — Added `memory_requests/` processing: reads search requests from container, calls `searchMemory()`, writes results to `memory_results/`
- `container/agent-runner/src/ipc-mcp-stdio.ts` — New `memory_search` MCP tool: writes IPC request, polls for results (10s timeout), returns formatted chunks with source references
- `src/index.ts` — Wires up memory indexer at startup

### Design principles

- **Lossy compression > raw context** — Agents distill signal into clean facts, not raw conversation dumps
- **Search over injection** — Never auto-inject all memories; the agent searches when it needs context
- **O(log n) retrieval** — FTS5 index keeps search cost constant regardless of memory size
- **Zero new dependencies** — Uses existing SQLite/better-sqlite3, no embeddings API needed
- **Gullible Memory mitigation** — Confidence scoring + episodic traceability; conflicts flagged, not auto-resolved

## Test plan

- [ ] Send messages, trigger compaction, verify daily log gets entries from the archived transcript
- [ ] Verify CLAUDE.md stays constant size (no memory accumulation)
- [ ] Write a test memory file, wait 30s for indexing, invoke `memory_search` from inside the container, verify relevant chunks are returned
- [ ] Test conflict resolution: update a fact, search for it, verify latest version returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)