### PR TITLE
feat: add persistent markdown task state with boot resume

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,6 @@
-
+# Persistent host markdown layer (enabled by default)
+# Keeps durable progress state per group and optional personality guidance.
+# PERSISTENCE_ENABLED=true
+# PERSISTENCE_ROOT=data/persistence
+# PERSISTENCE_AUTO_RESUME_ON_BOOT=true
+# PERSISTENCE_INCLUDE_PERSONALITY=true

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,10 @@ import { readEnvFile } from './env.js';
 const envConfig = readEnvFile([
   'ASSISTANT_NAME',
   'ASSISTANT_HAS_OWN_NUMBER',
+  'PERSISTENCE_ENABLED',
+  'PERSISTENCE_ROOT',
+  'PERSISTENCE_AUTO_RESUME_ON_BOOT',
+  'PERSISTENCE_INCLUDE_PERSONALITY',
 ]);
 
 export const ASSISTANT_NAME =
@@ -66,3 +70,32 @@ export const TRIGGER_PATTERN = new RegExp(
 // Uses system timezone by default
 export const TIMEZONE =
   process.env.TZ || Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+function parseBoolean(value: string | undefined, defaultValue: boolean): boolean {
+  if (value == null || value === '') return defaultValue;
+  const normalized = value.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+  return defaultValue;
+}
+
+function resolvePathFromProject(candidate: string): string {
+  if (path.isAbsolute(candidate)) return candidate;
+  return path.resolve(PROJECT_ROOT, candidate);
+}
+
+export const PERSISTENCE_ENABLED = parseBoolean(
+  process.env.PERSISTENCE_ENABLED || envConfig.PERSISTENCE_ENABLED,
+  true,
+);
+export const PERSISTENCE_ROOT = resolvePathFromProject(
+  process.env.PERSISTENCE_ROOT || envConfig.PERSISTENCE_ROOT || 'data/persistence',
+);
+export const PERSISTENCE_AUTO_RESUME_ON_BOOT = parseBoolean(
+  process.env.PERSISTENCE_AUTO_RESUME_ON_BOOT || envConfig.PERSISTENCE_AUTO_RESUME_ON_BOOT,
+  true,
+);
+export const PERSISTENCE_INCLUDE_PERSONALITY = parseBoolean(
+  process.env.PERSISTENCE_INCLUDE_PERSONALITY || envConfig.PERSISTENCE_INCLUDE_PERSONALITY,
+  true,
+);

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -14,6 +14,8 @@ vi.mock('./config.js', () => ({
   DATA_DIR: '/tmp/nanoclaw-test-data',
   GROUPS_DIR: '/tmp/nanoclaw-test-groups',
   IDLE_TIMEOUT: 1800000, // 30min
+  PERSISTENCE_ENABLED: true,
+  PERSISTENCE_ROOT: '/tmp/nanoclaw-test-persistence',
 }));
 
 // Mock logger

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -14,6 +14,8 @@ import {
   DATA_DIR,
   GROUPS_DIR,
   IDLE_TIMEOUT,
+  PERSISTENCE_ENABLED,
+  PERSISTENCE_ROOT,
 } from './config.js';
 import { readEnvFile } from './env.js';
 import { logger } from './logger.js';
@@ -98,6 +100,16 @@ function buildVolumeMounts(
         readonly: true,
       });
     }
+  }
+
+  if (PERSISTENCE_ENABLED) {
+    const groupPersistenceDir = path.join(PERSISTENCE_ROOT, group.folder);
+    fs.mkdirSync(groupPersistenceDir, { recursive: true });
+    mounts.push({
+      hostPath: groupPersistenceDir,
+      containerPath: '/workspace/persistence',
+      readonly: false,
+    });
   }
 
   // Per-group Claude sessions directory (isolated from other groups)

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,14 @@ import { findChannel, formatMessages, formatOutbound } from './router.js';
 import { startSchedulerLoop } from './task-scheduler.js';
 import { Channel, NewMessage, RegisteredGroup } from './types.js';
 import { logger } from './logger.js';
+import {
+  buildPromptWithPersistence,
+  ensureGroupPersistenceFiles,
+  markBootResumeQueued,
+  markTaskRunEnd,
+  markTaskRunStart,
+  shouldQueueBootResume,
+} from './persistent-state.js';
 
 // Re-export for backwards compatibility during refactor
 export { escapeXml, formatMessages } from './router.js';
@@ -143,7 +151,10 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     if (!hasTrigger) return true;
   }
 
-  const prompt = formatMessages(missedMessages);
+  ensureGroupPersistenceFiles(group.folder);
+  const basePrompt = formatMessages(missedMessages);
+  const prompt = buildPromptWithPersistence(basePrompt, group.folder);
+  markTaskRunStart(group.folder, basePrompt, 'chat');
 
   // Advance cursor so the piping path in startMessageLoop won't re-fetch
   // these messages. Save the old cursor so we can roll back on error.
@@ -171,6 +182,8 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   await channel.setTyping?.(chatJid, true);
   let hadError = false;
   let outputSentToUser = false;
+  let lastTextOutput: string | null = null;
+  let lastError: string | null = null;
 
   const output = await runAgent(group, prompt, chatJid, async (result) => {
     // Streaming output callback — called for each agent result
@@ -180,6 +193,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
       const text = raw.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
       logger.info({ group: group.name }, `Agent output: ${raw.slice(0, 200)}`);
       if (text) {
+        lastTextOutput = text;
         await channel.sendMessage(chatJid, text);
         outputSentToUser = true;
       }
@@ -189,6 +203,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
 
     if (result.status === 'error') {
       hadError = true;
+      lastError = result.error || 'Unknown error';
     }
   });
 
@@ -196,6 +211,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   if (idleTimer) clearTimeout(idleTimer);
 
   if (output === 'error' || hadError) {
+    markTaskRunEnd(group.folder, 'error', lastTextOutput, lastError);
     // If we already sent output to the user, don't roll back the cursor —
     // the user got their response and re-processing would send duplicates.
     if (outputSentToUser) {
@@ -209,6 +225,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     return false;
   }
 
+  markTaskRunEnd(group.folder, 'success', lastTextOutput, null);
   return true;
 }
 
@@ -398,6 +415,33 @@ function recoverPendingMessages(): void {
   }
 }
 
+function recoverPersistentProgress(): void {
+  for (const [chatJid, group] of Object.entries(registeredGroups)) {
+    if (!shouldQueueBootResume(group.folder)) continue;
+
+    const timestamp = new Date().toISOString();
+    const syntheticMessage = `@${ASSISTANT_NAME} Continue the interrupted work from /workspace/persistence/task-progress.md. Resume from the latest checkpoint, update the file with current status, and finish any remaining steps.`;
+
+    storeChatMetadata(chatJid, timestamp, group.name);
+    storeMessage({
+      id: `resume-${group.folder}-${Date.now()}`,
+      chat_jid: chatJid,
+      sender: 'nanoclaw-system',
+      sender_name: 'NanoClaw System',
+      content: syntheticMessage,
+      timestamp,
+      is_from_me: false,
+      is_bot_message: false,
+    });
+    markBootResumeQueued(group.folder);
+    queue.enqueueMessageCheck(chatJid);
+    logger.info(
+      { group: group.name, chatJid },
+      'Boot recovery queued persistent continuation',
+    );
+  }
+}
+
 function ensureContainerSystemRunning(): void {
   ensureContainerRuntimeRunning();
   cleanupOrphans();
@@ -461,6 +505,7 @@ async function main(): Promise<void> {
     writeGroupsSnapshot: (gf, im, ag, rj) => writeGroupsSnapshot(gf, im, ag, rj),
   });
   queue.setProcessMessagesFn(processGroupMessages);
+  recoverPersistentProgress();
   recoverPendingMessages();
   startMessageLoop();
 }

--- a/src/persistent-state.test.ts
+++ b/src/persistent-state.test.ts
@@ -1,0 +1,112 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const ENV_KEYS = [
+  'PERSISTENCE_ENABLED',
+  'PERSISTENCE_ROOT',
+  'PERSISTENCE_AUTO_RESUME_ON_BOOT',
+  'PERSISTENCE_INCLUDE_PERSONALITY',
+] as const;
+
+function backupEnv(): Record<string, string | undefined> {
+  const out: Record<string, string | undefined> = {};
+  for (const key of ENV_KEYS) out[key] = process.env[key];
+  return out;
+}
+
+function restoreEnv(snapshot: Record<string, string | undefined>): void {
+  for (const key of ENV_KEYS) {
+    const value = snapshot[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+function readTaskFile(root: string, group: string): string {
+  return fs.readFileSync(path.join(root, group, 'task-progress.md'), 'utf8');
+}
+
+describe('persistent-state', () => {
+  let tempRoot = '';
+  const envSnapshot = backupEnv();
+
+  afterEach(() => {
+    restoreEnv(envSnapshot);
+    vi.resetModules();
+    if (tempRoot) {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+      tempRoot = '';
+    }
+  });
+
+  async function loadModule() {
+    tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-persist-'));
+    process.env.PERSISTENCE_ENABLED = 'true';
+    process.env.PERSISTENCE_ROOT = tempRoot;
+    process.env.PERSISTENCE_AUTO_RESUME_ON_BOOT = 'true';
+    process.env.PERSISTENCE_INCLUDE_PERSONALITY = 'true';
+    vi.resetModules();
+    return import('./persistent-state.js');
+  }
+
+  it('creates task-progress file and embeds state metadata marker', async () => {
+    const mod = await loadModule();
+    mod.ensureGroupPersistenceFiles('group-a');
+    const taskFile = readTaskFile(tempRoot, 'group-a');
+    expect(taskFile).toContain('NANOCLAW_STATE');
+    expect(taskFile).toContain('# Task Progress');
+  });
+
+  it('marks start/end transitions and controls boot resume flag', async () => {
+    const mod = await loadModule();
+    mod.ensureGroupPersistenceFiles('group-b');
+    mod.markTaskRunStart('group-b', 'Investigate deployment incident', 'chat');
+
+    expect(mod.shouldQueueBootResume('group-b')).toBe(true);
+    const started = readTaskFile(tempRoot, 'group-b');
+    expect(started).toContain('status: in_progress');
+    expect(started).toContain('resume_on_boot: true');
+
+    mod.markTaskRunEnd('group-b', 'success', 'Work complete', null);
+    expect(mod.shouldQueueBootResume('group-b')).toBe(false);
+    const finished = readTaskFile(tempRoot, 'group-b');
+    expect(finished).toContain('status: idle');
+    expect(finished).toContain('resume_on_boot: false');
+  });
+
+  it('injects personality and progress context into prompt', async () => {
+    const mod = await loadModule();
+    mod.ensureGroupPersistenceFiles('group-c');
+    const paths = mod.getPersistencePaths('group-c');
+    fs.writeFileSync(paths.personalityFile, '# Personality\nBe concise and direct.\n');
+
+    const prompt = mod.buildPromptWithPersistence(
+      '<messages><message>hello</message></messages>',
+      'group-c',
+    );
+
+    expect(prompt).toContain('/workspace/persistence/task-progress.md');
+    expect(prompt).toContain('/workspace/persistence/personality.md');
+    expect(prompt).toContain('Be concise and direct.');
+    expect(prompt).toContain('<messages><message>hello</message></messages>');
+  });
+
+  it('marks boot resume as queued to avoid repeating forever', async () => {
+    const mod = await loadModule();
+    mod.ensureGroupPersistenceFiles('group-d');
+    mod.markTaskRunStart('group-d', 'Long running task', 'scheduled');
+    expect(mod.shouldQueueBootResume('group-d')).toBe(true);
+
+    mod.markBootResumeQueued('group-d');
+    expect(mod.shouldQueueBootResume('group-d')).toBe(false);
+    const file = readTaskFile(tempRoot, 'group-d');
+    expect(file).toContain('status: resuming');
+    expect(file).toContain('resume_on_boot: false');
+  });
+});

--- a/src/persistent-state.ts
+++ b/src/persistent-state.ts
@@ -1,0 +1,348 @@
+import fs from 'fs';
+import path from 'path';
+
+import {
+  PERSISTENCE_AUTO_RESUME_ON_BOOT,
+  PERSISTENCE_ENABLED,
+  PERSISTENCE_INCLUDE_PERSONALITY,
+  PERSISTENCE_ROOT,
+} from './config.js';
+import { logger } from './logger.js';
+
+const STATE_MARKER = 'NANOCLAW_STATE';
+const STATE_BLOCK_RE = /<!--\s*NANOCLAW_STATE\n([\s\S]*?)\n-->\n?/m;
+const PROMPT_PROGRESS_MAX_CHARS = 12_000;
+const PROMPT_PERSONALITY_MAX_CHARS = 6_000;
+
+type PersistentStatus = 'idle' | 'in_progress' | 'resuming' | 'error';
+type ExecutionSource = 'chat' | 'scheduled' | 'boot_resume';
+
+interface ProgressMetadata {
+  status: PersistentStatus;
+  resume_on_boot: boolean;
+  last_source: string;
+  last_started_at: string;
+  last_finished_at: string;
+  last_updated_at: string;
+  last_prompt_summary: string;
+  last_result_summary: string;
+}
+
+interface ParsedStateFile {
+  metadata: ProgressMetadata;
+  body: string;
+}
+
+const DEFAULT_BODY = `# Task Progress
+
+Use this file to keep durable progress notes across restarts.
+
+## Current Checklist
+- [ ] Update this checklist as work progresses
+
+## Progress Log
+`;
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function sanitizeSummary(text: string, max = 280): string {
+  const collapsed = text.replace(/\s+/g, ' ').trim();
+  if (collapsed.length <= max) return collapsed;
+  return `${collapsed.slice(0, max)}...`;
+}
+
+function clipForPrompt(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  const omitted = text.length - maxChars;
+  return `${text.slice(0, maxChars)}\n\n...[TRUNCATED ${omitted} chars]`;
+}
+
+function defaultMetadata(): ProgressMetadata {
+  return {
+    status: 'idle',
+    resume_on_boot: false,
+    last_source: '',
+    last_started_at: '',
+    last_finished_at: '',
+    last_updated_at: '',
+    last_prompt_summary: '',
+    last_result_summary: '',
+  };
+}
+
+function parseBoolean(value: string | undefined): boolean {
+  if (!value) return false;
+  return value.trim().toLowerCase() === 'true';
+}
+
+function parseStateFile(content: string): ParsedStateFile {
+  const defaults = defaultMetadata();
+  const match = content.match(STATE_BLOCK_RE);
+  if (!match) {
+    return { metadata: defaults, body: content || DEFAULT_BODY };
+  }
+
+  const metadata = { ...defaults };
+  for (const line of match[1].split('\n')) {
+    const idx = line.indexOf(':');
+    if (idx === -1) continue;
+    const key = line.slice(0, idx).trim();
+    const value = line.slice(idx + 1).trim();
+    switch (key) {
+      case 'status':
+        if (value === 'idle' || value === 'in_progress' || value === 'resuming' || value === 'error') {
+          metadata.status = value;
+        }
+        break;
+      case 'resume_on_boot':
+        metadata.resume_on_boot = parseBoolean(value);
+        break;
+      case 'last_source':
+        metadata.last_source = value;
+        break;
+      case 'last_started_at':
+        metadata.last_started_at = value;
+        break;
+      case 'last_finished_at':
+        metadata.last_finished_at = value;
+        break;
+      case 'last_updated_at':
+        metadata.last_updated_at = value;
+        break;
+      case 'last_prompt_summary':
+        metadata.last_prompt_summary = value;
+        break;
+      case 'last_result_summary':
+        metadata.last_result_summary = value;
+        break;
+      default:
+        break;
+    }
+  }
+
+  const body = content.replace(STATE_BLOCK_RE, '').trimStart() || DEFAULT_BODY;
+  return { metadata, body };
+}
+
+function serializeStateFile(parsed: ParsedStateFile): string {
+  const metadataLines = [
+    `status: ${parsed.metadata.status}`,
+    `resume_on_boot: ${parsed.metadata.resume_on_boot ? 'true' : 'false'}`,
+    `last_source: ${parsed.metadata.last_source}`,
+    `last_started_at: ${parsed.metadata.last_started_at}`,
+    `last_finished_at: ${parsed.metadata.last_finished_at}`,
+    `last_updated_at: ${parsed.metadata.last_updated_at}`,
+    `last_prompt_summary: ${parsed.metadata.last_prompt_summary}`,
+    `last_result_summary: ${parsed.metadata.last_result_summary}`,
+  ];
+
+  const header = [
+    `<!-- ${STATE_MARKER}`,
+    ...metadataLines,
+    '-->',
+    '',
+  ].join('\n');
+
+  return `${header}${parsed.body.trimStart()}\n`;
+}
+
+function appendProgressLog(body: string, title: string, details: string): string {
+  const ts = nowIso();
+  const entry = [
+    `### ${ts} - ${title}`,
+    details,
+    '',
+  ].join('\n');
+  return `${body.trimEnd()}\n\n${entry}`;
+}
+
+function withStateFile(
+  groupFolder: string,
+  updater: (parsed: ParsedStateFile) => ParsedStateFile,
+): void {
+  if (!PERSISTENCE_ENABLED) return;
+  const paths = getPersistencePaths(groupFolder);
+  ensureGroupPersistenceFiles(groupFolder);
+
+  try {
+    const content = fs.readFileSync(paths.taskProgressFile, 'utf8');
+    const updated = updater(parseStateFile(content));
+    fs.writeFileSync(paths.taskProgressFile, serializeStateFile(updated), 'utf8');
+  } catch (err) {
+    logger.warn(
+      { err, groupFolder, file: paths.taskProgressFile },
+      'Failed to update persistence state file',
+    );
+  }
+}
+
+export function getPersistencePaths(groupFolder: string): {
+  dir: string;
+  taskProgressFile: string;
+  personalityFile: string;
+} {
+  const dir = path.join(PERSISTENCE_ROOT, groupFolder);
+  return {
+    dir,
+    taskProgressFile: path.join(dir, 'task-progress.md'),
+    personalityFile: path.join(dir, 'personality.md'),
+  };
+}
+
+export function ensureGroupPersistenceFiles(groupFolder: string): void {
+  if (!PERSISTENCE_ENABLED) return;
+  const paths = getPersistencePaths(groupFolder);
+  fs.mkdirSync(paths.dir, { recursive: true });
+
+  if (!fs.existsSync(paths.taskProgressFile)) {
+    const initial: ParsedStateFile = {
+      metadata: {
+        ...defaultMetadata(),
+        last_updated_at: nowIso(),
+      },
+      body: DEFAULT_BODY,
+    };
+    fs.writeFileSync(paths.taskProgressFile, serializeStateFile(initial), 'utf8');
+  }
+}
+
+function readTaskProgress(groupFolder: string): string {
+  const paths = getPersistencePaths(groupFolder);
+  ensureGroupPersistenceFiles(groupFolder);
+  return fs.readFileSync(paths.taskProgressFile, 'utf8');
+}
+
+function readPersonality(groupFolder: string): string | null {
+  if (!PERSISTENCE_INCLUDE_PERSONALITY) return null;
+  const paths = getPersistencePaths(groupFolder);
+  if (!fs.existsSync(paths.personalityFile)) return null;
+  const content = fs.readFileSync(paths.personalityFile, 'utf8').trim();
+  return content || null;
+}
+
+export function buildPromptWithPersistence(
+  basePrompt: string,
+  groupFolder: string,
+): string {
+  if (!PERSISTENCE_ENABLED) return basePrompt;
+
+  ensureGroupPersistenceFiles(groupFolder);
+  const progress = clipForPrompt(
+    readTaskProgress(groupFolder),
+    PROMPT_PROGRESS_MAX_CHARS,
+  );
+  const personality = readPersonality(groupFolder);
+
+  const sections: string[] = [
+    '<persistent_context>',
+    'Files mounted from host at `/workspace/persistence`:',
+    '- `/workspace/persistence/task-progress.md` (persistent work log)',
+    '- `/workspace/persistence/personality.md` (optional)',
+    '',
+    'Before executing work, review `task-progress.md` and continue from the latest checkpoint if needed.',
+    'During and after work, update `task-progress.md` so progress survives restarts.',
+    '',
+    'Current `task-progress.md`:',
+    '```md',
+    progress,
+    '```',
+  ];
+
+  if (personality) {
+    sections.push(
+      '',
+      'Optional personality guidance from `personality.md`:',
+      '```md',
+      clipForPrompt(personality, PROMPT_PERSONALITY_MAX_CHARS),
+      '```',
+    );
+  }
+
+  sections.push('</persistent_context>', '', basePrompt);
+  return sections.join('\n');
+}
+
+export function markTaskRunStart(
+  groupFolder: string,
+  prompt: string,
+  source: ExecutionSource,
+): void {
+  if (!PERSISTENCE_ENABLED) return;
+  withStateFile(groupFolder, (parsed) => {
+    const ts = nowIso();
+    parsed.metadata.status = 'in_progress';
+    parsed.metadata.resume_on_boot = true;
+    parsed.metadata.last_source = source;
+    parsed.metadata.last_started_at = ts;
+    parsed.metadata.last_updated_at = ts;
+    parsed.metadata.last_prompt_summary = sanitizeSummary(prompt);
+    parsed.body = appendProgressLog(
+      parsed.body,
+      `Run started (${source})`,
+      `Prompt summary: ${parsed.metadata.last_prompt_summary || '(empty)'}`,
+    );
+    return parsed;
+  });
+}
+
+export function markTaskRunEnd(
+  groupFolder: string,
+  status: 'success' | 'error',
+  result: string | null,
+  error: string | null,
+): void {
+  if (!PERSISTENCE_ENABLED) return;
+  withStateFile(groupFolder, (parsed) => {
+    const ts = nowIso();
+    parsed.metadata.status = status === 'success' ? 'idle' : 'error';
+    parsed.metadata.resume_on_boot = false;
+    parsed.metadata.last_finished_at = ts;
+    parsed.metadata.last_updated_at = ts;
+    parsed.metadata.last_result_summary = sanitizeSummary(
+      status === 'success' ? result || 'Completed' : error || 'Error',
+    );
+    parsed.body = appendProgressLog(
+      parsed.body,
+      `Run finished (${status})`,
+      status === 'success'
+        ? `Result summary: ${parsed.metadata.last_result_summary}`
+        : `Error summary: ${parsed.metadata.last_result_summary}`,
+    );
+    return parsed;
+  });
+}
+
+export function shouldQueueBootResume(groupFolder: string): boolean {
+  if (!PERSISTENCE_ENABLED || !PERSISTENCE_AUTO_RESUME_ON_BOOT) return false;
+  const paths = getPersistencePaths(groupFolder);
+  if (!fs.existsSync(paths.taskProgressFile)) return false;
+  try {
+    const parsed = parseStateFile(fs.readFileSync(paths.taskProgressFile, 'utf8'));
+    return parsed.metadata.status === 'in_progress' && parsed.metadata.resume_on_boot;
+  } catch (err) {
+    logger.warn(
+      { err, groupFolder, file: paths.taskProgressFile },
+      'Failed to read persistence state during boot recovery',
+    );
+    return false;
+  }
+}
+
+export function markBootResumeQueued(groupFolder: string): void {
+  if (!PERSISTENCE_ENABLED) return;
+  withStateFile(groupFolder, (parsed) => {
+    const ts = nowIso();
+    parsed.metadata.status = 'resuming';
+    parsed.metadata.resume_on_boot = false;
+    parsed.metadata.last_source = 'boot_resume';
+    parsed.metadata.last_updated_at = ts;
+    parsed.body = appendProgressLog(
+      parsed.body,
+      'Boot resume queued',
+      'NanoClaw queued a continuation run after restart.',
+    );
+    return parsed;
+  });
+}

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -20,6 +20,12 @@ import {
 } from './db.js';
 import { GroupQueue } from './group-queue.js';
 import { logger } from './logger.js';
+import {
+  buildPromptWithPersistence,
+  ensureGroupPersistenceFiles,
+  markTaskRunEnd,
+  markTaskRunStart,
+} from './persistent-state.js';
 import { RegisteredGroup, ScheduledTask } from './types.js';
 
 export interface SchedulerDependencies {
@@ -83,6 +89,8 @@ async function runTask(
 
   let result: string | null = null;
   let error: string | null = null;
+  ensureGroupPersistenceFiles(task.group_folder);
+  markTaskRunStart(task.group_folder, task.prompt, 'scheduled');
 
   // For group context mode, use the group's current session
   const sessions = deps.getSessions();
@@ -105,7 +113,7 @@ async function runTask(
     const output = await runContainerAgent(
       group,
       {
-        prompt: task.prompt,
+        prompt: buildPromptWithPersistence(task.prompt, task.group_folder),
         sessionId,
         groupFolder: task.group_folder,
         chatJid: task.chat_jid,
@@ -175,6 +183,7 @@ async function runTask(
       ? result.slice(0, 200)
       : 'Completed';
   updateTaskAfterRun(task.id, nextRun, resultSummary);
+  markTaskRunEnd(task.group_folder, error ? 'error' : 'success', result, error);
 }
 
 let schedulerRunning = false;


### PR DESCRIPTION
## Summary
- add host-persistent markdown state layer under `data/persistence/<group>/`
- mount each group's persistence directory into containers at `/workspace/persistence`
- inject persistent context into prompts so agents can resume/update progress
- support optional `personality.md` file per group
- add boot-time auto-resume-once for interrupted in-progress work

## New files
- `src/persistent-state.ts`
- `src/persistent-state.test.ts`

## Behavior
- system maintains `task-progress.md` metadata and run log entries
- if NanoClaw restarts with `status=in_progress` and `resume_on_boot=true`, it enqueues one continuation run and marks resume as queued
- scheduled and interactive runs both update persistent state

## Configuration
- `PERSISTENCE_ENABLED` (default true)
- `PERSISTENCE_ROOT` (default `data/persistence`)
- `PERSISTENCE_AUTO_RESUME_ON_BOOT` (default true)
- `PERSISTENCE_INCLUDE_PERSONALITY` (default true)

## Tests
- `npm test`
- `npm run build`
