### PR TITLE
feat: add image and PDF support to media pipeline

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -20,7 +20,7 @@ import { query, HookCallback, PreCompactHookInput, PreToolUseHookInput } from '@
 import { fileURLToPath } from 'url';
 
 interface ContainerInput {
-  prompt: string;
+  prompt: string | object[];
   sessionId?: string;
   groupFolder: string;
   chatJid: string;
@@ -50,7 +50,7 @@ interface SessionsIndex {
 
 interface SDKUserMessage {
   type: 'user';
-  message: { role: 'user'; content: string };
+  message: { role: 'user'; content: string | object[] };
   parent_tool_use_id: null;
   session_id: string;
 }
@@ -68,7 +68,7 @@ class MessageStream {
   private waiting: (() => void) | null = null;
   private done = false;
 
-  push(text: string): void {
+  push(text: string | object[]): void {
     this.queue.push({
       type: 'user',
       message: { role: 'user', content: text },
@@ -298,20 +298,20 @@ function shouldClose(): boolean {
  * Drain all pending IPC input messages.
  * Returns messages found, or empty array.
  */
-function drainIpcInput(): string[] {
+function drainIpcInput(): (string | object[])[] {
   try {
     fs.mkdirSync(IPC_INPUT_DIR, { recursive: true });
     const files = fs.readdirSync(IPC_INPUT_DIR)
       .filter(f => f.endsWith('.json'))
       .sort();
 
-    const messages: string[] = [];
+    const messages: (string | object[])[] = [];
     for (const file of files) {
       const filePath = path.join(IPC_INPUT_DIR, file);
       try {
         const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
         fs.unlinkSync(filePath);
-        if (data.type === 'message' && data.text) {
+        if (data.type === 'message' && data.text != null) {
           messages.push(data.text);
         }
       } catch (err) {
@@ -355,7 +355,7 @@ function waitForIpcMessage(): Promise<string | null> {
  * Also pipes IPC messages into the stream during the query.
  */
 async function runQuery(
-  prompt: string,
+  prompt: string | object[],
   sessionId: string | undefined,
   mcpServerPath: string,
   containerInput: ContainerInput,

--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -18,7 +18,13 @@ import {
   updateChatName,
 } from '../db.js';
 import { logger } from '../logger.js';
-import { Channel, OnInboundMessage, OnChatMetadata, RegisteredGroup } from '../types.js';
+import {
+  isImageMessage,
+  isPdfDocument,
+  processImageMessage,
+  processPdfDocument,
+} from '../media-processing.js';
+import { Channel, ContentBlock, OnInboundMessage, OnChatMetadata, RegisteredGroup } from '../types.js';
 
 const GROUP_SYNC_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
@@ -194,12 +200,40 @@ export class WhatsAppChannel implements Channel {
             ? fromMe
             : content.startsWith(`${ASSISTANT_NAME}:`);
 
+          // Process media messages (images, PDFs)
+          let finalContent: string | ContentBlock[] = content;
+          if (isImageMessage(msg)) {
+            try {
+              const contentBlocks = await processImageMessage(msg, this.sock);
+              if (contentBlocks) {
+                finalContent = contentBlocks;
+              } else {
+                finalContent = '[Image - processing unavailable]';
+              }
+            } catch (err) {
+              logger.error({ err }, 'Image processing error');
+              finalContent = '[Image - processing failed]';
+            }
+          } else if (isPdfDocument(msg)) {
+            try {
+              const contentBlocks = await processPdfDocument(msg, this.sock);
+              if (contentBlocks) {
+                finalContent = contentBlocks;
+              } else {
+                finalContent = '[PDF - processing unavailable]';
+              }
+            } catch (err) {
+              logger.error({ err }, 'PDF processing error');
+              finalContent = '[PDF - processing failed]';
+            }
+          }
+
           this.opts.onMessage(chatJid, {
             id: msg.key.id || '',
             chat_jid: chatJid,
             sender,
             sender_name: senderName,
-            content,
+            content: finalContent,
             timestamp,
             is_from_me: fromMe,
             is_bot_message: isBotMessage,

--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -146,7 +146,7 @@ export class GroupQueue {
    * Send a follow-up message to the active container via IPC file.
    * Returns true if the message was written, false if no active container.
    */
-  sendMessage(groupJid: string, text: string): boolean {
+  sendMessage(groupJid: string, text: string | object[]): boolean {
     const state = this.getGroup(groupJid);
     if (!state.active || !state.groupFolder || state.isTaskContainer) return false;
     state.idleWaiting = false; // Agent is about to receive work, no longer idle

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,11 +36,21 @@ import { resolveGroupFolderPath } from './group-folder.js';
 import { startIpcWatcher } from './ipc.js';
 import { findChannel, formatMessages, formatOutbound } from './router.js';
 import { startSchedulerLoop } from './task-scheduler.js';
-import { Channel, NewMessage, RegisteredGroup } from './types.js';
+import { Channel, ContentBlock, NewMessage, RegisteredGroup } from './types.js';
 import { logger } from './logger.js';
 
 // Re-export for backwards compatibility during refactor
 export { escapeXml, formatMessages } from './router.js';
+
+// Helper function to extract text content from a message (handles both string and ContentBlock[])
+function getMessageText(msg: NewMessage): string {
+  if (typeof msg.content === 'string') {
+    return msg.content;
+  }
+  // For ContentBlock[], extract text from text blocks
+  const textBlocks = msg.content.filter((b: ContentBlock) => b.type === 'text');
+  return textBlocks.map((b: any) => b.text).join(' ');
+}
 
 let lastTimestamp = '';
 let sessions: Record<string, string> = {};
@@ -148,7 +158,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   // For non-main groups, check if trigger is required and present
   if (!isMainGroup && group.requiresTrigger !== false) {
     const hasTrigger = missedMessages.some((m) =>
-      TRIGGER_PATTERN.test(m.content.trim()),
+      TRIGGER_PATTERN.test(getMessageText(m).trim()),
     );
     if (!hasTrigger) return true;
   }
@@ -356,7 +366,7 @@ async function startMessageLoop(): Promise<void> {
           // context when a trigger eventually arrives.
           if (needsTrigger) {
             const hasTrigger = groupMessages.some((m) =>
-              TRIGGER_PATTERN.test(m.content.trim()),
+              TRIGGER_PATTERN.test(getMessageText(m).trim()),
             );
             if (!hasTrigger) continue;
           }

--- a/src/media-processing.ts
+++ b/src/media-processing.ts
@@ -1,0 +1,192 @@
+import { downloadMediaMessage } from '@whiskeysockets/baileys';
+import type { WAMessage, WASocket } from '@whiskeysockets/baileys';
+import { logger } from './logger.js';
+import type { ContentBlock, ImageSource, DocumentSource } from './types.js';
+
+// Detector functions
+export function isImageMessage(msg: WAMessage): boolean {
+  return msg.message?.imageMessage != null;
+}
+
+export function isPdfDocument(msg: WAMessage): boolean {
+  return (
+    msg.message?.documentMessage != null &&
+    msg.message.documentMessage.mimetype === 'application/pdf'
+  );
+}
+
+// Image processing
+export async function processImageMessage(
+  msg: WAMessage,
+  sock: WASocket,
+): Promise<ContentBlock[] | null> {
+  try {
+    logger.info({
+      chatJid: msg.key.remoteJid,
+      hasImageMessage: !!msg.message?.imageMessage,
+      hasMimetype: !!msg.message?.imageMessage?.mimetype,
+      hasUrl: !!msg.message?.imageMessage?.url,
+      hasMediaKey: !!msg.message?.imageMessage?.mediaKey
+    }, 'Attempting to download image - message details');
+
+    const buffer = (await downloadMediaMessage(
+      msg,
+      'buffer',
+      {},
+      {
+        logger: console as any,
+        reuploadRequest: sock.updateMediaMessage,
+      },
+    )) as Buffer;
+
+    if (!buffer || buffer.length === 0) {
+      logger.warn({ chatJid: msg.key.remoteJid }, 'Empty image buffer received - download failed, returning caption only');
+
+      // Even if download fails, extract caption and metadata
+      const caption = msg.message?.imageMessage?.caption || '';
+      const mimeType = msg.message?.imageMessage?.mimetype || 'unknown';
+      const width = msg.message?.imageMessage?.width;
+      const height = msg.message?.imageMessage?.height;
+
+      if (caption) {
+        // Return caption as text so user gets some information
+        return [{
+          type: 'text',
+          text: `📷 Image (download failed - Baileys limitation)\nCaption: ${caption}\nType: ${mimeType}${width && height ? `\nSize: ${width}x${height}` : ''}`
+        }];
+      }
+
+      // No caption, return null to show generic message
+      return null;
+    }
+
+    const base64 = buffer.toString('base64');
+    const mimeType = msg.message?.imageMessage?.mimetype || 'image/jpeg';
+    const caption = msg.message?.imageMessage?.caption || '';
+
+    // Sanitize MIME type to match Claude's expected types
+    const mediaType = mimeType.includes('png') ? 'image/png'
+      : mimeType.includes('gif') ? 'image/gif'
+      : mimeType.includes('webp') ? 'image/webp'
+      : 'image/jpeg';
+
+    const blocks: ContentBlock[] = [];
+
+    // Add caption as text block if present
+    if (caption) {
+      blocks.push({ type: 'text', text: caption });
+    }
+
+    // Add image block
+    blocks.push({
+      type: 'image',
+      source: {
+        type: 'base64',
+        media_type: mediaType,
+        data: base64,
+      } as ImageSource,
+    });
+
+    logger.info(
+      {
+        chatJid: msg.key.remoteJid,
+        sizeKB: Math.round(buffer.length / 1024),
+        mediaType,
+        hasCaption: !!caption,
+      },
+      'Processed image message'
+    );
+
+    return blocks;
+  } catch (err) {
+    logger.error({
+      err,
+      chatJid: msg.key.remoteJid,
+      errorMessage: err instanceof Error ? err.message : String(err),
+      errorStack: err instanceof Error ? err.stack : undefined
+    }, 'Image processing error - download or conversion failed');
+    return null;
+  }
+}
+
+// PDF processing
+export async function processPdfDocument(
+  msg: WAMessage,
+  sock: WASocket,
+): Promise<ContentBlock[] | null> {
+  try {
+    logger.info({ chatJid: msg.key.remoteJid }, 'Attempting to download PDF');
+
+    const buffer = (await downloadMediaMessage(
+      msg,
+      'buffer',
+      {},
+      {
+        logger: console as any,
+        reuploadRequest: sock.updateMediaMessage,
+      },
+    )) as Buffer;
+
+    if (!buffer || buffer.length === 0) {
+      logger.warn({ chatJid: msg.key.remoteJid }, 'Empty PDF buffer received - download failed, returning metadata only');
+
+      // Even if download fails, extract caption and metadata
+      const caption = msg.message?.documentMessage?.caption || '';
+      const filename = msg.message?.documentMessage?.fileName || 'document.pdf';
+      const pageCount = msg.message?.documentMessage?.pageCount;
+      const fileSize = msg.message?.documentMessage?.fileLength;
+
+      if (caption || filename !== 'document.pdf') {
+        // Return metadata as text so user gets some information
+        const sizeText = fileSize && typeof fileSize === 'number' ? `\nSize: ${Math.round(fileSize / 1024)}KB` : '';
+        return [{
+          type: 'text',
+          text: `📄 PDF Document (download failed - Baileys limitation)\nFilename: ${filename}${caption ? `\nCaption: ${caption}` : ''}${pageCount ? `\nPages: ${pageCount}` : ''}${sizeText}`
+        }];
+      }
+
+      // No useful metadata, return null
+      return null;
+    }
+
+    const base64 = buffer.toString('base64');
+    const caption = msg.message?.documentMessage?.caption || '';
+    const filename = msg.message?.documentMessage?.fileName || 'document.pdf';
+
+    const blocks: ContentBlock[] = [];
+
+    // Add caption/filename as text block
+    const textContent = caption || `[PDF: ${filename}]`;
+    blocks.push({ type: 'text', text: textContent });
+
+    // Add PDF document block
+    blocks.push({
+      type: 'document',
+      source: {
+        type: 'base64',
+        media_type: 'application/pdf',
+        data: base64,
+      } as DocumentSource,
+    });
+
+    logger.info(
+      {
+        chatJid: msg.key.remoteJid,
+        sizeKB: Math.round(buffer.length / 1024),
+        filename,
+        hasCaption: !!caption,
+      },
+      'Processed PDF document'
+    );
+
+    return blocks;
+  } catch (err) {
+    logger.error({
+      err,
+      chatJid: msg.key.remoteJid,
+      errorMessage: err instanceof Error ? err.message : String(err),
+      errorStack: err instanceof Error ? err.stack : undefined
+    }, 'PDF processing error - download or conversion failed');
+    return null;
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,12 +41,31 @@ export interface RegisteredGroup {
   requiresTrigger?: boolean; // Default: true for groups, false for solo chats
 }
 
+// --- Claude API content block types ---
+
+export interface ImageSource {
+  type: 'base64';
+  media_type: 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp';
+  data: string;
+}
+
+export interface DocumentSource {
+  type: 'base64';
+  media_type: 'application/pdf';
+  data: string;
+}
+
+export type ContentBlock =
+  | { type: 'text'; text: string }
+  | { type: 'image'; source: ImageSource }
+  | { type: 'document'; source: DocumentSource };
+
 export interface NewMessage {
   id: string;
   chat_jid: string;
   sender: string;
   sender_name: string;
-  content: string;
+  content: string | ContentBlock[];
   timestamp: string;
   is_from_me?: boolean;
   is_bot_message?: boolean;


### PR DESCRIPTION
## Summary

- **New `src/media-processing.ts`**: helpers to detect and download images/PDFs from Baileys, using correct `!= null` null checks (Baileys protobuf sets unset fields to `null`, not `undefined` — using `!== undefined` causes every text message to match as an image and crash)
- **`src/types.ts`**: add `ContentBlock`, `ImageSource`, `DocumentSource` types; change `NewMessage.content` to `string | ContentBlock[]`
- **`src/channels/whatsapp.ts`**: detect images/PDFs on inbound and pass as `ContentBlock[]` to the agent instead of empty caption string
- **Full pipeline fix**: `group-queue`, `index.ts`, and `agent-runner` all updated to accept `string | object[]` — previously `ContentBlock[]` was silently dropped in the active-container piping path and replaced with a placeholder string

## Problem

Without this, images and PDFs sent to any group where a container was already running would arrive at the agent as `'[New media message - please check WhatsApp]'` instead of actual content. Fresh container spawns also had the same issue for images (Baileys null check crash + type mismatch).

## Test plan

- [ ] Send an image to a group where no container is running — agent should see the image
- [ ] Send an image to a group where a container is already active (e.g. mid-conversation) — agent should still see the image (this was the broken path)
- [ ] Send a plain text message — should still work normally (not crash with "processImageMessage called on text message")
- [ ] Send a PDF — agent should receive document content block

🤖 Generated with [Claude Code](https://claude.com/claude-code)