### PR TITLE
Decouple formatting test from `@Andy`

### DIFF
--- a/src/formatting.test.ts
+++ b/src/formatting.test.ts
@@ -132,6 +132,7 @@ describe('TRIGGER_PATTERN', () => {
   });
 
   it('matches with leading whitespace after trim', () => {
+    // The actual usage trims before testing: TRIGGER_PATTERN.test(m.content.trim())
     expect(TRIGGER_PATTERN.test(`@${name} hey`.trim())).toBe(true);
   });
 });


### PR DESCRIPTION
## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [ ] **Fix** - bug fix or security fix to source code
- [x] **Simplification** - reduces or simplifies source code

## Description

I gave my instance a different name. When I ran the tests locally, the formatting failed because of the hardcoded `@Andy` in the expectations.

This PR uses `ASSISTANT_NAME` in those tests.

An alternative might have been to setup a different `.env` loading system for the tests, but that seemed a much bigger change.

## For Skills

_Not a skill._