### PR TITLE
feat: add memory system skill

### DIFF
--- a/.claude/skills/add-memory-system/SKILL.md
+++ b/.claude/skills/add-memory-system/SKILL.md
@@ -78,6 +78,7 @@ Your workspace has a structured memory system:
 - **NEVER store memory in CLAUDE.md.** CLAUDE.md is for identity and instructions only.
 - Use `memory/facts.md` for permanent facts. Use `memory/daily/` for daily event logs.
 - Use `mcp__nanoclaw__memory_search` to search your memory and past conversations before answering questions about past events or user preferences. Don't guess -- search first if unsure.
+- At the end of a conversation where you learned something noteworthy (a preference, decision, action item, or important event), write a brief entry to today's `memory/daily/YYYY-MM-DD.md`. Don't log chitchat — only things worth remembering.
 
 ### Writing to `memory/facts.md`
 
@@ -103,6 +104,8 @@ Distill facts -- don't store raw quotes. "User said they changed their mind abou
 **Capacity:** Max ~50 entries. When full, demote `agent-inferred` entries first, then consolidate.
 
 ### Writing to `memory/daily/YYYY-MM-DD.md`
+
+Proactively write to this file during or at the end of any conversation where something noteworthy happened -- a user preference, a decision made, an action completed, or an important event. Don't wait for compaction; treat this as your primary logging mechanism.
 
 Log important events, decisions, and action items -- not chitchat. Use markdown anchors (## headers) so facts.md can reference specific sections with `#section-anchor`.
 


### PR DESCRIPTION
## Summary

- Add `/add-memory-system` skill that implements structured memory with FTS5 search
- Replaces unbounded CLAUDE.md memory growth with two-layer memory (facts + daily logs), a background indexer, and a `memory_search` MCP tool
- Skill contains step-by-step instructions for Claude to implement the full system when invoked

### What the skill does when run

1. Creates `memory/` directory structure per group (facts.md + daily/ logs)
2. Updates CLAUDE.md files with memory conventions (confidence scoring, conflict handling, episodic traceability)
3. Enhances PreCompact hook to extract memory items into daily logs via regex
4. Adds `memory_chunks` + FTS5 tables to SQLite
5. Creates a background memory indexer (polls every 30s, chunks into ~400 tokens, indexes into FTS5)
6. Adds `memory_search` IPC handler (host) and MCP tool (container)
7. Rebuilds and restarts

### Design principles

- **Lossy compression > raw context** — distill facts, don't dump conversations
- **Search over injection** — agents search when they need context, never auto-inject all memories
- **Zero new dependencies** — uses existing better-sqlite3 FTS5
- **Gullible Memory mitigation** — confidence scoring + episodic traceability

## Test plan

- [ ] Run `/add-memory-system` skill, verify all 10 steps complete without errors
- [ ] Send messages, trigger compaction, verify daily log gets entries
- [ ] Wait 30s for indexer, invoke `memory_search` from container, verify results returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)