### PR TITLE
Omit "Andy:" when using own number

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -139,6 +139,7 @@ Run `./.claude/skills/setup/scripts/06-register-channel.sh` with args:
 - `--folder "main"` — always "main" for the first channel
 - `--no-trigger-required` — if personal chat, DM, or solo group
 - `--assistant-name "Name"` — if trigger word differs from "Andy"
+- `--own-number` — if bot has its own dedicated phone number
 
 ## 9. Mount Allowlist
 

--- a/.claude/skills/setup/scripts/06-register-channel.sh
+++ b/.claude/skills/setup/scripts/06-register-channel.sh
@@ -20,6 +20,7 @@ TRIGGER=""
 FOLDER=""
 REQUIRES_TRIGGER="true"
 ASSISTANT_NAME="Andy"
+OWN_NUMBER="false"
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -29,6 +30,7 @@ while [[ $# -gt 0 ]]; do
     --folder)           FOLDER="$2"; shift 2 ;;
     --no-trigger-required) REQUIRES_TRIGGER="false"; shift ;;
     --assistant-name)   ASSISTANT_NAME="$2"; shift 2 ;;
+    --own-number)       OWN_NUMBER="true"; shift ;;
     *) shift ;;
   esac
 done
@@ -80,6 +82,19 @@ if [ "$ASSISTANT_NAME" != "Andy" ]; then
   done
 
   NAME_UPDATED="true"
+fi
+
+# Write assistant name and phone config to .env
+ENV_FILE="$PROJECT_ROOT/.env"
+if [ "$ASSISTANT_NAME" != "Andy" ]; then
+  sed -i '' '/^ASSISTANT_NAME=/d' "$ENV_FILE"
+  echo "ASSISTANT_NAME=$ASSISTANT_NAME" >> "$ENV_FILE"
+  log "Set ASSISTANT_NAME=$ASSISTANT_NAME in .env"
+fi
+if [ "$OWN_NUMBER" = "true" ]; then
+  sed -i '' '/^ASSISTANT_HAS_OWN_NUMBER=/d' "$ENV_FILE"
+  echo "ASSISTANT_HAS_OWN_NUMBER=true" >> "$ENV_FILE"
+  log "Set ASSISTANT_HAS_OWN_NUMBER=true in .env"
 fi
 
 cat <<EOF


### PR DESCRIPTION
## Type of Change

- **Fix** - bug fix or security fix to source code

## Description

I set up my NanoClaw instance with a dedicated number. The messages it sent had the "Assistant name:" (e.g. Andy:) prefix, which makes sense for a setup with a single number to distinguish who sent what, but seems redundant to me when the message from the agent comes from a different account than the user's.

Needless to say, the fix was suggested by Claude Code during setup, but it makes sense to me to track those env var for scripts to read, vs only having preferences such as the name in the natural language docs the model reads.

Maybe this is not the right way to fix the issue, but I thought this would be a decent place to start, if others reported the same issue. Let me know what you think.