### PR TITLE
feat: add Codex and Cursor CLI backends for local agent runtime

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,20 @@
+# Agent backend selection:
+# - sdk (default): Claude Agent SDK
+# - codex: OpenAI Codex CLI
+# - cursor-agent: Cursor Agent CLI
+# AGENT_BACKEND=sdk
 
+# Optional CLI executable override.
+# codex default: codex
+# cursor-agent default: cursor-agent
+# AGENT_CLI_CMD=
+
+# Optional JSON array of extra CLI args.
+# AGENT_CLI_ARGS=["--oss","--local-provider=ollama"]
+
+# Optional output format for cursor-agent: text or json.
+# AGENT_CLI_OUTPUT_FORMAT=text
+
+# Optional hot-reload mode: recompile agent-runner on each container start.
+# Disabled by default for better startup reliability/performance.
+# NANOCLAW_RUNNER_HOT_RELOAD=0

--- a/README.md
+++ b/README.md
@@ -22,13 +22,17 @@ NanoClaw gives you the same core functionality in a codebase you can understand 
 
 ## Quick Start
 
+**With Claude Code (recommended):**
 ```bash
 git clone https://github.com/qwibitai/nanoclaw.git
 cd nanoclaw
 claude
 ```
-
 Then run `/setup`. Claude Code handles everything: dependencies, authentication, container setup, service configuration.
+
+**Without Claude Code:** See [docs/SETUP-MANUAL.md](docs/SETUP-MANUAL.md) for step-by-step manual setup.
+
+**Local CLIs:** Use Codex or Cursor Agent instead of API tokens. Set `AGENT_BACKEND=codex` or `AGENT_BACKEND=cursor-agent` in `.env`. See [docs/CLI-ADAPTER.md](docs/CLI-ADAPTER.md).
 
 ## Philosophy
 

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -29,8 +29,8 @@ RUN apt-get update && apt-get install -y \
 ENV AGENT_BROWSER_EXECUTABLE_PATH=/usr/bin/chromium
 ENV PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium
 
-# Install agent-browser and claude-code globally
-RUN npm install -g agent-browser @anthropic-ai/claude-code
+# Install agent-browser, claude-code, and codex CLI (for AGENT_BACKEND=codex)
+RUN npm install -g agent-browser @anthropic-ai/claude-code @openai/codex
 
 # Create app directory
 WORKDIR /app
@@ -53,7 +53,9 @@ RUN mkdir -p /workspace/group /workspace/global /workspace/extra /workspace/ipc/
 # Create entrypoint script
 # Secrets are passed via stdin JSON — temp file is deleted immediately after Node reads it
 # Follow-up messages arrive via IPC files in /workspace/ipc/input/
-RUN printf '#!/bin/bash\nset -e\ncd /app && npx tsc --outDir /tmp/dist 2>&1 >&2\nln -s /app/node_modules /tmp/dist/node_modules\nchmod -R a-w /tmp/dist\ncat > /tmp/input.json\nnode /tmp/dist/index.js < /tmp/input.json\n' > /app/entrypoint.sh && chmod +x /app/entrypoint.sh
+# Default path uses prebuilt dist for lower startup latency and memory usage.
+# Set NANOCLAW_RUNNER_HOT_RELOAD=1 to recompile /app/src on each run.
+RUN printf '#!/bin/bash\nset -e\ncat > /tmp/input.json\nif [ \"${NANOCLAW_RUNNER_HOT_RELOAD:-0}\" = \"1\" ]; then\n  cd /app\n  npx tsc --outDir /tmp/dist 2>&1 >&2\n  ln -sf /app/node_modules /tmp/dist/node_modules\n  chmod -R a-w /tmp/dist\n  exec node /tmp/dist/index.js < /tmp/input.json\nfi\nexec node /app/dist/index.js < /tmp/input.json\n' > /app/entrypoint.sh && chmod +x /app/entrypoint.sh
 
 # Set ownership to node user (non-root) for writable directories
 RUN chown -R node:node /workspace && chmod 777 /home/node

--- a/container/agent-runner/src/adapters/cli-adapter.ts
+++ b/container/agent-runner/src/adapters/cli-adapter.ts
@@ -1,0 +1,184 @@
+import { spawn } from 'child_process';
+import type { AdapterInput, ContainerOutput } from './interface.js';
+
+type CliPreset = 'codex' | 'cursor-agent';
+
+function log(message: string): void {
+  console.error(`[agent-runner] ${message}`);
+}
+
+function getCliPreset(): CliPreset | null {
+  const backend = process.env.AGENT_BACKEND;
+  if (backend === 'codex' || backend === 'cursor-agent') return backend;
+  return null;
+}
+
+function parseCodexJsonl(stdout: string): string | null {
+  let lastTextItem: string | null = null;
+  let lastAgentMessage: string | null = null;
+  for (const line of stdout.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const obj = JSON.parse(trimmed);
+      if (obj.type === 'item.completed' && typeof obj.item?.text === 'string') {
+        lastTextItem = obj.item.text;
+        if (obj.item?.type === 'agent_message') {
+          lastAgentMessage = obj.item.text;
+        }
+      }
+    } catch { }
+  }
+  return lastAgentMessage ?? lastTextItem;
+}
+
+function parseCursorJson(stdout: string): string | null {
+  try {
+    const obj = JSON.parse(stdout);
+    if (obj.result) return obj.result;
+    if (obj.text) return obj.text;
+  } catch { }
+  return null;
+}
+
+function parseCliArgs(rawArgs: string): string[] {
+  const parsed = JSON.parse(rawArgs);
+  if (!Array.isArray(parsed) || parsed.some((arg) => typeof arg !== 'string')) {
+    throw new Error('AGENT_CLI_ARGS must be a JSON array of strings');
+  }
+  return parsed;
+}
+
+export const cliAdapter = {
+  async *run(input: AdapterInput): AsyncGenerator<ContainerOutput> {
+    const preset = getCliPreset();
+    if (!preset) {
+      yield { status: 'error', result: null, error: 'AGENT_BACKEND must be "codex" or "cursor-agent" for CLI adapter' };
+      return;
+    }
+
+    let csv: string;
+    let args: string[];
+    let useStdin = false;
+
+    if (preset === 'codex') {
+      csv = process.env.AGENT_CLI_CMD || 'codex';
+      args = [
+        'exec',
+        '-C', input.cwd,
+        '--dangerously-bypass-approvals-and-sandbox',
+        '--json',
+        '-',
+      ];
+      useStdin = true;
+      const extraArgs = process.env.AGENT_CLI_ARGS;
+      if (extraArgs) {
+        try {
+          const parsed = parseCliArgs(extraArgs);
+          args.splice(-1, 0, ...parsed);
+        } catch (err) {
+          yield {
+            status: 'error',
+            result: null,
+            error: err instanceof Error ? err.message : 'Invalid AGENT_CLI_ARGS',
+          };
+          return;
+        }
+      }
+    } else if (preset === 'cursor-agent') {
+      csv = process.env.AGENT_CLI_CMD || 'cursor-agent';
+      const outputFormat = process.env.AGENT_CLI_OUTPUT_FORMAT || 'text';
+      args = [
+        '-p',
+        '--trust',
+        '--workspace', input.cwd,
+        `--output-format`, outputFormat,
+        input.prompt,
+      ];
+    } else {
+      yield { status: 'error', result: null, error: `Unknown preset: ${preset}` };
+      return;
+    }
+
+    const timeoutMs = parseInt(process.env.CONTAINER_TIMEOUT || '1800000', 10);
+
+    const child = spawn(csv, args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, ...input.env },
+      cwd: input.cwd,
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    const stdoutPromise = new Promise<void>((resolve, reject) => {
+      child.stdout?.on('data', (chunk: Buffer) => { stdout += chunk.toString(); });
+      child.stdout?.on('end', resolve);
+      child.stdout?.on('error', reject);
+    });
+
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+      log(chunk.toString().trim());
+    });
+
+    if (useStdin && child.stdin) {
+      child.stdin.write(input.prompt);
+      child.stdin.end();
+    }
+
+    const exitPromise = new Promise<number | null>((resolve) => {
+      child.on('close', (code) => resolve(code));
+      child.on('error', (err) => {
+        log(`CLI spawn error: ${err.message}`);
+        resolve(-1);
+      });
+    });
+
+    const timeoutPromise = new Promise<'timeout'>((resolve) => {
+      setTimeout(() => resolve('timeout'), timeoutMs);
+    });
+
+    const result = await Promise.race([
+      Promise.all([stdoutPromise, exitPromise]).then(([, code]) => ({ code })),
+      timeoutPromise.then(() => ({ code: 'timeout' as const })),
+    ]);
+
+    if (result.code === 'timeout') {
+      child.kill('SIGKILL');
+      yield {
+        status: 'error',
+        result: null,
+        error: `CLI timed out after ${timeoutMs}ms`,
+      };
+      return;
+    }
+
+    const code = result.code;
+    if (code !== 0 && code !== null) {
+      yield {
+        status: 'error',
+        result: null,
+        error: `CLI exited with code ${code}: ${stderr.slice(-500)}`,
+      };
+      return;
+    }
+
+    let text: string | null = null;
+    if (preset === 'codex') {
+      text = parseCodexJsonl(stdout);
+    } else if (preset === 'cursor-agent') {
+      const outputFormat = process.env.AGENT_CLI_OUTPUT_FORMAT || 'text';
+      if (outputFormat === 'json') {
+        text = parseCursorJson(stdout);
+      } else {
+        text = stdout.trim() || null;
+      }
+    }
+
+    yield {
+      status: 'success',
+      result: text,
+    };
+  },
+};

--- a/container/agent-runner/src/adapters/interface.ts
+++ b/container/agent-runner/src/adapters/interface.ts
@@ -1,0 +1,26 @@
+export interface ContainerOutput {
+  status: 'success' | 'error';
+  result: string | null;
+  newSessionId?: string;
+  error?: string;
+  closedDuringQuery?: boolean;
+  resumeAt?: string;
+}
+
+export interface AdapterInput {
+  prompt: string;
+  sessionId?: string;
+  resumeAt?: string;
+  cwd: string;
+  env: Record<string, string | undefined>;
+  groupFolder: string;
+  chatJid: string;
+  isMain: boolean;
+  globalClaudeMd?: string;
+  extraDirs: string[];
+  mcpServerPath?: string;
+}
+
+export interface AgentAdapter {
+  run(input: AdapterInput): AsyncGenerator<ContainerOutput>;
+}

--- a/container/agent-runner/src/adapters/ipc.ts
+++ b/container/agent-runner/src/adapters/ipc.ts
@@ -1,0 +1,60 @@
+import fs from 'fs';
+import path from 'path';
+
+const IPC_DIR = process.env.NANOCLAW_IPC_DIR || '/workspace/ipc';
+const IPC_INPUT_DIR = path.join(IPC_DIR, 'input');
+const IPC_INPUT_CLOSE_SENTINEL = path.join(IPC_INPUT_DIR, '_close');
+
+export function shouldClose(): boolean {
+  if (fs.existsSync(IPC_INPUT_CLOSE_SENTINEL)) {
+    try { fs.unlinkSync(IPC_INPUT_CLOSE_SENTINEL); } catch { }
+    return true;
+  }
+  return false;
+}
+
+const IPC_POLL_MS = 500;
+
+export function drainIpcInput(): string[] {
+  try {
+    fs.mkdirSync(IPC_INPUT_DIR, { recursive: true });
+    const files = fs.readdirSync(IPC_INPUT_DIR)
+      .filter(f => f.endsWith('.json'))
+      .sort();
+
+    const messages: string[] = [];
+    for (const file of files) {
+      const filePath = path.join(IPC_INPUT_DIR, file);
+      try {
+        const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+        fs.unlinkSync(filePath);
+        if (data.type === 'message' && data.text) {
+          messages.push(data.text);
+        }
+      } catch {
+        try { fs.unlinkSync(filePath); } catch { }
+      }
+    }
+    return messages;
+  } catch {
+    return [];
+  }
+}
+
+export function waitForIpcMessage(): Promise<string | null> {
+  return new Promise((resolve) => {
+    const poll = () => {
+      if (shouldClose()) {
+        resolve(null);
+        return;
+      }
+      const messages = drainIpcInput();
+      if (messages.length > 0) {
+        resolve(messages.join('\n'));
+        return;
+      }
+      setTimeout(poll, IPC_POLL_MS);
+    };
+    poll();
+  });
+}

--- a/container/agent-runner/src/adapters/sdk-adapter.ts
+++ b/container/agent-runner/src/adapters/sdk-adapter.ts
@@ -1,0 +1,280 @@
+import fs from 'fs';
+import path from 'path';
+import { query, HookCallback, PreCompactHookInput, PreToolUseHookInput } from '@anthropic-ai/claude-agent-sdk';
+import type { AdapterInput, AgentAdapter, ContainerOutput } from './interface.js';
+import { drainIpcInput, shouldClose } from './ipc.js';
+
+interface SDKUserMessage {
+  type: 'user';
+  message: { role: 'user'; content: string };
+  parent_tool_use_id: null;
+  session_id: string;
+}
+
+interface SessionEntry {
+  sessionId: string;
+  fullPath: string;
+  summary: string;
+  firstPrompt: string;
+}
+
+interface SessionsIndex {
+  entries: SessionEntry[];
+}
+
+const IPC_POLL_MS = 500;
+
+function log(message: string): void {
+  console.error(`[agent-runner] ${message}`);
+}
+
+class MessageStream {
+  private queue: SDKUserMessage[] = [];
+  private waiting: (() => void) | null = null;
+  private done = false;
+
+  push(text: string): void {
+    this.queue.push({
+      type: 'user',
+      message: { role: 'user', content: text },
+      parent_tool_use_id: null,
+      session_id: '',
+    });
+    this.waiting?.();
+  }
+
+  end(): void {
+    this.done = true;
+    this.waiting?.();
+  }
+
+  async *[Symbol.asyncIterator](): AsyncGenerator<SDKUserMessage> {
+    while (true) {
+      while (this.queue.length > 0) {
+        yield this.queue.shift()!;
+      }
+      if (this.done) return;
+      await new Promise<void>(r => { this.waiting = r; });
+      this.waiting = null;
+    }
+  }
+}
+
+function getSessionSummary(sessionId: string, transcriptPath: string): string | null {
+  const projectDir = path.dirname(transcriptPath);
+  const indexPath = path.join(projectDir, 'sessions-index.json');
+  if (!fs.existsSync(indexPath)) return null;
+  try {
+    const index: SessionsIndex = JSON.parse(fs.readFileSync(indexPath, 'utf-8'));
+    const entry = index.entries.find(e => e.sessionId === sessionId);
+    return entry?.summary ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function sanitizeFilename(summary: string): string {
+  return summary
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 50);
+}
+
+function generateFallbackName(): string {
+  const time = new Date();
+  return `conversation-${time.getHours().toString().padStart(2, '0')}${time.getMinutes().toString().padStart(2, '0')}`;
+}
+
+interface ParsedMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+function parseTranscript(content: string): ParsedMessage[] {
+  const messages: ParsedMessage[] = [];
+  for (const line of content.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const entry = JSON.parse(line);
+      if (entry.type === 'user' && entry.message?.content) {
+        const text = typeof entry.message.content === 'string'
+          ? entry.message.content
+          : entry.message.content.map((c: { text?: string }) => c.text || '').join('');
+        if (text) messages.push({ role: 'user', content: text });
+      } else if (entry.type === 'assistant' && entry.message?.content) {
+        const textParts = entry.message.content
+          .filter((c: { type: string }) => c.type === 'text')
+          .map((c: { text: string }) => c.text);
+        const text = textParts.join('');
+        if (text) messages.push({ role: 'assistant', content: text });
+      }
+    } catch { }
+  }
+  return messages;
+}
+
+function formatTranscriptMarkdown(messages: ParsedMessage[], title?: string | null): string {
+  const now = new Date();
+  const formatDateTime = (d: Date) => d.toLocaleString('en-US', {
+    month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit', hour12: true
+  });
+  const lines: string[] = [];
+  lines.push(`# ${title || 'Conversation'}\n`);
+  lines.push(`Archived: ${formatDateTime(now)}\n\n---\n\n`);
+  for (const msg of messages) {
+    const sender = msg.role === 'user' ? 'User' : 'Andy';
+    const content = msg.content.length > 2000 ? msg.content.slice(0, 2000) + '...' : msg.content;
+    lines.push(`**${sender}**: ${content}\n\n`);
+  }
+  return lines.join('');
+}
+
+function createPreCompactHook(): HookCallback {
+  return async (input: unknown, _toolUseId: unknown, _context: unknown) => {
+    const preCompact = input as PreCompactHookInput;
+    const transcriptPath = preCompact.transcript_path;
+    const sessionId = preCompact.session_id;
+    if (!transcriptPath || !fs.existsSync(transcriptPath)) return {};
+    try {
+      const content = fs.readFileSync(transcriptPath, 'utf-8');
+      const messages = parseTranscript(content);
+      if (messages.length === 0) return {};
+      const summary = getSessionSummary(sessionId, transcriptPath);
+      const name = summary ? sanitizeFilename(summary) : generateFallbackName();
+      const conversationsDir = '/workspace/group/conversations';
+      fs.mkdirSync(conversationsDir, { recursive: true });
+      const date = new Date().toISOString().split('T')[0];
+      const filePath = path.join(conversationsDir, `${date}-${name}.md`);
+      fs.writeFileSync(filePath, formatTranscriptMarkdown(messages, summary));
+      log(`Archived conversation to ${filePath}`);
+    } catch (err) {
+      log(`Failed to archive transcript: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    return {};
+  };
+}
+
+const SECRET_ENV_VARS = ['ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN'];
+
+function createSanitizeBashHook(): HookCallback {
+  return async (input: unknown, _toolUseId: unknown, _context: unknown) => {
+    const preInput = input as PreToolUseHookInput;
+    const command = (preInput.tool_input as { command?: string })?.command;
+    if (!command) return {};
+    const unsetPrefix = `unset ${SECRET_ENV_VARS.join(' ')} 2>/dev/null; `;
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        updatedInput: {
+          ...(preInput.tool_input as Record<string, unknown>),
+          command: unsetPrefix + command,
+        },
+      },
+    };
+  };
+}
+
+export const sdkAdapter: AgentAdapter = {
+  async *run(input: AdapterInput) {
+    yield* runSdkQuery(input);
+  },
+};
+
+async function* runSdkQuery(input: AdapterInput): AsyncGenerator<ContainerOutput> {
+  const mcpServerPath = input.mcpServerPath;
+  if (!mcpServerPath) {
+    yield { status: 'error', result: null, error: 'SDK adapter requires mcpServerPath' };
+    return;
+  }
+
+  const stream = new MessageStream();
+  stream.push(input.prompt);
+
+  let ipcPolling = true;
+  let closedDuringQuery = false;
+  const pollIpcDuringQuery = () => {
+    if (!ipcPolling) return;
+    if (shouldClose()) {
+      log('Close sentinel detected during query, ending stream');
+      closedDuringQuery = true;
+      stream.end();
+      ipcPolling = false;
+      return;
+    }
+    for (const text of drainIpcInput()) {
+      log(`Piping IPC message into active query (${text.length} chars)`);
+      stream.push(text);
+    }
+    setTimeout(pollIpcDuringQuery, IPC_POLL_MS);
+  };
+  setTimeout(pollIpcDuringQuery, IPC_POLL_MS);
+
+  let newSessionId: string | undefined;
+  let lastAssistantUuid: string | undefined;
+
+  const extraDirs = input.extraDirs.length > 0 ? input.extraDirs : undefined;
+
+  for await (const message of query({
+    prompt: stream,
+    options: {
+      cwd: input.cwd,
+      additionalDirectories: extraDirs,
+      resume: input.sessionId,
+      resumeSessionAt: input.resumeAt,
+      systemPrompt: input.globalClaudeMd
+        ? { type: 'preset' as const, preset: 'claude_code' as const, append: input.globalClaudeMd }
+        : undefined,
+      allowedTools: [
+        'Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep',
+        'WebSearch', 'WebFetch', 'Task', 'TaskOutput', 'TaskStop',
+        'TeamCreate', 'TeamDelete', 'SendMessage', 'TodoWrite', 'ToolSearch', 'Skill',
+        'NotebookEdit', 'mcp__nanoclaw__*'
+      ],
+      env: input.env,
+      permissionMode: 'bypassPermissions',
+      allowDangerouslySkipPermissions: true,
+      settingSources: ['project', 'user'],
+      mcpServers: {
+        nanoclaw: {
+          command: 'node',
+          args: [mcpServerPath],
+          env: {
+            NANOCLAW_CHAT_JID: input.chatJid,
+            NANOCLAW_GROUP_FOLDER: input.groupFolder,
+            NANOCLAW_IS_MAIN: input.isMain ? '1' : '0',
+          },
+        },
+      },
+      hooks: {
+        PreCompact: [{ hooks: [createPreCompactHook()] }],
+        PreToolUse: [{ matcher: 'Bash', hooks: [createSanitizeBashHook()] }],
+      },
+    }
+  })) {
+    if (message.type === 'assistant' && 'uuid' in message) {
+      lastAssistantUuid = (message as { uuid: string }).uuid;
+    }
+    if (message.type === 'system' && message.subtype === 'init') {
+      newSessionId = message.session_id;
+      log(`Session initialized: ${newSessionId}`);
+    }
+    if (message.type === 'result') {
+      const textResult = 'result' in message ? (message as { result?: string }).result : null;
+      yield {
+        status: 'success',
+        result: textResult || null,
+        newSessionId,
+      };
+    }
+  }
+
+  ipcPolling = false;
+  yield {
+    status: 'success',
+    result: null,
+    newSessionId,
+    closedDuringQuery,
+    resumeAt: lastAssistantUuid,
+  };
+}

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -16,8 +16,11 @@
 
 import fs from 'fs';
 import path from 'path';
-import { query, HookCallback, PreCompactHookInput, PreToolUseHookInput } from '@anthropic-ai/claude-agent-sdk';
 import { fileURLToPath } from 'url';
+import type { AgentAdapter, ContainerOutput } from './adapters/interface.js';
+import { sdkAdapter } from './adapters/sdk-adapter.js';
+import { cliAdapter } from './adapters/cli-adapter.js';
+import { drainIpcInput, waitForIpcMessage } from './adapters/ipc.js';
 
 interface ContainerInput {
   prompt: string;
@@ -29,69 +32,21 @@ interface ContainerInput {
   secrets?: Record<string, string>;
 }
 
-interface ContainerOutput {
-  status: 'success' | 'error';
-  result: string | null;
-  newSessionId?: string;
-  error?: string;
+const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
+const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
+const IPC_DIR = process.env.NANOCLAW_IPC_DIR || '/workspace/ipc';
+const GROUP_DIR = process.env.NANOCLAW_GROUP_DIR || '/workspace/group';
+const GLOBAL_DIR = process.env.NANOCLAW_GLOBAL_DIR || '/workspace/global';
+const EXTRA_DIR = process.env.NANOCLAW_EXTRA_DIR || '/workspace/extra';
+
+function writeOutput(output: ContainerOutput): void {
+  console.log(OUTPUT_START_MARKER);
+  console.log(JSON.stringify(output));
+  console.log(OUTPUT_END_MARKER);
 }
 
-interface SessionEntry {
-  sessionId: string;
-  fullPath: string;
-  summary: string;
-  firstPrompt: string;
-}
-
-interface SessionsIndex {
-  entries: SessionEntry[];
-}
-
-interface SDKUserMessage {
-  type: 'user';
-  message: { role: 'user'; content: string };
-  parent_tool_use_id: null;
-  session_id: string;
-}
-
-const IPC_INPUT_DIR = '/workspace/ipc/input';
-const IPC_INPUT_CLOSE_SENTINEL = path.join(IPC_INPUT_DIR, '_close');
-const IPC_POLL_MS = 500;
-
-/**
- * Push-based async iterable for streaming user messages to the SDK.
- * Keeps the iterable alive until end() is called, preventing isSingleUserTurn.
- */
-class MessageStream {
-  private queue: SDKUserMessage[] = [];
-  private waiting: (() => void) | null = null;
-  private done = false;
-
-  push(text: string): void {
-    this.queue.push({
-      type: 'user',
-      message: { role: 'user', content: text },
-      parent_tool_use_id: null,
-      session_id: '',
-    });
-    this.waiting?.();
-  }
-
-  end(): void {
-    this.done = true;
-    this.waiting?.();
-  }
-
-  async *[Symbol.asyncIterator](): AsyncGenerator<SDKUserMessage> {
-    while (true) {
-      while (this.queue.length > 0) {
-        yield this.queue.shift()!;
-      }
-      if (this.done) return;
-      await new Promise<void>(r => { this.waiting = r; });
-      this.waiting = null;
-    }
-  }
+function log(message: string): void {
+  console.error(`[agent-runner] ${message}`);
 }
 
 async function readStdin(): Promise<string> {
@@ -104,389 +59,12 @@ async function readStdin(): Promise<string> {
   });
 }
 
-const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
-const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
-
-function writeOutput(output: ContainerOutput): void {
-  console.log(OUTPUT_START_MARKER);
-  console.log(JSON.stringify(output));
-  console.log(OUTPUT_END_MARKER);
-}
-
-function log(message: string): void {
-  console.error(`[agent-runner] ${message}`);
-}
-
-function getSessionSummary(sessionId: string, transcriptPath: string): string | null {
-  const projectDir = path.dirname(transcriptPath);
-  const indexPath = path.join(projectDir, 'sessions-index.json');
-
-  if (!fs.existsSync(indexPath)) {
-    log(`Sessions index not found at ${indexPath}`);
-    return null;
+function selectAdapter(): AgentAdapter {
+  const backend = process.env.AGENT_BACKEND || 'sdk';
+  if (backend === 'codex' || backend === 'cursor-agent') {
+    return cliAdapter;
   }
-
-  try {
-    const index: SessionsIndex = JSON.parse(fs.readFileSync(indexPath, 'utf-8'));
-    const entry = index.entries.find(e => e.sessionId === sessionId);
-    if (entry?.summary) {
-      return entry.summary;
-    }
-  } catch (err) {
-    log(`Failed to read sessions index: ${err instanceof Error ? err.message : String(err)}`);
-  }
-
-  return null;
-}
-
-/**
- * Archive the full transcript to conversations/ before compaction.
- */
-function createPreCompactHook(): HookCallback {
-  return async (input, _toolUseId, _context) => {
-    const preCompact = input as PreCompactHookInput;
-    const transcriptPath = preCompact.transcript_path;
-    const sessionId = preCompact.session_id;
-
-    if (!transcriptPath || !fs.existsSync(transcriptPath)) {
-      log('No transcript found for archiving');
-      return {};
-    }
-
-    try {
-      const content = fs.readFileSync(transcriptPath, 'utf-8');
-      const messages = parseTranscript(content);
-
-      if (messages.length === 0) {
-        log('No messages to archive');
-        return {};
-      }
-
-      const summary = getSessionSummary(sessionId, transcriptPath);
-      const name = summary ? sanitizeFilename(summary) : generateFallbackName();
-
-      const conversationsDir = '/workspace/group/conversations';
-      fs.mkdirSync(conversationsDir, { recursive: true });
-
-      const date = new Date().toISOString().split('T')[0];
-      const filename = `${date}-${name}.md`;
-      const filePath = path.join(conversationsDir, filename);
-
-      const markdown = formatTranscriptMarkdown(messages, summary);
-      fs.writeFileSync(filePath, markdown);
-
-      log(`Archived conversation to ${filePath}`);
-    } catch (err) {
-      log(`Failed to archive transcript: ${err instanceof Error ? err.message : String(err)}`);
-    }
-
-    return {};
-  };
-}
-
-// Secrets to strip from Bash tool subprocess environments.
-// These are needed by claude-code for API auth but should never
-// be visible to commands Kit runs.
-const SECRET_ENV_VARS = ['ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN'];
-
-function createSanitizeBashHook(): HookCallback {
-  return async (input, _toolUseId, _context) => {
-    const preInput = input as PreToolUseHookInput;
-    const command = (preInput.tool_input as { command?: string })?.command;
-    if (!command) return {};
-
-    const unsetPrefix = `unset ${SECRET_ENV_VARS.join(' ')} 2>/dev/null; `;
-    return {
-      hookSpecificOutput: {
-        hookEventName: 'PreToolUse',
-        updatedInput: {
-          ...(preInput.tool_input as Record<string, unknown>),
-          command: unsetPrefix + command,
-        },
-      },
-    };
-  };
-}
-
-function sanitizeFilename(summary: string): string {
-  return summary
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, 50);
-}
-
-function generateFallbackName(): string {
-  const time = new Date();
-  return `conversation-${time.getHours().toString().padStart(2, '0')}${time.getMinutes().toString().padStart(2, '0')}`;
-}
-
-interface ParsedMessage {
-  role: 'user' | 'assistant';
-  content: string;
-}
-
-function parseTranscript(content: string): ParsedMessage[] {
-  const messages: ParsedMessage[] = [];
-
-  for (const line of content.split('\n')) {
-    if (!line.trim()) continue;
-    try {
-      const entry = JSON.parse(line);
-      if (entry.type === 'user' && entry.message?.content) {
-        const text = typeof entry.message.content === 'string'
-          ? entry.message.content
-          : entry.message.content.map((c: { text?: string }) => c.text || '').join('');
-        if (text) messages.push({ role: 'user', content: text });
-      } else if (entry.type === 'assistant' && entry.message?.content) {
-        const textParts = entry.message.content
-          .filter((c: { type: string }) => c.type === 'text')
-          .map((c: { text: string }) => c.text);
-        const text = textParts.join('');
-        if (text) messages.push({ role: 'assistant', content: text });
-      }
-    } catch {
-    }
-  }
-
-  return messages;
-}
-
-function formatTranscriptMarkdown(messages: ParsedMessage[], title?: string | null): string {
-  const now = new Date();
-  const formatDateTime = (d: Date) => d.toLocaleString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-    hour12: true
-  });
-
-  const lines: string[] = [];
-  lines.push(`# ${title || 'Conversation'}`);
-  lines.push('');
-  lines.push(`Archived: ${formatDateTime(now)}`);
-  lines.push('');
-  lines.push('---');
-  lines.push('');
-
-  for (const msg of messages) {
-    const sender = msg.role === 'user' ? 'User' : 'Andy';
-    const content = msg.content.length > 2000
-      ? msg.content.slice(0, 2000) + '...'
-      : msg.content;
-    lines.push(`**${sender}**: ${content}`);
-    lines.push('');
-  }
-
-  return lines.join('\n');
-}
-
-/**
- * Check for _close sentinel.
- */
-function shouldClose(): boolean {
-  if (fs.existsSync(IPC_INPUT_CLOSE_SENTINEL)) {
-    try { fs.unlinkSync(IPC_INPUT_CLOSE_SENTINEL); } catch { /* ignore */ }
-    return true;
-  }
-  return false;
-}
-
-/**
- * Drain all pending IPC input messages.
- * Returns messages found, or empty array.
- */
-function drainIpcInput(): string[] {
-  try {
-    fs.mkdirSync(IPC_INPUT_DIR, { recursive: true });
-    const files = fs.readdirSync(IPC_INPUT_DIR)
-      .filter(f => f.endsWith('.json'))
-      .sort();
-
-    const messages: string[] = [];
-    for (const file of files) {
-      const filePath = path.join(IPC_INPUT_DIR, file);
-      try {
-        const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-        fs.unlinkSync(filePath);
-        if (data.type === 'message' && data.text) {
-          messages.push(data.text);
-        }
-      } catch (err) {
-        log(`Failed to process input file ${file}: ${err instanceof Error ? err.message : String(err)}`);
-        try { fs.unlinkSync(filePath); } catch { /* ignore */ }
-      }
-    }
-    return messages;
-  } catch (err) {
-    log(`IPC drain error: ${err instanceof Error ? err.message : String(err)}`);
-    return [];
-  }
-}
-
-/**
- * Wait for a new IPC message or _close sentinel.
- * Returns the messages as a single string, or null if _close.
- */
-function waitForIpcMessage(): Promise<string | null> {
-  return new Promise((resolve) => {
-    const poll = () => {
-      if (shouldClose()) {
-        resolve(null);
-        return;
-      }
-      const messages = drainIpcInput();
-      if (messages.length > 0) {
-        resolve(messages.join('\n'));
-        return;
-      }
-      setTimeout(poll, IPC_POLL_MS);
-    };
-    poll();
-  });
-}
-
-/**
- * Run a single query and stream results via writeOutput.
- * Uses MessageStream (AsyncIterable) to keep isSingleUserTurn=false,
- * allowing agent teams subagents to run to completion.
- * Also pipes IPC messages into the stream during the query.
- */
-async function runQuery(
-  prompt: string,
-  sessionId: string | undefined,
-  mcpServerPath: string,
-  containerInput: ContainerInput,
-  sdkEnv: Record<string, string | undefined>,
-  resumeAt?: string,
-): Promise<{ newSessionId?: string; lastAssistantUuid?: string; closedDuringQuery: boolean }> {
-  const stream = new MessageStream();
-  stream.push(prompt);
-
-  // Poll IPC for follow-up messages and _close sentinel during the query
-  let ipcPolling = true;
-  let closedDuringQuery = false;
-  const pollIpcDuringQuery = () => {
-    if (!ipcPolling) return;
-    if (shouldClose()) {
-      log('Close sentinel detected during query, ending stream');
-      closedDuringQuery = true;
-      stream.end();
-      ipcPolling = false;
-      return;
-    }
-    const messages = drainIpcInput();
-    for (const text of messages) {
-      log(`Piping IPC message into active query (${text.length} chars)`);
-      stream.push(text);
-    }
-    setTimeout(pollIpcDuringQuery, IPC_POLL_MS);
-  };
-  setTimeout(pollIpcDuringQuery, IPC_POLL_MS);
-
-  let newSessionId: string | undefined;
-  let lastAssistantUuid: string | undefined;
-  let messageCount = 0;
-  let resultCount = 0;
-
-  // Load global CLAUDE.md as additional system context (shared across all groups)
-  const globalClaudeMdPath = '/workspace/global/CLAUDE.md';
-  let globalClaudeMd: string | undefined;
-  if (!containerInput.isMain && fs.existsSync(globalClaudeMdPath)) {
-    globalClaudeMd = fs.readFileSync(globalClaudeMdPath, 'utf-8');
-  }
-
-  // Discover additional directories mounted at /workspace/extra/*
-  // These are passed to the SDK so their CLAUDE.md files are loaded automatically
-  const extraDirs: string[] = [];
-  const extraBase = '/workspace/extra';
-  if (fs.existsSync(extraBase)) {
-    for (const entry of fs.readdirSync(extraBase)) {
-      const fullPath = path.join(extraBase, entry);
-      if (fs.statSync(fullPath).isDirectory()) {
-        extraDirs.push(fullPath);
-      }
-    }
-  }
-  if (extraDirs.length > 0) {
-    log(`Additional directories: ${extraDirs.join(', ')}`);
-  }
-
-  for await (const message of query({
-    prompt: stream,
-    options: {
-      cwd: '/workspace/group',
-      additionalDirectories: extraDirs.length > 0 ? extraDirs : undefined,
-      resume: sessionId,
-      resumeSessionAt: resumeAt,
-      systemPrompt: globalClaudeMd
-        ? { type: 'preset' as const, preset: 'claude_code' as const, append: globalClaudeMd }
-        : undefined,
-      allowedTools: [
-        'Bash',
-        'Read', 'Write', 'Edit', 'Glob', 'Grep',
-        'WebSearch', 'WebFetch',
-        'Task', 'TaskOutput', 'TaskStop',
-        'TeamCreate', 'TeamDelete', 'SendMessage',
-        'TodoWrite', 'ToolSearch', 'Skill',
-        'NotebookEdit',
-        'mcp__nanoclaw__*'
-      ],
-      env: sdkEnv,
-      permissionMode: 'bypassPermissions',
-      allowDangerouslySkipPermissions: true,
-      settingSources: ['project', 'user'],
-      mcpServers: {
-        nanoclaw: {
-          command: 'node',
-          args: [mcpServerPath],
-          env: {
-            NANOCLAW_CHAT_JID: containerInput.chatJid,
-            NANOCLAW_GROUP_FOLDER: containerInput.groupFolder,
-            NANOCLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
-          },
-        },
-      },
-      hooks: {
-        PreCompact: [{ hooks: [createPreCompactHook()] }],
-        PreToolUse: [{ matcher: 'Bash', hooks: [createSanitizeBashHook()] }],
-      },
-    }
-  })) {
-    messageCount++;
-    const msgType = message.type === 'system' ? `system/${(message as { subtype?: string }).subtype}` : message.type;
-    log(`[msg #${messageCount}] type=${msgType}`);
-
-    if (message.type === 'assistant' && 'uuid' in message) {
-      lastAssistantUuid = (message as { uuid: string }).uuid;
-    }
-
-    if (message.type === 'system' && message.subtype === 'init') {
-      newSessionId = message.session_id;
-      log(`Session initialized: ${newSessionId}`);
-    }
-
-    if (message.type === 'system' && (message as { subtype?: string }).subtype === 'task_notification') {
-      const tn = message as { task_id: string; status: string; summary: string };
-      log(`Task notification: task=${tn.task_id} status=${tn.status} summary=${tn.summary}`);
-    }
-
-    if (message.type === 'result') {
-      resultCount++;
-      const textResult = 'result' in message ? (message as { result?: string }).result : null;
-      log(`Result #${resultCount}: subtype=${message.subtype}${textResult ? ` text=${textResult.slice(0, 200)}` : ''}`);
-      writeOutput({
-        status: 'success',
-        result: textResult || null,
-        newSessionId
-      });
-    }
-  }
-
-  ipcPolling = false;
-  log(`Query done. Messages: ${messageCount}, results: ${resultCount}, lastAssistantUuid: ${lastAssistantUuid || 'none'}, closedDuringQuery: ${closedDuringQuery}`);
-  return { newSessionId, lastAssistantUuid, closedDuringQuery };
+  return sdkAdapter;
 }
 
 async function main(): Promise<void> {
@@ -495,8 +73,7 @@ async function main(): Promise<void> {
   try {
     const stdinData = await readStdin();
     containerInput = JSON.parse(stdinData);
-    // Delete the temp file the entrypoint wrote — it contains secrets
-    try { fs.unlinkSync('/tmp/input.json'); } catch { /* may not exist */ }
+    try { fs.unlinkSync('/tmp/input.json'); } catch { }
     log(`Received input for group: ${containerInput.groupFolder}`);
   } catch (err) {
     writeOutput({
@@ -507,8 +84,6 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  // Build SDK env: merge secrets into process.env for the SDK only.
-  // Secrets never touch process.env itself, so Bash subprocesses can't see them.
   const sdkEnv: Record<string, string | undefined> = { ...process.env };
   for (const [key, value] of Object.entries(containerInput.secrets || {})) {
     sdkEnv[key] = value;
@@ -517,13 +92,10 @@ async function main(): Promise<void> {
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
   const mcpServerPath = path.join(__dirname, 'ipc-mcp-stdio.js');
 
-  let sessionId = containerInput.sessionId;
-  fs.mkdirSync(IPC_INPUT_DIR, { recursive: true });
+  const ipcInputDir = path.join(IPC_DIR, 'input');
+  fs.mkdirSync(ipcInputDir, { recursive: true });
+  try { fs.unlinkSync(path.join(ipcInputDir, '_close')); } catch { }
 
-  // Clean up stale _close sentinel from previous container runs
-  try { fs.unlinkSync(IPC_INPUT_CLOSE_SENTINEL); } catch { /* ignore */ }
-
-  // Build initial prompt (drain any pending IPC messages too)
   let prompt = containerInput.prompt;
   if (containerInput.isScheduledTask) {
     prompt = `[SCHEDULED TASK - The following message was sent automatically and is not coming directly from the user or group.]\n\n${prompt}`;
@@ -534,34 +106,66 @@ async function main(): Promise<void> {
     prompt += '\n' + pending.join('\n');
   }
 
-  // Query loop: run query → wait for IPC message → run new query → repeat
+  const globalClaudeMdPath = path.join(GLOBAL_DIR, 'CLAUDE.md');
+  let globalClaudeMd: string | undefined;
+  if (!containerInput.isMain && fs.existsSync(globalClaudeMdPath)) {
+    globalClaudeMd = fs.readFileSync(globalClaudeMdPath, 'utf-8');
+  }
+
+  const extraDirs: string[] = [];
+  if (fs.existsSync(EXTRA_DIR)) {
+    for (const entry of fs.readdirSync(EXTRA_DIR)) {
+      const fullPath = path.join(EXTRA_DIR, entry);
+      if (fs.statSync(fullPath).isDirectory()) {
+        extraDirs.push(fullPath);
+      }
+    }
+  }
+
+  let sessionId = containerInput.sessionId;
   let resumeAt: string | undefined;
+
   try {
+    const adapter = selectAdapter();
+
     while (true) {
       log(`Starting query (session: ${sessionId || 'new'}, resumeAt: ${resumeAt || 'latest'})...`);
 
-      const queryResult = await runQuery(prompt, sessionId, mcpServerPath, containerInput, sdkEnv, resumeAt);
-      if (queryResult.newSessionId) {
-        sessionId = queryResult.newSessionId;
-      }
-      if (queryResult.lastAssistantUuid) {
-        resumeAt = queryResult.lastAssistantUuid;
+      const adapterInput = {
+        prompt,
+        sessionId,
+        resumeAt,
+        cwd: GROUP_DIR,
+        env: sdkEnv,
+        groupFolder: containerInput.groupFolder,
+        chatJid: containerInput.chatJid,
+        isMain: containerInput.isMain,
+        globalClaudeMd,
+        extraDirs,
+        mcpServerPath,
+      };
+
+      let lastOutput: ContainerOutput | undefined;
+      for await (const output of adapter.run(adapterInput)) {
+        lastOutput = output;
+        writeOutput(output);
       }
 
-      // If _close was consumed during the query, exit immediately.
-      // Don't emit a session-update marker (it would reset the host's
-      // idle timer and cause a 30-min delay before the next _close).
-      if (queryResult.closedDuringQuery) {
+      if (lastOutput?.newSessionId) {
+        sessionId = lastOutput.newSessionId;
+      }
+      if (lastOutput?.resumeAt) {
+        resumeAt = lastOutput.resumeAt;
+      }
+
+      if (lastOutput?.closedDuringQuery) {
         log('Close sentinel consumed during query, exiting');
         break;
       }
 
-      // Emit session update so host can track it
       writeOutput({ status: 'success', result: null, newSessionId: sessionId });
-
       log('Query ended, waiting for next IPC message...');
 
-      // Wait for the next message or _close sentinel
       const nextMessage = await waitForIpcMessage();
       if (nextMessage === null) {
         log('Close sentinel received, exiting');

--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -11,7 +11,7 @@ import fs from 'fs';
 import path from 'path';
 import { CronExpressionParser } from 'cron-parser';
 
-const IPC_DIR = '/workspace/ipc';
+const IPC_DIR = process.env.NANOCLAW_IPC_DIR || '/workspace/ipc';
 const MESSAGES_DIR = path.join(IPC_DIR, 'messages');
 const TASKS_DIR = path.join(IPC_DIR, 'tasks');
 

--- a/docs/CLI-ADAPTER.md
+++ b/docs/CLI-ADAPTER.md
@@ -1,0 +1,63 @@
+# CLI Agent Adapter
+
+NanoClaw can run LLM conversations through a local CLI adapter instead of the SDK token path.
+
+Supported CLI backends:
+
+- `AGENT_BACKEND=codex`
+- `AGENT_BACKEND=cursor-agent`
+
+## Required .env settings
+
+```bash
+AGENT_BACKEND=codex
+```
+
+or:
+
+```bash
+AGENT_BACKEND=cursor-agent
+```
+
+## How it works
+
+1. NanoClaw receives incoming messages from the configured channel.
+2. The container agent-runner selects the CLI adapter.
+3. Adapter executes one of:
+
+```bash
+codex exec -C /workspace/group --dangerously-bypass-approvals-and-sandbox --json -
+```
+
+```bash
+cursor-agent -p --trust --workspace /workspace/group --output-format text "<prompt>"
+```
+
+4. Prompt/response is parsed and returned through NanoClaw's output protocol.
+
+## Capability differences vs SDK backend
+
+With CLI backends (`codex` or `cursor-agent`):
+
+- No MCP tool integration (`send_message`, task tools, etc.)
+- No Agent Teams orchestration
+- No SDK session resume semantics
+- Conversational CLI execution only
+
+## Optional overrides
+
+- `AGENT_CLI_CMD`: override executable path/name
+- `AGENT_CLI_ARGS`: JSON array of extra args (optional, applied to Codex preset)
+- `AGENT_CLI_OUTPUT_FORMAT`: `text` (default) or `json` for Cursor preset
+- `CONTAINER_TIMEOUT`: timeout in ms (default `1800000`)
+
+## Runtime notes
+
+- Container image installs Codex CLI by default.
+- Cursor CLI binary must be available in runtime PATH (or configured via `AGENT_CLI_CMD`).
+
+## Troubleshooting
+
+- `AGENT_BACKEND must be "codex" or "cursor-agent"`: set one of those in `.env`
+- `CLI exited with code ...`: verify selected CLI binary is installed and runnable
+- No responses: check `logs/nanoclaw.error.log` and group container logs under `groups/main/logs/`

--- a/docs/SETUP-MANUAL.md
+++ b/docs/SETUP-MANUAL.md
@@ -1,0 +1,78 @@
+# NanoClaw Manual Setup (CLI Backends)
+
+This guide sets up NanoClaw with:
+
+- your existing NanoClaw chat channel setup
+- Codex CLI or Cursor Agent CLI as the LLM backend
+- No API-token-based SDK flow
+
+## Prerequisites
+
+- Node.js 20+
+- Docker running
+- CLI binary for the backend you choose:
+  - `codex` for `AGENT_BACKEND=codex` (installed in the container image by default)
+  - `cursor-agent` for `AGENT_BACKEND=cursor-agent` (must be available in runtime PATH or configured via `AGENT_CLI_CMD`)
+
+## Step 1: Install dependencies
+
+```bash
+npm install
+```
+
+## Step 2: Build the container image
+
+```bash
+./.claude/skills/setup/scripts/03-setup-container.sh --runtime docker
+```
+
+## Step 3: Configure `.env`
+
+Create `.env` in project root:
+
+```bash
+AGENT_BACKEND=codex
+```
+
+Notes:
+
+- Set `AGENT_BACKEND=cursor-agent` to use Cursor instead.
+- Optional Codex local-model mode: `AGENT_CLI_ARGS=["--oss","--local-provider=ollama"]`
+- Optional Cursor JSON output: `AGENT_CLI_OUTPUT_FORMAT=json`
+- Optional CLI path override: `AGENT_CLI_CMD=/path/to/your/cli`
+
+## Step 4: Start NanoClaw
+
+```bash
+npm run build
+npm start
+```
+
+Or use the service script:
+
+```bash
+./.claude/skills/setup/scripts/08-setup-service.sh
+```
+
+## Step 5: Verify conversation
+
+Send:
+
+```text
+@Andy hello
+```
+
+(or your configured assistant name)
+
+Then check logs if needed:
+
+```bash
+tail -f logs/nanoclaw.log
+tail -f logs/nanoclaw.error.log
+```
+
+## Troubleshooting
+
+- `AGENT_BACKEND must be "codex" or "cursor-agent"`: set one of these values in `.env`
+- `CLI exited with code ...`: ensure the selected CLI binary is installed and runnable
+- CLI failures: inspect latest `groups/main/logs/container-*.log`

--- a/scripts/run-with-docker.sh
+++ b/scripts/run-with-docker.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+NODE="${NANOCLAW_NODE:-$(command -v node)}"
+exec sg docker -c "exec $NODE $ROOT/dist/index.js"


### PR DESCRIPTION
## Summary
- add optional local CLI backends for agent execution:
  - `AGENT_BACKEND=codex`
  - `AGENT_BACKEND=cursor-agent`
- keep `sdk` as default backend for backward compatibility
- split container agent-runner into adapter-based architecture (`sdk` vs `cli`)
- add CLI backend configuration plumbing and docs

## Configuration
- `AGENT_BACKEND` (`sdk` default)
- `AGENT_CLI_CMD`
- `AGENT_CLI_ARGS`
- `AGENT_CLI_OUTPUT_FORMAT`
- `NANOCLAW_RUNNER_HOT_RELOAD`

## Runtime behavior
- Codex path uses JSON event output parsing for assistant text
- Cursor path supports text/json output modes
- timeout and non-zero exits return structured errors to NanoClaw

## Docs
- update README + `docs/CLI-ADAPTER.md`
- update setup/manual docs and docker runtime notes

## Testing
- `npm test`
- `npm run build`
