### PR TITLE
feat: add channel megaskill for multi-platform support

### DIFF
--- a/.claude/skills/add-channel/SKILL.md
+++ b/.claude/skills/add-channel/SKILL.md
@@ -169,7 +169,7 @@ export class DiscordChannel implements Channel {
 
 **Key implementation details:**
 - Client intents: `Guilds`, `GuildMessages`, `MessageContent`, `DirectMessages`
-- Message normalization: `{ channelId, content, authorName, messageId, isBot, timestamp }`
+- Message normalization: match the `NewMessage` interface: `{ id, chat_jid, sender, sender_name, content, timestamp, is_from_me?, is_bot_message? }`
 - 2000 char limit: Split long messages at newlines
 - JID format: Discord uses numeric channel IDs (e.g., `"1234567890"`)
 


### PR DESCRIPTION
## Summary
- Adds `/add-channel` skill that lets users choose their messaging platform (WhatsApp, Discord, Telegram, etc.)
- Supports multi-channel setups — run WhatsApp + Discord + Telegram simultaneously
- Enforces modular Channel interface pattern (`src/channels/`) with router-based message routing
- Consolidates setup skill into single declarative SKILL.md (replaces 9 separate shell scripts)

## Design
- WhatsApp stays as default (already in main codebase)
- Skill teaches Claude Code how to transform the installation based on user choice
- All channel implementations follow the `Channel` interface with `ownsJid()` for routing
- Addresses reviewer feedback: "combine channel skills into one megaskill that allows people to choose one of any potential transport mechanisms"

## Test plan
- [ ] Run `/add-channel` and verify platform options are presented
- [ ] Select "Keep WhatsApp" — no changes to codebase
- [ ] Select "Add Discord" — verify Discord connector is added alongside WhatsApp
- [ ] Verify `/setup` skill works end-to-end with consolidated SKILL.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)