### PR TITLE
feat: add Feishu (Lark) channel skill and fix non-streaming container deadlock

### DIFF
--- a/.claude/skills/add-feishu/SKILL.md
+++ b/.claude/skills/add-feishu/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: add-feishu
+description: Add Feishu (Lark) as a channel for NanoClaw. Supports both group chats and private messages via WebSocket long connection.
+---
+
+# Add Feishu Channel
+
+This skill adds Feishu (Lark) support to NanoClaw using the skills engine for deterministic code changes, then walks through interactive setup.
+
+## Phase 1: Pre-flight
+
+### Check if already applied
+
+Read `.nanoclaw/state.yaml`. If `feishu` is in `applied_skills`, skip to Phase 3 (Setup). The code changes are already in place.
+
+### Ask the user
+
+1. **Mode**: Replace WhatsApp or add alongside it?
+   - Replace → will set `FEISHU_ONLY=true`
+   - Alongside → both channels active (default)
+
+2. **Do they already have a Feishu app?** If yes, collect App ID and App Secret now. If no, we'll create one in Phase 3.
+
+## Phase 2: Apply Code Changes
+
+Run the skills engine to apply this skill's code package. The package files are in this directory alongside this SKILL.md.
+
+### Initialize skills system (if needed)
+
+If `.nanoclaw/` directory doesn't exist yet:
+
+```bash
+npx tsx scripts/apply-skill.ts --init
+```
+
+Or call `initSkillsSystem()` from `skills-engine/migrate.ts`.
+
+### Apply the skill
+
+```bash
+npx tsx scripts/apply-skill.ts .claude/skills/add-feishu
+```
+
+This deterministically:
+- Adds `src/channels/feishu.ts` (FeishuChannel class implementing Channel interface)
+- Adds `src/channels/feishu.test.ts` (unit tests)
+- Three-way merges Feishu support into `src/index.ts` (multi-channel support, findChannel routing)
+- Three-way merges Feishu config into `src/config.ts` (FEISHU_APP_ID, FEISHU_APP_SECRET, FEISHU_ONLY exports)
+- Three-way merges updated routing tests into `src/routing.test.ts`
+- Installs the `@larksuiteoapi/node-sdk` npm dependency
+- Updates `.env.example` with `FEISHU_APP_ID`, `FEISHU_APP_SECRET`, and `FEISHU_ONLY`
+- Records the application in `.nanoclaw/state.yaml`
+
+If the apply reports merge conflicts, read the intent files:
+- `modify/src/index.ts.intent.md` — what changed and invariants for index.ts
+- `modify/src/config.ts.intent.md` — what changed for config.ts
+
+### Validate code changes
+
+```bash
+npm test
+npm run build
+```
+
+All tests must pass (including the new feishu tests) and build must be clean before proceeding.
+
+## Phase 3: Setup
+
+### Create Feishu App (if needed)
+
+If the user doesn't have a Feishu app, tell them:
+
+> I need you to create a Feishu app:
+>
+> 1. Go to https://open.feishu.cn/app
+> 2. Click **创建企业自建应用** (Create Enterprise Self-built App)
+> 3. Fill in app name, description, and icon
+> 4. Go to **凭证与基础信息** (Credentials & Basic Info) to get App ID and App Secret
+> 5. Go to **应用能力** > **添加应用能力** > Add **机器人** (Bot) capability
+> 6. Go to **权限管理** and add these permissions:
+>    - `im:message.p2p_msg:readonly` - Read user private chat messages
+>    - `im:message.group_at_msg:readonly` - Receive group @ mentions
+>    - `im:message:send_as_bot` - Send messages as bot
+>    - `im:chat:read` - Read chat info
+> 7. Go to **事件与回调** > **订阅方式** and select **使用长连接接收事件** (Long connection)
+> 8. Go to **事件配置** and add `im.message.receive_v1` event
+> 9. Go to **版本管理与发布** and create a test version
+
+Wait for the user to provide the App ID (format: `cli_xxxxxxxxxxxxxxxx`) and App Secret.
+
+### Configure environment
+
+Add to `.env`:
+
+```bash
+FEISHU_APP_ID=<their-app-id>
+FEISHU_APP_SECRET=<their-app-secret>
+```
+
+If they chose to replace WhatsApp:
+
+```bash
+FEISHU_ONLY=true
+```
+
+Sync to container environment:
+
+```bash
+mkdir -p data/env && cp .env data/env/env
+```
+
+The container reads environment from `data/env/env`, not `.env` directly.
+
+### Build and restart
+
+```bash
+npm run build
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+```
+
+## Phase 4: Registration
+
+### Get Chat ID
+
+The user needs to send a message to get the chat ID. Tell them:
+
+> 1. Add the bot to your group chat, or send a private message to the bot
+> 2. Send any message (e.g., "hello")
+> 3. Check the logs to find the chat ID
+
+Wait for the user to send a message, then look at the logs:
+
+```bash
+tail -f logs/nanoclaw.log | grep "chatJid"
+```
+
+The chat ID will look like `feishu:oc_xxxxxxxxxxxxxxxx` (group) or `feishu:oc_xxxxxxxxxxxxxxxx` (private).
+
+### Register the chat
+
+Use the IPC register flow or register directly. The chat ID, name, and folder name are needed.
+
+For a main chat (responds to all messages, uses the `main` folder):
+
+```typescript
+registerGroup("feishu:<chat-id>", {
+  name: "<chat-name>",
+  folder: "main",
+  trigger: `@${ASSISTANT_NAME}`,
+  added_at: new Date().toISOString(),
+  requiresTrigger: false,
+});
+```
+
+For additional chats (trigger-only):
+
+```typescript
+registerGroup("feishu:<chat-id>", {
+  name: "<chat-name>",
+  folder: "<folder-name>",
+  trigger: `@${ASSISTANT_NAME}`,
+  added_at: new Date().toISOString(),
+  requiresTrigger: true,
+});
+```
+
+## Phase 5: Verify
+
+### Test the connection
+
+Tell the user:
+
+> Send a message to your registered Feishu chat:
+> - For main chat: Any message works
+> - For non-main: `@Andy hello` or mention the bot
+>
+> The bot should respond within a few seconds.
+
+### Check logs if needed
+
+```bash
+tail -f logs/nanoclaw.log
+```
+
+## Troubleshooting
+
+### Bot not responding
+
+1. Check `FEISHU_APP_ID` and `FEISHU_APP_SECRET` are set in `.env` AND synced to `data/env/env`
+2. Check chat is registered: `sqlite3 store/messages.db "SELECT * FROM registered_groups WHERE jid LIKE 'feishu:%'"`
+3. For non-main chats: message must include trigger pattern
+4. Service is running: `launchctl list | grep nanoclaw`
+5. Check Feishu app permissions are enabled and app is published
+
+### WebSocket connection errors
+...
+### Container Deadlock (Typing indicator not removed)
+
+If the Feishu bot hangs with "Typing..." and never responds:
+1. Ensure `isOneShot: true` is being passed to `runContainerAgent` for non-streaming queries.
+2. Check that `runAgent` always passes a callback to `runContainerAgent` to enable stdout marker parsing.
+3. Verify the container's `agent-runner` is updated to handle the `isOneShot` flag.
+
+### Getting chat ID
+
+If the chat ID doesn't appear in logs:
+- Verify the bot is in the group (for group chats)
+- Send a direct message to the bot (for private chats)
+- Check `logs/nanoclaw.log` for `Feishu: chat JID info` entries
+
+## After Setup
+
+The Feishu channel supports:
+- Group chat messages (using `chat_id`)
+- Private chat messages (using `chat_id`)
+- Text messages
+- Post/rich text messages
+- Auto-reply to registered chats
+
+No additional setup is required.

--- a/.claude/skills/add-feishu/add/src/channels/feishu.test.ts
+++ b/.claude/skills/add-feishu/add/src/channels/feishu.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FeishuChannel } from './feishu.js';
+
+describe('FeishuChannel', () => {
+  const mockOpts = {
+    appId: 'cli_test',
+    appSecret: 'test-secret',
+    onMessage: vi.fn(),
+    onChatMetadata: vi.fn(),
+    registeredGroups: vi.fn(() => ({
+      'feishu:oc_test123': {
+        jid: 'feishu:oc_test123',
+        name: 'Test Group',
+        folder: 'main',
+        trigger_pattern: '@Andy',
+        added_at: new Date().toISOString(),
+        requires_trigger: 0,
+      },
+    })),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('ownsJid', () => {
+    it('should return true for feishu: prefixed JIDs', () => {
+      const channel = new FeishuChannel(mockOpts);
+      expect(channel.ownsJid('feishu:oc_test123')).toBe(true);
+      expect(channel.ownsJid('feishu:ou_test456')).toBe(true);
+    });
+
+    it('should return false for non-feishu JIDs', () => {
+      const channel = new FeishuChannel(mockOpts);
+      expect(channel.ownsJid('whatsapp:123@g.us')).toBe(false);
+      expect(channel.ownsJid('tg:123456')).toBe(false);
+    });
+  });
+
+  describe('isConnected', () => {
+    it('should return false before connect', () => {
+      const channel = new FeishuChannel(mockOpts);
+      expect(channel.isConnected()).toBe(false);
+    });
+  });
+
+  describe('name', () => {
+    it('should be "feishu"', () => {
+      const channel = new FeishuChannel(mockOpts);
+      expect(channel.name).toBe('feishu');
+    });
+  });
+});

--- a/.claude/skills/add-feishu/add/src/channels/feishu.ts
+++ b/.claude/skills/add-feishu/add/src/channels/feishu.ts
@@ -1,0 +1,482 @@
+import { Client, WSClient, EventDispatcher } from '@larksuiteoapi/node-sdk';
+import fs from 'fs';
+import path from 'path';
+
+import { logger } from '../logger.js';
+import {
+  Channel,
+  NewMessage,
+  OnChatMetadata,
+  OnInboundMessage,
+  RegisteredGroup,
+} from '../types.js';
+import { GROUPS_DIR } from '../config.js';
+
+export interface FeishuChannelOpts {
+  appId: string;
+  appSecret: string;
+  onMessage: OnInboundMessage;
+  onChatMetadata: OnChatMetadata;
+  registeredGroups: () => Record<string, RegisteredGroup>;
+  registerGroup?: (jid: string, group: RegisteredGroup) => Promise<void>;
+  mainGroupFolder?: string;
+}
+
+export class FeishuChannel implements Channel {
+  name = 'feishu';
+
+  private client: Client;
+  private wsClient: WSClient | null = null;
+  private opts: FeishuChannelOpts;
+  private connected = false;
+  // Track active reactions per chat: chatJid -> Set of {messageId, reactionId}
+  private activeReactions: Map<string, Set<{ messageId: string; reactionId: string }>> = new Map();
+  // Track last message info per chat for reply context: chatJid -> {messageId, isGroup}
+  private lastMessageInfo: Map<string, { messageId: string; isGroup: boolean }> = new Map();
+  // Track processed event IDs to prevent duplicate processing (Feishu may send duplicate events)
+  private processedEvents: Set<string> = new Set();
+  private readonly MAX_PROCESSED_EVENTS = 1000;
+
+  constructor(opts: FeishuChannelOpts) {
+    this.opts = opts;
+    this.client = new Client({
+      appId: opts.appId,
+      appSecret: opts.appSecret,
+      domain: 'https://open.feishu.cn',
+    });
+  }
+
+  /**
+   * Add a reaction emoji to a message
+   * @param messageId The message ID to react to
+   * @param emojiType The emoji type (e.g., 'THUMBSUP', 'OK')
+   * @returns The reaction ID for later removal
+   */
+  private async addReaction(messageId: string, emojiType: string): Promise<string | null> {
+    try {
+      const response = await this.client.im.messageReaction.create({
+        path: {
+          message_id: messageId,
+        },
+        data: {
+          reaction_type: {
+            emoji_type: emojiType,
+          },
+        },
+      });
+      logger.info({ messageId, emojiType, reactionId: response?.data?.reaction_id }, 'Feishu: added reaction');
+      return response?.data?.reaction_id || null;
+    } catch (error) {
+      logger.error({ messageId, emojiType, error }, 'Feishu: failed to add reaction');
+      return null;
+    }
+  }
+
+  /**
+   * Remove a reaction from a message
+   * @param messageId The message ID
+   * @param reactionId The reaction ID to remove
+   */
+  private async removeReaction(messageId: string, reactionId: string): Promise<void> {
+    try {
+      await this.client.im.messageReaction.delete({
+        path: {
+          message_id: messageId,
+          reaction_id: reactionId,
+        },
+      });
+      logger.info({ messageId, reactionId }, 'Feishu: removed reaction');
+    } catch (error) {
+      logger.error({ messageId, reactionId, error }, 'Feishu: failed to remove reaction');
+    }
+  }
+
+  async connect(): Promise<void> {
+    logger.info('Connecting to Feishu...');
+
+    // Create EventDispatcher to handle incoming messages
+    const eventDispatcher = new EventDispatcher({}).register({
+      'im.message.receive_v1': async (data: any) => {
+        await this.handleMessage(data);
+      },
+    });
+
+    // Create WSClient with app credentials
+    this.wsClient = new WSClient({
+      appId: this.opts.appId,
+      appSecret: this.opts.appSecret,
+      domain: 'https://open.feishu.cn',
+    });
+
+    // Start the WebSocket connection with event handler
+    this.wsClient.start({
+      eventDispatcher,
+    });
+
+    this.connected = true;
+    logger.info('Feishu channel connected');
+  }
+
+  private async handleMessage(data: any): Promise<void> {
+    try {
+      // Deduplicate events using event_id (Feishu may send duplicate events)
+      const eventId = data.event_id;
+      if (eventId) {
+        if (this.processedEvents.has(eventId)) {
+          logger.debug({ eventId }, 'Feishu: skipping duplicate event');
+          return;
+        }
+        // Add to processed events set, with cleanup to prevent memory leak
+        this.processedEvents.add(eventId);
+        if (this.processedEvents.size > this.MAX_PROCESSED_EVENTS) {
+          // Remove oldest entries when exceeding limit
+          const entries = Array.from(this.processedEvents);
+          const toRemove = entries.slice(0, 100);
+          for (const e of toRemove) {
+            this.processedEvents.delete(e);
+          }
+        }
+      }
+
+      // Debug log for all received messages
+      logger.info({ data: JSON.stringify(data) }, 'Feishu: received message event raw');
+
+      const message = data.message;
+      const sender = data.sender;
+      const chatType = message.chat_type;
+      const messageId = message.message_id;
+
+      logger.info({ chatType, senderOpenId: sender?.sender_id?.open_id, messageId }, 'Feishu: parsed message info');
+
+      // Get message content (text only for now)
+      let content = '';
+      const messageType = message.message_type;
+
+      if (messageType === 'text') {
+        const contentObj = JSON.parse(message.content);
+        content = contentObj.text || '';
+      } else if (messageType === 'post') {
+        // Handle post messages (rich text)
+        const contentObj = JSON.parse(message.content);
+        // Extract text from post content
+        const post = contentObj.post;
+        if (post && post.zh_cn) {
+          content = this.extractTextFromPost(post.zh_cn);
+        }
+      }
+
+      // Skip empty messages
+      if (!content) return;
+
+      // Build chat JID - both p2p and group use chat_id
+      // p2p (private chat): chat_id starts with "oc_"
+      // group: chat_id starts with "oc_"
+      const chatJid = `feishu:${message.chat_id}`;
+
+      logger.info({ chatJid, registeredJids: Object.keys(this.opts.registeredGroups()) }, 'Feishu: chat JID info');
+
+      // Get timestamp
+      const timestamp = new Date(message.create_time * 1000).toISOString();
+
+      // Get sender info
+      const senderName = sender.sender_id.name || 'Unknown';
+      const senderId = sender.sender_id.open_id || '';
+
+      // Store chat metadata
+      this.opts.onChatMetadata(chatJid, timestamp, undefined, 'feishu', chatType === 'group');
+
+      // Only deliver full message for registered chats
+      let group = this.opts.registeredGroups()[chatJid];
+      logger.info({ chatJid, groupExists: !!group, chatType, hasRegisterCallback: !!this.opts.registerGroup }, 'Feishu: checking chat registration');
+      if (!group) {
+        // Auto-register p2p (private) chats if registerGroup callback is provided
+        if (chatType === 'p2p' && this.opts.registerGroup) {
+          logger.info({ chatJid, senderId }, 'Feishu: auto-registering new private chat');
+
+          // Generate unique folder name for each p2p chat to avoid conflicts
+          // Use sender's open_id suffix to create unique folder
+          const senderSuffix = senderId.slice(-8);
+          const folderName = `p2p-${senderSuffix}`;
+          const newGroup: RegisteredGroup = {
+            name: `Private Chat ${senderSuffix}`,
+            folder: folderName,
+            trigger: '@Andy',
+            added_at: timestamp,
+            requiresTrigger: false, // Private chats don't require trigger
+          };
+
+          try {
+            await this.opts.registerGroup(chatJid, newGroup);
+            logger.info({ chatJid, folder: folderName, senderId }, 'Feishu: auto-registered private chat');
+
+            // Create CLAUDE.md for the new private chat to prevent duplicate messages
+            this.createClaudeMdForGroup(folderName);
+
+            // Re-fetch the registered groups to get the newly registered one
+            group = this.opts.registeredGroups()[chatJid];
+          } catch (error) {
+            logger.error({ chatJid, folder: folderName, error }, 'Feishu: failed to auto-register private chat');
+            return;
+          }
+        } else {
+          logger.debug(`Feishu: ignoring message from unregistered chat ${chatJid}`);
+          return;
+        }
+      }
+
+      // Store message info for reply context (used in group chats)
+      this.lastMessageInfo.set(chatJid, { messageId, isGroup: chatType === 'group' });
+
+      // Add "typing" reaction to indicate processing
+      const reactionId = await this.addReaction(messageId, 'Typing');
+      if (reactionId) {
+        // Store reaction per chat for later cleanup
+        if (!this.activeReactions.has(chatJid)) {
+          this.activeReactions.set(chatJid, new Set());
+        }
+        this.activeReactions.get(chatJid)!.add({ messageId, reactionId });
+      }
+
+      // Create NewMessage object
+      const newMessage: NewMessage = {
+        id: messageId,
+        chat_jid: chatJid,
+        sender: senderId,
+        sender_name: senderName,
+        content: content,
+        timestamp: timestamp,
+        is_from_me: false,
+        is_bot_message: false,
+      };
+
+      this.opts.onMessage(chatJid, newMessage);
+    } catch (error) {
+      logger.error({ error }, 'Error handling Feishu message');
+    }
+  }
+
+  private extractTextFromPost(post: any): string {
+    let text = '';
+    const content = post.content || [];
+    for (const block of content) {
+      for (const item of block) {
+        if (item.tag === 'text') {
+          text += item.text;
+        } else if (item.tag === 'at') {
+          text += `@${item.mention_name || 'user'} `;
+        }
+      }
+    }
+    return text;
+  }
+
+  /**
+   * Create CLAUDE.md for a newly registered group to prevent duplicate messages.
+   * This file explicitly tells the agent not to use mcp__nanoclaw__send_message tool.
+   */
+  private createClaudeMdForGroup(folderName: string): void {
+    try {
+      const groupDir = path.join(GROUPS_DIR, folderName);
+      fs.mkdirSync(groupDir, { recursive: true });
+
+      const claudeMdPath = path.join(groupDir, 'CLAUDE.md');
+      if (fs.existsSync(claudeMdPath)) {
+        // CLAUDE.md already exists, don't overwrite
+        return;
+      }
+
+      const claudeMdContent = `# Feishu Assistant
+
+你是 Feishu (飞书) 上的智能助手。
+
+## 通信方式 (重要)
+
+**只使用标准输出发送消息**。
+
+不要使用 \`mcp__nanoclaw__send_message\` 工具。你的所有输出都会通过标准输出自动发送给用户。
+
+## 功能
+
+- 回答问题并进行对话
+- 搜索网页和获取 URL 内容
+- **浏览网页** 使用 \`agent-browser\` — 打开页面、点击、填写表单、截图、提取数据（运行 \`agent-browser open <url>\` 开始，然后 \`agent-browser snapshot -i\` 查看可交互元素）
+- 读写工作区文件
+- 运行 bash 命令
+- 安排稍后运行或定期运行的任务
+
+## Feishu 消息格式化
+
+飞书支持 Markdown 格式，你可以使用：
+- **粗体** (**text**)
+- *斜体* (*text*)
+- \`代码\` (\`code\`)
+- [链接](url)
+- 表情符号 (如 [比心])
+
+## 内部思考
+
+如果部分内容只是内部推理而非给用户看的内容，使用 \`<internal>\` 标签包裹：
+
+\`\`\`
+<internal>这是一个内部思考，不会发送给用户</internal>
+
+这是给用户的回复内容...
+\`\`\`
+
+\`<internal>\` 标签内的文本会被记录但不会发送给用户。
+
+## 记忆
+
+\`conversations/\` 文件夹包含过去对话的可搜索历史。使用它来回忆之前会话的上下文。
+
+当你学到重要信息时：
+- 为结构化数据创建文件（例如 \`customers.md\`、\`preferences.md\`）
+- 将超过 500 行的文件拆分为文件夹
+- 在你创建的文件中保持索引
+`;
+
+      fs.writeFileSync(claudeMdPath, claudeMdContent, 'utf-8');
+      logger.info({ folderName, claudeMdPath }, 'Feishu: created CLAUDE.md for new group');
+    } catch (error) {
+      logger.error({ folderName, error }, 'Feishu: failed to create CLAUDE.md for new group');
+    }
+  }
+
+  async sendMessage(jid: string, text: string): Promise<void> {
+    // Check if we have message context for reply
+    const messageInfo = this.lastMessageInfo.get(jid);
+
+    logger.info({ jid, hasMessageInfo: !!messageInfo, isGroup: messageInfo?.isGroup, messageId: messageInfo?.messageId }, 'Feishu: sendMessage called');
+
+    // Use reply in group chats, normal send in p2p chats
+    // NOTE: We don't clear lastMessageInfo here to allow multiple streaming outputs
+    // to use the same message context. State is cleared when markProcessingComplete is called.
+    if (messageInfo?.isGroup && messageInfo.messageId) {
+      try {
+        logger.info({ jid, messageId: messageInfo.messageId }, 'Feishu: using reply for group chat');
+        await this.replyToMessage(messageInfo.messageId, text);
+        return;
+      } catch (error) {
+        logger.warn({ jid, error }, 'Feishu: reply failed, falling back to normal send');
+        // Fallback to normal send
+      }
+    }
+
+    // For p2p chats or fallback from reply, use normal message
+    await this.sendNormalMessage(jid, text);
+  }
+
+  /**
+   * Mark message processing as complete and clear related state.
+   * This should be called after the agent finishes processing a message.
+   * It clears typing indicators and message context to prepare for the next message.
+   */
+  async markProcessingComplete(jid: string): Promise<void> {
+    logger.info({ jid }, 'Feishu: marking processing complete');
+
+    // Clear typing reaction for this chat (Typing indicator should be removed after response)
+    const reactions = this.activeReactions.get(jid);
+    if (reactions && reactions.size > 0) {
+      logger.info({ jid, count: reactions.size }, 'Feishu: clearing typing reactions on processing complete');
+      for (const { messageId, reactionId } of reactions) {
+        await this.removeReaction(messageId, reactionId);
+      }
+      this.activeReactions.delete(jid);
+    }
+
+    // Clear last message info
+    this.lastMessageInfo.delete(jid);
+
+    logger.info({ jid }, 'Feishu: processing complete, state cleared');
+  }
+
+  /**
+   * Send a normal message (for p2p chats or when no reply context)
+   */
+  private async sendNormalMessage(jid: string, text: string): Promise<void> {
+    // Extract ID from JID
+    const id = jid.replace('feishu:', '');
+
+    // Determine if it's a chat_id (group) or open_id (personal)
+    const isChatId = id.startsWith('oc_');
+    const receiveIdType = isChatId ? 'chat_id' : 'open_id';
+
+    try {
+      await this.client.im.message.create({
+        params: {
+          receive_id_type: receiveIdType,
+        },
+        data: {
+          receive_id: id,
+          msg_type: 'text',
+          content: JSON.stringify({ text }),
+        },
+      });
+      logger.info(`Feishu: message sent to ${jid} (type: ${receiveIdType})`);
+    } catch (error) {
+      logger.error({ jid, error }, 'Feishu: failed to send message');
+      throw error;
+    }
+  }
+
+  /**
+   * Reply to a specific message (for group chats)
+   * This creates a threaded reply that shows the original message context
+   */
+  private async replyToMessage(messageId: string, text: string): Promise<void> {
+    await this.client.im.message.reply({
+      path: {
+        message_id: messageId,
+      },
+      data: {
+        msg_type: 'text',
+        content: JSON.stringify({ text }),
+        reply_in_thread: false, // Reply as normal threaded message, not as topic
+      },
+    });
+    logger.info({ messageId }, 'Feishu: replied to message');
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  ownsJid(jid: string): boolean {
+    return jid.startsWith('feishu:');
+  }
+
+  /**
+   * Set typing indicator by managing message reactions
+   * When isTyping=true, reactions are already added by handleMessage
+   * When isTyping=false, remove all active reactions for this chat
+   */
+  async setTyping(jid: string, isTyping: boolean): Promise<void> {
+    logger.info({ jid, isTyping, activeReactions: this.activeReactions.has(jid) }, 'Feishu: setTyping called');
+
+    if (isTyping) {
+      // Reactions are already added by handleMessage when messages arrive
+      return;
+    }
+
+    // Remove all reactions for this chat when done processing
+    const reactions = this.activeReactions.get(jid);
+    if (reactions && reactions.size > 0) {
+      logger.info({ jid, count: reactions.size }, 'Feishu: removing typing reactions');
+      for (const { messageId, reactionId } of reactions) {
+        await this.removeReaction(messageId, reactionId);
+      }
+      this.activeReactions.delete(jid);
+    } else {
+      logger.info({ jid, hasEntry: this.activeReactions.has(jid) }, 'Feishu: no reactions to remove');
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.wsClient) {
+      this.wsClient.close();
+      this.wsClient = null;
+      this.connected = false;
+      logger.info('Feishu channel disconnected');
+    }
+  }
+}

--- a/.claude/skills/add-feishu/manifest.yaml
+++ b/.claude/skills/add-feishu/manifest.yaml
@@ -1,0 +1,23 @@
+skill: add-feishu
+version: 1.0.0
+description: "Add Feishu (Lark) as a channel for NanoClaw. Supports both group chats and private messages via WebSocket long connection."
+core_version: 0.1.0
+adds:
+  - src/channels/feishu.ts
+  - src/channels/feishu.test.ts
+modifies:
+  - src/index.ts
+  - src/config.ts
+  - src/routing.test.ts
+  - src/container-runner.ts
+  - container/agent-runner/src/index.ts
+structured:
+  npm_dependencies:
+    "@larksuiteoapi/node-sdk": "^1.29.0"
+  env_additions:
+    - FEISHU_APP_ID
+    - FEISHU_APP_SECRET
+    - FEISHU_ONLY
+conflicts: []
+depends: []
+test: "npx vitest run src/channels/feishu.test.ts"

--- a/.claude/skills/add-feishu/modify/container/agent-runner/src/index.ts
+++ b/.claude/skills/add-feishu/modify/container/agent-runner/src/index.ts
@@ -1,0 +1,587 @@
+/**
+ * NanoClaw Agent Runner
+ * Runs inside a container, receives config via stdin, outputs result to stdout
+ *
+ * Input protocol:
+ *   Stdin: Full ContainerInput JSON (read until EOF, like before)
+ *   IPC:   Follow-up messages written as JSON files to /workspace/ipc/input/
+ *          Files: {type:"message", text:"..."}.json — polled and consumed
+ *          Sentinel: /workspace/ipc/input/_close — signals session end
+ *
+ * Stdout protocol:
+ *   Each result is wrapped in OUTPUT_START_MARKER / OUTPUT_END_MARKER pairs.
+ *   Multiple results may be emitted (one per agent teams result).
+ *   Final marker after loop ends signals completion.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { query, HookCallback, PreCompactHookInput, PreToolUseHookInput } from '@anthropic-ai/claude-agent-sdk';
+import { fileURLToPath } from 'url';
+
+interface ContainerInput {
+  prompt: string;
+  sessionId?: string;
+  groupFolder: string;
+  chatJid: string;
+  isMain: boolean;
+  isScheduledTask?: boolean;
+  secrets?: Record<string, string>;
+}
+
+interface ContainerOutput {
+  status: 'success' | 'error';
+  result: string | null;
+  newSessionId?: string;
+  error?: string;
+}
+
+interface SessionEntry {
+  sessionId: string;
+  fullPath: string;
+  summary: string;
+  firstPrompt: string;
+}
+
+interface SessionsIndex {
+  entries: SessionEntry[];
+}
+
+interface SDKUserMessage {
+  type: 'user';
+  message: { role: 'user'; content: string };
+  parent_tool_use_id: null;
+  session_id: string;
+}
+
+const IPC_INPUT_DIR = '/workspace/ipc/input';
+const IPC_INPUT_CLOSE_SENTINEL = path.join(IPC_INPUT_DIR, '_close');
+const IPC_POLL_MS = 500;
+
+/**
+ * Push-based async iterable for streaming user messages to the SDK.
+ * Keeps the iterable alive until end() is called, preventing isSingleUserTurn.
+ */
+class MessageStream {
+  private queue: SDKUserMessage[] = [];
+  private waiting: (() => void) | null = null;
+  private done = false;
+
+  push(text: string): void {
+    this.queue.push({
+      type: 'user',
+      message: { role: 'user', content: text },
+      parent_tool_use_id: null,
+      session_id: '',
+    });
+    this.waiting?.();
+  }
+
+  end(): void {
+    this.done = true;
+    this.waiting?.();
+  }
+
+  async *[Symbol.asyncIterator](): AsyncGenerator<SDKUserMessage> {
+    while (true) {
+      while (this.queue.length > 0) {
+        yield this.queue.shift()!;
+      }
+      if (this.done) return;
+      await new Promise<void>(r => { this.waiting = r; });
+      this.waiting = null;
+    }
+  }
+}
+
+async function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', chunk => { data += chunk; });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
+  });
+}
+
+const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
+const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
+
+function writeOutput(output: ContainerOutput): void {
+  console.log(OUTPUT_START_MARKER);
+  console.log(JSON.stringify(output));
+  console.log(OUTPUT_END_MARKER);
+}
+
+function log(message: string): void {
+  console.error(`[agent-runner] ${message}`);
+}
+
+function getSessionSummary(sessionId: string, transcriptPath: string): string | null {
+  const projectDir = path.dirname(transcriptPath);
+  const indexPath = path.join(projectDir, 'sessions-index.json');
+
+  if (!fs.existsSync(indexPath)) {
+    log(`Sessions index not found at ${indexPath}`);
+    return null;
+  }
+
+  try {
+    const index: SessionsIndex = JSON.parse(fs.readFileSync(indexPath, 'utf-8'));
+    const entry = index.entries.find(e => e.sessionId === sessionId);
+    if (entry?.summary) {
+      return entry.summary;
+    }
+  } catch (err) {
+    log(`Failed to read sessions index: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  return null;
+}
+
+/**
+ * Archive the full transcript to conversations/ before compaction.
+ */
+function createPreCompactHook(): HookCallback {
+  return async (input, _toolUseId, _context) => {
+    const preCompact = input as PreCompactHookInput;
+    const transcriptPath = preCompact.transcript_path;
+    const sessionId = preCompact.session_id;
+
+    if (!transcriptPath || !fs.existsSync(transcriptPath)) {
+      log('No transcript found for archiving');
+      return {};
+    }
+
+    try {
+      const content = fs.readFileSync(transcriptPath, 'utf-8');
+      const messages = parseTranscript(content);
+
+      if (messages.length === 0) {
+        log('No messages to archive');
+        return {};
+      }
+
+      const summary = getSessionSummary(sessionId, transcriptPath);
+      const name = summary ? sanitizeFilename(summary) : generateFallbackName();
+
+      const conversationsDir = '/workspace/group/conversations';
+      fs.mkdirSync(conversationsDir, { recursive: true });
+
+      const date = new Date().toISOString().split('T')[0];
+      const filename = `${date}-${name}.md`;
+      const filePath = path.join(conversationsDir, filename);
+
+      const markdown = formatTranscriptMarkdown(messages, summary);
+      fs.writeFileSync(filePath, markdown);
+
+      log(`Archived conversation to ${filePath}`);
+    } catch (err) {
+      log(`Failed to archive transcript: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    return {};
+  };
+}
+
+// Secrets to strip from Bash tool subprocess environments.
+// These are needed by claude-code for API auth but should never
+// be visible to commands Kit runs.
+const SECRET_ENV_VARS = ['ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN'];
+
+function createSanitizeBashHook(): HookCallback {
+  return async (input, _toolUseId, _context) => {
+    const preInput = input as PreToolUseHookInput;
+    const command = (preInput.tool_input as { command?: string })?.command;
+    if (!command) return {};
+
+    const unsetPrefix = `unset ${SECRET_ENV_VARS.join(' ')} 2>/dev/null; `;
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        updatedInput: {
+          ...(preInput.tool_input as Record<string, unknown>),
+          command: unsetPrefix + command,
+        },
+      },
+    };
+  };
+}
+
+function sanitizeFilename(summary: string): string {
+  return summary
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 50);
+}
+
+function generateFallbackName(): string {
+  const time = new Date();
+  return `conversation-${time.getHours().toString().padStart(2, '0')}${time.getMinutes().toString().padStart(2, '0')}`;
+}
+
+interface ParsedMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+function parseTranscript(content: string): ParsedMessage[] {
+  const messages: ParsedMessage[] = [];
+
+  for (const line of content.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const entry = JSON.parse(line);
+      if (entry.type === 'user' && entry.message?.content) {
+        const text = typeof entry.message.content === 'string'
+          ? entry.message.content
+          : entry.message.content.map((c: { text?: string }) => c.text || '').join('');
+        if (text) messages.push({ role: 'user', content: text });
+      } else if (entry.type === 'assistant' && entry.message?.content) {
+        const textParts = entry.message.content
+          .filter((c: { type: string }) => c.type === 'text')
+          .map((c: { text: string }) => c.text);
+        const text = textParts.join('');
+        if (text) messages.push({ role: 'assistant', content: text });
+      }
+    } catch {
+    }
+  }
+
+  return messages;
+}
+
+function formatTranscriptMarkdown(messages: ParsedMessage[], title?: string | null): string {
+  const now = new Date();
+  const formatDateTime = (d: Date) => d.toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true
+  });
+
+  const lines: string[] = [];
+  lines.push(`# ${title || 'Conversation'}`);
+  lines.push('');
+  lines.push(`Archived: ${formatDateTime(now)}`);
+  lines.push('');
+  lines.push('---');
+  lines.push('');
+
+  for (const msg of messages) {
+    const sender = msg.role === 'user' ? 'User' : 'Andy';
+    const content = msg.content.length > 2000
+      ? msg.content.slice(0, 2000) + '...'
+      : msg.content;
+    lines.push(`**${sender}**: ${content}`);
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Check for _close sentinel.
+ */
+function shouldClose(): boolean {
+  if (fs.existsSync(IPC_INPUT_CLOSE_SENTINEL)) {
+    try { fs.unlinkSync(IPC_INPUT_CLOSE_SENTINEL); } catch { /* ignore */ }
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Drain all pending IPC input messages.
+ * Returns messages found, or empty array.
+ */
+function drainIpcInput(): string[] {
+  try {
+    fs.mkdirSync(IPC_INPUT_DIR, { recursive: true });
+    const files = fs.readdirSync(IPC_INPUT_DIR)
+      .filter(f => f.endsWith('.json'))
+      .sort();
+
+    const messages: string[] = [];
+    for (const file of files) {
+      const filePath = path.join(IPC_INPUT_DIR, file);
+      try {
+        const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+        fs.unlinkSync(filePath);
+        if (data.type === 'message' && data.text) {
+          messages.push(data.text);
+        }
+      } catch (err) {
+        log(`Failed to process input file ${file}: ${err instanceof Error ? err.message : String(err)}`);
+        try { fs.unlinkSync(filePath); } catch { /* ignore */ }
+      }
+    }
+    return messages;
+  } catch (err) {
+    log(`IPC drain error: ${err instanceof Error ? err.message : String(err)}`);
+    return [];
+  }
+}
+
+/**
+ * Wait for a new IPC message or _close sentinel.
+ * Returns the messages as a single string, or null if _close.
+ */
+function waitForIpcMessage(): Promise<string | null> {
+  return new Promise((resolve) => {
+    const poll = () => {
+      if (shouldClose()) {
+        resolve(null);
+        return;
+      }
+      const messages = drainIpcInput();
+      if (messages.length > 0) {
+        resolve(messages.join('\n'));
+        return;
+      }
+      setTimeout(poll, IPC_POLL_MS);
+    };
+    poll();
+  });
+}
+
+/**
+ * Run a single query and stream results via writeOutput.
+ * Uses MessageStream (AsyncIterable) to keep isSingleUserTurn=false,
+ * allowing agent teams subagents to run to completion.
+ * Also pipes IPC messages into the stream during the query.
+ */
+async function runQuery(
+  prompt: string,
+  sessionId: string | undefined,
+  mcpServerPath: string,
+  containerInput: ContainerInput,
+  sdkEnv: Record<string, string | undefined>,
+  resumeAt?: string,
+): Promise<{ newSessionId?: string; lastAssistantUuid?: string; closedDuringQuery: boolean }> {
+  const stream = new MessageStream();
+  stream.push(prompt);
+
+  // Poll IPC for follow-up messages and _close sentinel during the query
+  let ipcPolling = true;
+  let closedDuringQuery = false;
+  const pollIpcDuringQuery = () => {
+    if (!ipcPolling) return;
+    if (shouldClose()) {
+      log('Close sentinel detected during query, ending stream');
+      closedDuringQuery = true;
+      stream.end();
+      ipcPolling = false;
+      return;
+    }
+    const messages = drainIpcInput();
+    for (const text of messages) {
+      log(`Piping IPC message into active query (${text.length} chars)`);
+      stream.push(text);
+    }
+    setTimeout(pollIpcDuringQuery, IPC_POLL_MS);
+  };
+  setTimeout(pollIpcDuringQuery, IPC_POLL_MS);
+
+  let newSessionId: string | undefined;
+  let lastAssistantUuid: string | undefined;
+  let messageCount = 0;
+  let resultCount = 0;
+
+  // Load global CLAUDE.md as additional system context (shared across all groups)
+  const globalClaudeMdPath = '/workspace/global/CLAUDE.md';
+  let globalClaudeMd: string | undefined;
+  if (!containerInput.isMain && fs.existsSync(globalClaudeMdPath)) {
+    globalClaudeMd = fs.readFileSync(globalClaudeMdPath, 'utf-8');
+  }
+
+  // Discover additional directories mounted at /workspace/extra/*
+  // These are passed to the SDK so their CLAUDE.md files are loaded automatically
+  const extraDirs: string[] = [];
+  const extraBase = '/workspace/extra';
+  if (fs.existsSync(extraBase)) {
+    for (const entry of fs.readdirSync(extraBase)) {
+      const fullPath = path.join(extraBase, entry);
+      if (fs.statSync(fullPath).isDirectory()) {
+        extraDirs.push(fullPath);
+      }
+    }
+  }
+  if (extraDirs.length > 0) {
+    log(`Additional directories: ${extraDirs.join(', ')}`);
+  }
+
+  for await (const message of query({
+    prompt: stream,
+    options: {
+      cwd: '/workspace/group',
+      additionalDirectories: extraDirs.length > 0 ? extraDirs : undefined,
+      resume: sessionId,
+      resumeSessionAt: resumeAt,
+      systemPrompt: globalClaudeMd
+        ? { type: 'preset' as const, preset: 'claude_code' as const, append: globalClaudeMd }
+        : undefined,
+      allowedTools: [
+        'Bash',
+        'Read', 'Write', 'Edit', 'Glob', 'Grep',
+        'WebSearch', 'WebFetch',
+        'Task', 'TaskOutput', 'TaskStop',
+        'TeamCreate', 'TeamDelete', 'SendMessage',
+        'TodoWrite', 'ToolSearch', 'Skill',
+        'NotebookEdit',
+        'mcp__nanoclaw__*'
+      ],
+      env: sdkEnv,
+      permissionMode: 'bypassPermissions',
+      allowDangerouslySkipPermissions: true,
+      settingSources: ['project', 'user'],
+      mcpServers: {
+        nanoclaw: {
+          command: 'node',
+          args: [mcpServerPath],
+          env: {
+            NANOCLAW_CHAT_JID: containerInput.chatJid,
+            NANOCLAW_GROUP_FOLDER: containerInput.groupFolder,
+            NANOCLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
+          },
+        },
+      },
+      hooks: {
+        PreCompact: [{ hooks: [createPreCompactHook()] }],
+        PreToolUse: [{ matcher: 'Bash', hooks: [createSanitizeBashHook()] }],
+      },
+    }
+  })) {
+    messageCount++;
+    const msgType = message.type === 'system' ? `system/${(message as { subtype?: string }).subtype}` : message.type;
+    log(`[msg #${messageCount}] type=${msgType}`);
+
+    if (message.type === 'assistant' && 'uuid' in message) {
+      lastAssistantUuid = (message as { uuid: string }).uuid;
+    }
+
+    if (message.type === 'system' && message.subtype === 'init') {
+      newSessionId = message.session_id;
+      log(`Session initialized: ${newSessionId}`);
+    }
+
+    if (message.type === 'system' && (message as { subtype?: string }).subtype === 'task_notification') {
+      const tn = message as { task_id: string; status: string; summary: string };
+      log(`Task notification: task=${tn.task_id} status=${tn.status} summary=${tn.summary}`);
+    }
+
+    if (message.type === 'result') {
+      resultCount++;
+      const textResult = 'result' in message ? (message as { result?: string }).result : null;
+      log(`Result #${resultCount}: subtype=${message.subtype}${textResult ? ` text=${textResult.slice(0, 200)}` : ''}`);
+      writeOutput({
+        status: 'success',
+        result: textResult || null,
+        newSessionId
+      });
+    }
+  }
+
+  ipcPolling = false;
+  log(`Query done. Messages: ${messageCount}, results: ${resultCount}, lastAssistantUuid: ${lastAssistantUuid || 'none'}, closedDuringQuery: ${closedDuringQuery}`);
+  return { newSessionId, lastAssistantUuid, closedDuringQuery };
+}
+
+async function main(): Promise<void> {
+  let containerInput: ContainerInput;
+
+  try {
+    const stdinData = await readStdin();
+    containerInput = JSON.parse(stdinData);
+    // Delete the temp file the entrypoint wrote — it contains secrets
+    try { fs.unlinkSync('/tmp/input.json'); } catch { /* may not exist */ }
+    log(`Received input for group: ${containerInput.groupFolder}`);
+  } catch (err) {
+    writeOutput({
+      status: 'error',
+      result: null,
+      error: `Failed to parse input: ${err instanceof Error ? err.message : String(err)}`
+    });
+    process.exit(1);
+  }
+
+  // Build SDK env: merge secrets into process.env for the SDK only.
+  // Secrets never touch process.env itself, so Bash subprocesses can't see them.
+  const sdkEnv: Record<string, string | undefined> = { ...process.env };
+  for (const [key, value] of Object.entries(containerInput.secrets || {})) {
+    sdkEnv[key] = value;
+  }
+
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const mcpServerPath = path.join(__dirname, 'ipc-mcp-stdio.js');
+
+  let sessionId = containerInput.sessionId;
+  fs.mkdirSync(IPC_INPUT_DIR, { recursive: true });
+
+  // Clean up stale _close sentinel from previous container runs
+  try { fs.unlinkSync(IPC_INPUT_CLOSE_SENTINEL); } catch { /* ignore */ }
+
+  // Build initial prompt (drain any pending IPC messages too)
+  let prompt = containerInput.prompt;
+  if (containerInput.isScheduledTask) {
+    prompt = `[SCHEDULED TASK - The following message was sent automatically and is not coming directly from the user or group.]\n\n${prompt}`;
+  }
+  const pending = drainIpcInput();
+  if (pending.length > 0) {
+    log(`Draining ${pending.length} pending IPC messages into initial prompt`);
+    prompt += '\n' + pending.join('\n');
+  }
+
+  // Query loop: run query → wait for IPC message → run new query → repeat
+  let resumeAt: string | undefined;
+  try {
+    while (true) {
+      log(`Starting query (session: ${sessionId || 'new'}, resumeAt: ${resumeAt || 'latest'})...`);
+
+      const queryResult = await runQuery(prompt, sessionId, mcpServerPath, containerInput, sdkEnv, resumeAt);
+      if (queryResult.newSessionId) {
+        sessionId = queryResult.newSessionId;
+      }
+      if (queryResult.lastAssistantUuid) {
+        resumeAt = queryResult.lastAssistantUuid;
+      }
+
+      // If _close was consumed during the query, exit immediately.
+      // Don't emit a session-update marker (it would reset the host's
+      // idle timer and cause a 30-min delay before the next _close).
+      if (queryResult.closedDuringQuery) {
+        log('Close sentinel consumed during query, exiting');
+        break;
+      }
+
+      // Emit session update so host can track it
+      writeOutput({ status: 'success', result: null, newSessionId: sessionId });
+
+      log('Query ended, waiting for next IPC message...');
+
+      // Wait for the next message or _close sentinel
+      const nextMessage = await waitForIpcMessage();
+      if (nextMessage === null) {
+        log('Close sentinel received, exiting');
+        break;
+      }
+
+      log(`Got new message (${nextMessage.length} chars), starting new query`);
+      prompt = nextMessage;
+    }
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    log(`Agent error: ${errorMessage}`);
+    writeOutput({
+      status: 'error',
+      result: null,
+      newSessionId: sessionId,
+      error: errorMessage
+    });
+    process.exit(1);
+  }
+}
+
+main();

--- a/.claude/skills/add-feishu/modify/src/config.ts
+++ b/.claude/skills/add-feishu/modify/src/config.ts
@@ -1,0 +1,77 @@
+import path from 'path';
+
+import { readEnvFile } from './env.js';
+
+// Read config values from .env (falls back to process.env).
+// Secrets are NOT read here — they stay on disk and are loaded only
+// where needed (container-runner.ts) to avoid leaking to child processes.
+const envConfig = readEnvFile([
+  'ASSISTANT_NAME',
+  'ASSISTANT_HAS_OWN_NUMBER',
+  'FEISHU_APP_ID',
+  'FEISHU_APP_SECRET',
+  'FEISHU_ONLY',
+]);
+
+export const ASSISTANT_NAME =
+  process.env.ASSISTANT_NAME || envConfig.ASSISTANT_NAME || 'Andy';
+export const ASSISTANT_HAS_OWN_NUMBER =
+  (process.env.ASSISTANT_HAS_OWN_NUMBER || envConfig.ASSISTANT_HAS_OWN_NUMBER) === 'true';
+export const POLL_INTERVAL = 2000;
+export const SCHEDULER_POLL_INTERVAL = 60000;
+
+// Absolute paths needed for container mounts
+const PROJECT_ROOT = process.cwd();
+const HOME_DIR = process.env.HOME || '/Users/user';
+
+// Mount security: allowlist stored OUTSIDE project root, never mounted into containers
+export const MOUNT_ALLOWLIST_PATH = path.join(
+  HOME_DIR,
+  '.config',
+  'nanoclaw',
+  'mount-allowlist.json',
+);
+export const STORE_DIR = path.resolve(PROJECT_ROOT, 'store');
+export const GROUPS_DIR = path.resolve(PROJECT_ROOT, 'groups');
+export const DATA_DIR = path.resolve(PROJECT_ROOT, 'data');
+export const MAIN_GROUP_FOLDER = 'main';
+
+export const CONTAINER_IMAGE =
+  process.env.CONTAINER_IMAGE || 'nanoclaw-agent:latest';
+export const CONTAINER_TIMEOUT = parseInt(
+  process.env.CONTAINER_TIMEOUT || '1800000',
+  10,
+);
+export const CONTAINER_MAX_OUTPUT_SIZE = parseInt(
+  process.env.CONTAINER_MAX_OUTPUT_SIZE || '10485760',
+  10,
+); // 10MB default
+export const IPC_POLL_INTERVAL = 1000;
+export const IDLE_TIMEOUT = parseInt(
+  process.env.IDLE_TIMEOUT || '1800000',
+  10,
+); // 30min default — how long to keep container alive after last result
+export const MAX_CONCURRENT_CONTAINERS = Math.max(
+  1,
+  parseInt(process.env.MAX_CONCURRENT_CONTAINERS || '5', 10) || 5,
+);
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export const TRIGGER_PATTERN = new RegExp(
+  `^@${escapeRegex(ASSISTANT_NAME)}\b`,
+  'i',
+);
+
+// Timezone for scheduled tasks (cron expressions, etc.)
+// Uses system timezone by default
+export const TIMEZONE =
+  process.env.TZ || Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+// Feishu configuration
+export const FEISHU_APP_ID = process.env.FEISHU_APP_ID || envConfig.FEISHU_APP_ID;
+export const FEISHU_APP_SECRET = process.env.FEISHU_APP_SECRET || envConfig.FEISHU_APP_SECRET;
+export const FEISHU_ONLY =
+  (process.env.FEISHU_ONLY || envConfig.FEISHU_ONLY) === 'true';

--- a/.claude/skills/add-feishu/modify/src/config.ts.intent.md
+++ b/.claude/skills/add-feishu/modify/src/config.ts.intent.md
@@ -1,0 +1,44 @@
+# Intent: src/config.ts modifications for Feishu support
+
+## What Changed
+
+Added Feishu (Lark) configuration options to enable the Feishu channel:
+
+1. **Environment variables**: Added `FEISHU_APP_ID`, `FEISHU_APP_SECRET`, `FEISHU_ONLY` to `readEnvFile` call
+2. **Config exports**: Added three new exports for Feishu configuration
+
+## Key Sections
+
+### readEnvFile Call
+Added three new environment variable names to the array:
+```typescript
+const envConfig = readEnvFile([
+  'ASSISTANT_NAME',
+  'ASSISTANT_HAS_OWN_NUMBER',
+  'FEISHU_APP_ID',
+  'FEISHU_APP_SECRET',
+  'FEISHU_ONLY',
+]);
+```
+
+### New Exports
+```typescript
+export const FEISHU_APP_ID = process.env.FEISHU_APP_ID || envConfig.FEISHU_APP_ID;
+export const FEISHU_APP_SECRET = process.env.FEISHU_APP_SECRET || envConfig.FEISHU_APP_SECRET;
+export const FEISHU_ONLY =
+  (process.env.FEISHU_ONLY || envConfig.FEISHU_ONLY) === 'true';
+```
+
+## Invariants (Must NOT Change)
+
+1. **readEnvFile pattern**: Must continue to use `readEnvFile()` helper with array of env var names
+2. **Fallback behavior**: All Feishu config should be optional (undefined when not set)
+3. **Boolean parsing**: `FEISHU_ONLY` must use `=== 'true'` pattern for proper boolean conversion
+4. **Existing exports**: All existing config exports must remain unchanged
+
+## Must Keep
+
+- Existing `ASSISTANT_NAME`, `ASSISTANT_HAS_OWN_NUMBER` handling
+- All existing path, timeout, and pattern configurations
+- The `escapeRegex` helper function
+- `TRIGGER_PATTERN` construction logic

--- a/.claude/skills/add-feishu/modify/src/container-runner.ts
+++ b/.claude/skills/add-feishu/modify/src/container-runner.ts
@@ -1,0 +1,651 @@
+/**
+ * Container Runner for NanoClaw
+ * Spawns agent execution in containers and handles IPC
+ */
+import { ChildProcess, exec, spawn } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import {
+  CONTAINER_IMAGE,
+  CONTAINER_MAX_OUTPUT_SIZE,
+  CONTAINER_TIMEOUT,
+  DATA_DIR,
+  GROUPS_DIR,
+  IDLE_TIMEOUT,
+} from './config.js';
+import { readEnvFile } from './env.js';
+import { logger } from './logger.js';
+import { CONTAINER_RUNTIME_BIN, readonlyMountArgs, stopContainer } from './container-runtime.js';
+import { validateAdditionalMounts } from './mount-security.js';
+import { RegisteredGroup } from './types.js';
+
+// Sentinel markers for robust output parsing (must match agent-runner)
+const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
+const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
+
+function getHomeDir(): string {
+  const home = process.env.HOME || os.homedir();
+  if (!home) {
+    throw new Error(
+      'Unable to determine home directory: HOME environment variable is not set and os.homedir() returned empty',
+    );
+  }
+  return home;
+}
+
+export interface ContainerInput {
+  prompt: string;
+  sessionId?: string;
+  groupFolder: string;
+  chatJid: string;
+  isMain: boolean;
+  isScheduledTask?: boolean;
+  isOneShot?: boolean;
+  secrets?: Record<string, string>;
+}
+
+export interface ContainerOutput {
+  status: 'success' | 'error';
+  result: string | null;
+  newSessionId?: string;
+  error?: string;
+}
+
+interface VolumeMount {
+  hostPath: string;
+  containerPath: string;
+  readonly: boolean;
+}
+
+function buildVolumeMounts(
+  group: RegisteredGroup,
+  isMain: boolean,
+): VolumeMount[] {
+  const mounts: VolumeMount[] = [];
+  const homeDir = getHomeDir();
+  const projectRoot = process.cwd();
+
+  if (isMain) {
+    // Main gets the entire project root mounted
+    mounts.push({
+      hostPath: projectRoot,
+      containerPath: '/workspace/project',
+      readonly: false,
+    });
+
+    // Main also gets its group folder as the working directory
+    mounts.push({
+      hostPath: path.join(GROUPS_DIR, group.folder),
+      containerPath: '/workspace/group',
+      readonly: false,
+    });
+  } else {
+    // Other groups only get their own folder
+    mounts.push({
+      hostPath: path.join(GROUPS_DIR, group.folder),
+      containerPath: '/workspace/group',
+      readonly: false,
+    });
+
+    // Global memory directory (read-only for non-main)
+    // Only directory mounts are supported, not file mounts
+    const globalDir = path.join(GROUPS_DIR, 'global');
+    if (fs.existsSync(globalDir)) {
+      mounts.push({
+        hostPath: globalDir,
+        containerPath: '/workspace/global',
+        readonly: true,
+      });
+    }
+  }
+
+  // Per-group Claude sessions directory (isolated from other groups)
+  // Each group gets their own .claude/ to prevent cross-group session access
+  const groupSessionsDir = path.join(
+    DATA_DIR,
+    'sessions',
+    group.folder,
+    '.claude',
+  );
+  fs.mkdirSync(groupSessionsDir, { recursive: true });
+  const settingsFile = path.join(groupSessionsDir, 'settings.json');
+  if (!fs.existsSync(settingsFile)) {
+    fs.writeFileSync(settingsFile, JSON.stringify({
+      env: {
+        // Enable agent swarms (subagent orchestration)
+        // https://code.claude.com/docs/en/agent-teams#orchestrate-teams-of-claude-code-sessions
+        CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1',
+        // Load CLAUDE.md from additional mounted directories
+        // https://code.claude.com/docs/en/memory#load-memory-from-additional-directories
+        CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: '1',
+        // Enable Claude's memory feature (persists user preferences between sessions)
+        // https://code.claude.com/docs/en/memory#manage-auto-memory
+        CLAUDE_CODE_DISABLE_AUTO_MEMORY: '0',
+      },
+    }, null, 2) + '\n');
+  }
+
+  // Sync skills from container/skills/ into each group's .claude/skills/
+  const skillsSrc = path.join(process.cwd(), 'container', 'skills');
+  const skillsDst = path.join(groupSessionsDir, 'skills');
+  if (fs.existsSync(skillsSrc)) {
+    for (const skillDir of fs.readdirSync(skillsSrc)) {
+      const srcDir = path.join(skillsSrc, skillDir);
+      if (!fs.statSync(srcDir).isDirectory()) continue;
+      const dstDir = path.join(skillsDst, skillDir);
+      fs.mkdirSync(dstDir, { recursive: true });
+      for (const file of fs.readdirSync(srcDir)) {
+        const srcFile = path.join(srcDir, file);
+        const dstFile = path.join(dstDir, file);
+        fs.copyFileSync(srcFile, dstFile);
+      }
+    }
+  }
+  mounts.push({
+    hostPath: groupSessionsDir,
+    containerPath: '/home/node/.claude',
+    readonly: false,
+  });
+
+  // Per-group IPC namespace: each group gets its own IPC directory
+  // This prevents cross-group privilege escalation via IPC
+  const groupIpcDir = path.join(DATA_DIR, 'ipc', group.folder);
+  fs.mkdirSync(path.join(groupIpcDir, 'messages'), { recursive: true });
+  fs.mkdirSync(path.join(groupIpcDir, 'tasks'), { recursive: true });
+  fs.mkdirSync(path.join(groupIpcDir, 'input'), { recursive: true });
+  mounts.push({
+    hostPath: groupIpcDir,
+    containerPath: '/workspace/ipc',
+    readonly: false,
+  });
+
+  // Mount agent-runner source from host — recompiled on container startup.
+  // Bypasses sticky build cache for code changes.
+  const agentRunnerSrc = path.join(projectRoot, 'container', 'agent-runner', 'src');
+  mounts.push({
+    hostPath: agentRunnerSrc,
+    containerPath: '/app/src',
+    readonly: true,
+  });
+
+  // Additional mounts validated against external allowlist (tamper-proof from containers)
+  if (group.containerConfig?.additionalMounts) {
+    const validatedMounts = validateAdditionalMounts(
+      group.containerConfig.additionalMounts,
+      group.name,
+      isMain,
+    );
+    mounts.push(...validatedMounts);
+  }
+
+  return mounts;
+}
+
+/**
+ * Read allowed secrets from .env for passing to the container via stdin.
+ * Secrets are never written to disk or mounted as files.
+ */
+function readSecrets(): Record<string, string> {
+  return readEnvFile(['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_API_KEY', 'ANTHROPIC_BASE_URL']);
+}
+
+function buildContainerArgs(mounts: VolumeMount[], containerName: string): string[] {
+  const args: string[] = ['run', '-i', '--rm', '--name', containerName];
+
+  // Run as host user so bind-mounted files are accessible.
+  // Skip when running as root (uid 0), as the container's node user (uid 1000),
+  // or when getuid is unavailable (native Windows without WSL).
+  const hostUid = process.getuid?.();
+  const hostGid = process.getgid?.();
+  if (hostUid != null && hostUid !== 0 && hostUid !== 1000) {
+    args.push('--user', `${hostUid}:${hostGid}`);
+    args.push('-e', 'HOME=/home/node');
+  }
+
+  for (const mount of mounts) {
+    if (mount.readonly) {
+      args.push(...readonlyMountArgs(mount.hostPath, mount.containerPath));
+    } else {
+      args.push('-v', `${mount.hostPath}:${mount.containerPath}`);
+    }
+  }
+
+  args.push(CONTAINER_IMAGE);
+
+  return args;
+}
+
+export async function runContainerAgent(
+  group: RegisteredGroup,
+  input: ContainerInput,
+  onProcess: (proc: ChildProcess, containerName: string) => void,
+  onOutput?: (output: ContainerOutput) => Promise<void>,
+): Promise<ContainerOutput> {
+  const startTime = Date.now();
+
+  const groupDir = path.join(GROUPS_DIR, group.folder);
+  fs.mkdirSync(groupDir, { recursive: true });
+
+  const mounts = buildVolumeMounts(group, input.isMain);
+  const safeName = group.folder.replace(/[^a-zA-Z0-9-]/g, '-');
+  const containerName = `nanoclaw-${safeName}-${Date.now()}`;
+  const containerArgs = buildContainerArgs(mounts, containerName);
+
+  logger.debug(
+    {
+      group: group.name,
+      containerName,
+      mounts: mounts.map(
+        (m) =>
+          `${m.hostPath} -> ${m.containerPath}${m.readonly ? ' (ro)' : ''}`,
+      ),
+      containerArgs: containerArgs.join(' '),
+    },
+    'Container mount configuration',
+  );
+
+  logger.info(
+    {
+      group: group.name,
+      containerName,
+      mountCount: mounts.length,
+      isMain: input.isMain,
+    },
+    'Spawning container agent',
+  );
+
+  const logsDir = path.join(GROUPS_DIR, group.folder, 'logs');
+  fs.mkdirSync(logsDir, { recursive: true });
+
+  return new Promise((resolve) => {
+    const container = spawn(CONTAINER_RUNTIME_BIN, containerArgs, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    onProcess(container, containerName);
+
+    let stdout = '';
+    let stderr = '';
+    let stdoutTruncated = false;
+    let stderrTruncated = false;
+
+    // Pass secrets via stdin (never written to disk or mounted as files)
+    input.secrets = readSecrets();
+    container.stdin.write(JSON.stringify(input));
+    container.stdin.end();
+    // Remove secrets from input so they don't appear in logs
+    delete input.secrets;
+
+    // Streaming output: parse OUTPUT_START/END marker pairs as they arrive
+    let parseBuffer = '';
+    let newSessionId: string | undefined;
+    let outputChain = Promise.resolve();
+
+    container.stdout.on('data', (data) => {
+      const chunk = data.toString();
+
+      // Always accumulate for logging
+      if (!stdoutTruncated) {
+        const remaining = CONTAINER_MAX_OUTPUT_SIZE - stdout.length;
+        if (chunk.length > remaining) {
+          stdout += chunk.slice(0, remaining);
+          stdoutTruncated = true;
+          logger.warn(
+            { group: group.name, size: stdout.length },
+            'Container stdout truncated due to size limit',
+          );
+        } else {
+          stdout += chunk;
+        }
+      }
+
+      // Stream-parse for output markers
+      if (onOutput) {
+        parseBuffer += chunk;
+        let startIdx: number;
+        while ((startIdx = parseBuffer.indexOf(OUTPUT_START_MARKER)) !== -1) {
+          const endIdx = parseBuffer.indexOf(OUTPUT_END_MARKER, startIdx);
+          if (endIdx === -1) break; // Incomplete pair, wait for more data
+
+          const jsonStr = parseBuffer
+            .slice(startIdx + OUTPUT_START_MARKER.length, endIdx)
+            .trim();
+          parseBuffer = parseBuffer.slice(endIdx + OUTPUT_END_MARKER.length);
+
+          try {
+            const parsed: ContainerOutput = JSON.parse(jsonStr);
+            if (parsed.newSessionId) {
+              newSessionId = parsed.newSessionId;
+            }
+            hadStreamingOutput = true;
+            // Activity detected — reset the hard timeout
+            resetTimeout();
+            // Call onOutput for all markers (including null results)
+            // so idle timers start even for "silent" query completions.
+            outputChain = outputChain.then(() => onOutput(parsed));
+          } catch (err) {
+            logger.warn(
+              { group: group.name, error: err },
+              'Failed to parse streamed output chunk',
+            );
+          }
+        }
+      }
+    });
+
+    container.stderr.on('data', (data) => {
+      const chunk = data.toString();
+      const lines = chunk.trim().split('\n');
+      for (const line of lines) {
+        if (line) logger.debug({ container: group.folder }, line);
+      }
+      // Don't reset timeout on stderr — SDK writes debug logs continuously.
+      // Timeout only resets on actual output (OUTPUT_MARKER in stdout).
+      if (stderrTruncated) return;
+      const remaining = CONTAINER_MAX_OUTPUT_SIZE - stderr.length;
+      if (chunk.length > remaining) {
+        stderr += chunk.slice(0, remaining);
+        stderrTruncated = true;
+        logger.warn(
+          { group: group.name, size: stderr.length },
+          'Container stderr truncated due to size limit',
+        );
+      } else {
+        stderr += chunk;
+      }
+    });
+
+    let timedOut = false;
+    let hadStreamingOutput = false;
+    const configTimeout = group.containerConfig?.timeout || CONTAINER_TIMEOUT;
+    // Grace period: hard timeout must be at least IDLE_TIMEOUT + 30s so the
+    // graceful _close sentinel has time to trigger before the hard kill fires.
+    const timeoutMs = Math.max(configTimeout, IDLE_TIMEOUT + 30_000);
+
+    const killOnTimeout = () => {
+      timedOut = true;
+      logger.error({ group: group.name, containerName }, 'Container timeout, stopping gracefully');
+      exec(stopContainer(containerName), { timeout: 15000 }, (err) => {
+        if (err) {
+          logger.warn({ group: group.name, containerName, err }, 'Graceful stop failed, force killing');
+          container.kill('SIGKILL');
+        }
+      });
+    };
+
+    let timeout = setTimeout(killOnTimeout, timeoutMs);
+
+    // Reset the timeout whenever there's activity (streaming output)
+    const resetTimeout = () => {
+      clearTimeout(timeout);
+      timeout = setTimeout(killOnTimeout, timeoutMs);
+    };
+
+    container.on('close', (code) => {
+      clearTimeout(timeout);
+      const duration = Date.now() - startTime;
+
+      if (timedOut) {
+        const ts = new Date().toISOString().replace(/[:.]/g, '-');
+        const timeoutLog = path.join(logsDir, `container-${ts}.log`);
+        fs.writeFileSync(timeoutLog, [
+          `=== Container Run Log (TIMEOUT) ===`,
+          `Timestamp: ${new Date().toISOString()}`,
+          `Group: ${group.name}`,
+          `Container: ${containerName}`,
+          `Duration: ${duration}ms`,
+          `Exit Code: ${code}`,
+          `Had Streaming Output: ${hadStreamingOutput}`,
+        ].join('\n'));
+
+        // Timeout after output = idle cleanup, not failure.
+        // The agent already sent its response; this is just the
+        // container being reaped after the idle period expired.
+        if (hadStreamingOutput) {
+          logger.info(
+            { group: group.name, containerName, duration, code },
+            'Container timed out after output (idle cleanup)',
+          );
+          outputChain.then(() => {
+            resolve({
+              status: 'success',
+              result: null,
+              newSessionId,
+            });
+          });
+          return;
+        }
+
+        logger.error(
+          { group: group.name, containerName, duration, code },
+          'Container timed out with no output',
+        );
+
+        resolve({
+          status: 'error',
+          result: null,
+          error: `Container timed out after ${configTimeout}ms`,
+        });
+        return;
+      }
+
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+      const logFile = path.join(logsDir, `container-${timestamp}.log`);
+      const isVerbose = process.env.LOG_LEVEL === 'debug' || process.env.LOG_LEVEL === 'trace';
+
+      const logLines = [
+        `=== Container Run Log ===`,
+        `Timestamp: ${new Date().toISOString()}`,
+        `Group: ${group.name}`,
+        `IsMain: ${input.isMain}`,
+        `Duration: ${duration}ms`,
+        `Exit Code: ${code}`,
+        `Stdout Truncated: ${stdoutTruncated}`,
+        `Stderr Truncated: ${stderrTruncated}`,
+        ``,
+      ];
+
+      const isError = code !== 0;
+
+      if (isVerbose || isError) {
+        logLines.push(
+          `=== Input ===`,
+          JSON.stringify(input, null, 2),
+          ``,
+          `=== Container Args ===`,
+          containerArgs.join(' '),
+          ``,
+          `=== Mounts ===`,
+          mounts
+            .map(
+              (m) =>
+                `${m.hostPath} -> ${m.containerPath}${m.readonly ? ' (ro)' : ''}`,
+            )
+            .join('\n'),
+          ``,
+          `=== Stderr${stderrTruncated ? ' (TRUNCATED)' : ''} ===`,
+          stderr,
+          ``,
+          `=== Stdout${stdoutTruncated ? ' (TRUNCATED)' : ''} ===`,
+          stdout,
+        );
+      } else {
+        logLines.push(
+          `=== Input Summary ===`,
+          `Prompt length: ${input.prompt.length} chars`,
+          `Session ID: ${input.sessionId || 'new'}`,
+          ``,
+          `=== Mounts ===`,
+          mounts
+            .map((m) => `${m.containerPath}${m.readonly ? ' (ro)' : ''}`)
+            .join('\n'),
+          ``,
+        );
+      }
+
+      fs.writeFileSync(logFile, logLines.join('\n'));
+      logger.debug({ logFile, verbose: isVerbose }, 'Container log written');
+
+      if (code !== 0) {
+        logger.error(
+          {
+            group: group.name,
+            code,
+            duration,
+            stderr,
+            stdout,
+            logFile,
+          },
+          'Container exited with error',
+        );
+
+        resolve({
+          status: 'error',
+          result: null,
+          error: `Container exited with code ${code}: ${stderr.slice(-200)}`,
+        });
+        return;
+      }
+
+      // Streaming mode: wait for output chain to settle, return completion marker
+      if (onOutput) {
+        outputChain.then(() => {
+          logger.info(
+            { group: group.name, duration, newSessionId },
+            'Container completed (streaming mode)',
+          );
+          resolve({
+            status: 'success',
+            result: null,
+            newSessionId,
+          });
+        });
+        return;
+      }
+
+      // Legacy mode: parse the last output marker pair from accumulated stdout
+      try {
+        // Extract JSON between sentinel markers for robust parsing
+        const startIdx = stdout.indexOf(OUTPUT_START_MARKER);
+        const endIdx = stdout.indexOf(OUTPUT_END_MARKER);
+
+        let jsonLine: string;
+        if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
+          jsonLine = stdout
+            .slice(startIdx + OUTPUT_START_MARKER.length, endIdx)
+            .trim();
+        } else {
+          // Fallback: last non-empty line (backwards compatibility)
+          const lines = stdout.trim().split('\n');
+          jsonLine = lines[lines.length - 1];
+        }
+
+        const output: ContainerOutput = JSON.parse(jsonLine);
+
+        logger.info(
+          {
+            group: group.name,
+            duration,
+            status: output.status,
+            hasResult: !!output.result,
+          },
+          'Container completed',
+        );
+
+        resolve(output);
+      } catch (err) {
+        logger.error(
+          {
+            group: group.name,
+            stdout,
+            stderr,
+            error: err,
+          },
+          'Failed to parse container output',
+        );
+
+        resolve({
+          status: 'error',
+          result: null,
+          error: `Failed to parse container output: ${err instanceof Error ? err.message : String(err)}`,
+        });
+      }
+    });
+
+    container.on('error', (err) => {
+      clearTimeout(timeout);
+      logger.error({ group: group.name, containerName, error: err }, 'Container spawn error');
+      resolve({
+        status: 'error',
+        result: null,
+        error: `Container spawn error: ${err.message}`,
+      });
+    });
+  });
+}
+
+export function writeTasksSnapshot(
+  groupFolder: string,
+  isMain: boolean,
+  tasks: Array<{
+    id: string;
+    groupFolder: string;
+    prompt: string;
+    schedule_type: string;
+    schedule_value: string;
+    status: string;
+    next_run: string | null;
+  }>,
+): void {
+  // Write filtered tasks to the group's IPC directory
+  const groupIpcDir = path.join(DATA_DIR, 'ipc', groupFolder);
+  fs.mkdirSync(groupIpcDir, { recursive: true });
+
+  // Main sees all tasks, others only see their own
+  const filteredTasks = isMain
+    ? tasks
+    : tasks.filter((t) => t.groupFolder === groupFolder);
+
+  const tasksFile = path.join(groupIpcDir, 'current_tasks.json');
+  fs.writeFileSync(tasksFile, JSON.stringify(filteredTasks, null, 2));
+}
+
+export interface AvailableGroup {
+  jid: string;
+  name: string;
+  lastActivity: string;
+  isRegistered: boolean;
+}
+
+/**
+ * Write available groups snapshot for the container to read.
+ * Only main group can see all available groups (for activation).
+ * Non-main groups only see their own registration status.
+ */
+export function writeGroupsSnapshot(
+  groupFolder: string,
+  isMain: boolean,
+  groups: AvailableGroup[],
+  registeredJids: Set<string>,
+): void {
+  const groupIpcDir = path.join(DATA_DIR, 'ipc', groupFolder);
+  fs.mkdirSync(groupIpcDir, { recursive: true });
+
+  // Main sees all groups; others see nothing (they can't activate groups)
+  const visibleGroups = isMain ? groups : [];
+
+  const groupsFile = path.join(groupIpcDir, 'available_groups.json');
+  fs.writeFileSync(
+    groupsFile,
+    JSON.stringify(
+      {
+        groups: visibleGroups,
+        lastSync: new Date().toISOString(),
+      },
+      null,
+      2,
+    ),
+  );
+}

--- a/.claude/skills/add-feishu/modify/src/index.ts
+++ b/.claude/skills/add-feishu/modify/src/index.ts
@@ -1,0 +1,553 @@
+import fs from 'fs';
+import path from 'path';
+
+import {
+  ASSISTANT_NAME,
+  DATA_DIR,
+  FEISHU_APP_ID,
+  FEISHU_APP_SECRET,
+  FEISHU_ONLY,
+  IDLE_TIMEOUT,
+  MAIN_GROUP_FOLDER,
+  POLL_INTERVAL,
+  TRIGGER_PATTERN,
+} from './config.js';
+import { FeishuChannel } from './channels/feishu.js';
+import { WhatsAppChannel } from './channels/whatsapp.js';
+import {
+  ContainerOutput,
+  runContainerAgent,
+  writeGroupsSnapshot,
+  writeTasksSnapshot,
+} from './container-runner.js';
+import { cleanupOrphans, ensureContainerRuntimeRunning } from './container-runtime.js';
+import {
+  getAllChats,
+  getAllRegisteredGroups,
+  getAllSessions,
+  getAllTasks,
+  getMessagesSince,
+  getNewMessages,
+  getRouterState,
+  initDatabase,
+  setRegisteredGroup,
+  setRouterState,
+  setSession,
+  storeChatMetadata,
+  storeMessage,
+} from './db.js';
+import { GroupQueue } from './group-queue.js';
+import { startIpcWatcher } from './ipc.js';
+import { findChannel, formatMessages, formatOutbound } from './router.js';
+import { startSchedulerLoop } from './task-scheduler.js';
+import { Channel, NewMessage, RegisteredGroup } from './types.js';
+import { logger } from './logger.js';
+
+// Re-export for backwards compatibility during refactor
+export { escapeXml, formatMessages } from './router.js';
+
+let lastTimestamp = '';
+let sessions: Record<string, string> = {};
+let registeredGroups: Record<string, RegisteredGroup> = {};
+let lastAgentTimestamp: Record<string, string> = {};
+let messageLoopRunning = false;
+
+let whatsapp: WhatsAppChannel;
+const channels: Channel[] = [];
+const queue = new GroupQueue();
+
+function loadState(): void {
+  lastTimestamp = getRouterState('last_timestamp') || '';
+  const agentTs = getRouterState('last_agent_timestamp');
+  try {
+    lastAgentTimestamp = agentTs ? JSON.parse(agentTs) : {};
+  } catch {
+    logger.warn('Corrupted last_agent_timestamp in DB, resetting');
+    lastAgentTimestamp = {};
+  }
+  sessions = getAllSessions();
+  registeredGroups = getAllRegisteredGroups();
+  logger.info(
+    { groupCount: Object.keys(registeredGroups).length },
+    'State loaded',
+  );
+}
+
+function saveState(): void {
+  setRouterState('last_timestamp', lastTimestamp);
+  setRouterState(
+    'last_agent_timestamp',
+    JSON.stringify(lastAgentTimestamp),
+  );
+}
+
+function registerGroup(jid: string, group: RegisteredGroup): void {
+  registeredGroups[jid] = group;
+  setRegisteredGroup(jid, group);
+
+  // Create group folder
+  const groupDir = path.join(DATA_DIR, '..', 'groups', group.folder);
+  fs.mkdirSync(path.join(groupDir, 'logs'), { recursive: true });
+
+  logger.info(
+    { jid, name: group.name, folder: group.folder },
+    'Group registered',
+  );
+}
+
+/**
+ * Get available groups list for the agent.
+ * Returns groups ordered by most recent activity.
+ */
+export function getAvailableGroups(): import('./container-runner.js').AvailableGroup[] {
+  const chats = getAllChats();
+  const registeredJids = new Set(Object.keys(registeredGroups));
+
+  return chats
+    .filter((c) => c.jid !== '__group_sync__' && c.is_group)
+    .map((c) => ({
+      jid: c.jid,
+      name: c.name,
+      lastActivity: c.last_message_time,
+      isRegistered: registeredJids.has(c.jid),
+    }));
+}
+
+/** @internal - exported for testing */
+export function _setRegisteredGroups(groups: Record<string, RegisteredGroup>): void {
+  registeredGroups = groups;
+}
+
+/**
+ * Process all pending messages for a group.
+ * Called by the GroupQueue when it's this group's turn.
+ */
+async function processGroupMessages(chatJid: string): Promise<boolean> {
+  const group = registeredGroups[chatJid];
+  if (!group) return true;
+
+  const channel = findChannel(channels, chatJid);
+  if (!channel) {
+    console.log(`Warning: no channel owns JID ${chatJid}, skipping messages`);
+    return true;
+  }
+
+  const isMainGroup = group.folder === MAIN_GROUP_FOLDER;
+
+  const sinceTimestamp = lastAgentTimestamp[chatJid] || '';
+  const missedMessages = getMessagesSince(chatJid, sinceTimestamp, ASSISTANT_NAME);
+
+  if (missedMessages.length === 0) return true;
+
+  // For non-main groups, check if trigger is required and present
+  if (!isMainGroup && group.requiresTrigger !== false) {
+    const hasTrigger = missedMessages.some((m) =>
+      TRIGGER_PATTERN.test(m.content.trim()),
+    );
+    if (!hasTrigger) return true;
+  }
+
+  const prompt = formatMessages(missedMessages);
+
+  // Advance cursor so the piping path in startMessageLoop won't re-fetch
+  // these messages. Save the old cursor so we can roll back on error.
+  const previousCursor = lastAgentTimestamp[chatJid] || '';
+  lastAgentTimestamp[chatJid] =
+    missedMessages[missedMessages.length - 1].timestamp;
+  saveState();
+
+  logger.info(
+    { group: group.name, messageCount: missedMessages.length },
+    'Processing messages',
+  );
+
+  // Track idle timer for closing stdin when agent is idle
+  let idleTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const resetIdleTimer = () => {
+    if (idleTimer) clearTimeout(idleTimer);
+    idleTimer = setTimeout(() => {
+      logger.debug({ group: group.name }, 'Idle timeout, closing container stdin');
+      queue.closeStdin(chatJid);
+    }, IDLE_TIMEOUT);
+  };
+
+  await channel.setTyping?.(chatJid, true);
+  let hadError = false;
+  let outputSentToUser = false;
+
+  // Determine if we should use streaming mode
+  // Feishu uses non-streaming to prevent duplicate messages from multiple agent outputs
+  // Other channels use streaming for real-time feedback
+  const isFeishu = chatJid.startsWith('feishu:');
+  const useStreaming = !isFeishu;
+
+  const output = await runAgent(group, prompt, chatJid, async (result) => {
+    // Called for each agent result (both streaming and non-streaming).
+    // In streaming mode: send messages immediately for real-time feedback.
+    // In non-streaming mode: skip sending here (final result is sent
+    //   after container exits to prevent duplicate messages); but always
+    //   reset the idle timer so the container exit chain works.
+    if (result.result) {
+      // Always reset idle timer so the container eventually gets _close
+      resetIdleTimer();
+
+      if (useStreaming) {
+        const raw = typeof result.result === 'string' ? result.result : JSON.stringify(result.result);
+        // Strip <internal>...</internal> blocks — agent uses these for internal reasoning
+        const text = raw.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
+        logger.info({ group: group.name, textPreview: text.slice(0, 200) }, `Agent output: ${text.slice(0, 100)}`);
+        if (text) {
+          await channel.sendMessage(chatJid, text);
+          outputSentToUser = true;
+        }
+      }
+    }
+
+    if (result.status === 'error') {
+      hadError = true;
+    }
+  }, useStreaming);
+
+  await channel.setTyping?.(chatJid, false);
+  // Mark processing complete to clear typing indicators and message context
+  await channel.markProcessingComplete?.(chatJid);
+  if (idleTimer) clearTimeout(idleTimer);
+
+  if (output === 'error' || hadError) {
+    // If we already sent output to the user, don't roll back the cursor —
+    // the user got their response and re-processing would send duplicates.
+    if (outputSentToUser) {
+      logger.warn({ group: group.name }, 'Agent error after output was sent, skipping cursor rollback to prevent duplicates');
+      return true;
+    }
+    // Roll back cursor so retries can re-process these messages
+    lastAgentTimestamp[chatJid] = previousCursor;
+    saveState();
+    logger.warn({ group: group.name }, 'Agent error, rolled back message cursor for retry');
+    return false;
+  }
+
+  return true;
+}
+
+async function runAgent(
+  group: RegisteredGroup,
+  prompt: string,
+  chatJid: string,
+  onOutput?: (output: ContainerOutput) => Promise<void>,
+  streaming: boolean = true,
+): Promise<'success' | 'error'> {
+  const isMain = group.folder === MAIN_GROUP_FOLDER;
+  const sessionId = sessions[group.folder];
+
+  // Update tasks snapshot for container to read (filtered by group)
+  const tasks = getAllTasks();
+  writeTasksSnapshot(
+    group.folder,
+    isMain,
+    tasks.map((t) => ({
+      id: t.id,
+      groupFolder: t.group_folder,
+      prompt: t.prompt,
+      schedule_type: t.schedule_type,
+      schedule_value: t.schedule_value,
+      status: t.status,
+      next_run: t.next_run,
+    })),
+  );
+
+  // Update available groups snapshot (main group only can see all groups)
+  const availableGroups = getAvailableGroups();
+  writeGroupsSnapshot(
+    group.folder,
+    isMain,
+    availableGroups,
+    new Set(Object.keys(registeredGroups)),
+  );
+
+  // Always wrap onOutput for runContainerAgent — the callback MUST be
+  // provided so that stdout output markers are parsed in real-time.
+  // This drives the idle timer chain that lets the container exit:
+  //   output marker → onOutput → resetIdleTimer → closeStdin → _close
+  const wrappedOnOutput = onOutput
+    ? async (output: ContainerOutput) => {
+      if (output.newSessionId) {
+        sessions[group.folder] = output.newSessionId;
+        setSession(group.folder, output.newSessionId);
+      }
+      await onOutput(output);
+    }
+    : undefined;
+
+  try {
+    logger.info({ group: group.name, streaming }, 'runAgent: starting container agent');
+    const output = await runContainerAgent(
+      group,
+      {
+        prompt,
+        sessionId,
+        groupFolder: group.folder,
+        chatJid,
+        isMain,
+        isOneShot: !streaming,
+      },
+      (proc, containerName) => queue.registerProcess(chatJid, proc, containerName, group.folder),
+      wrappedOnOutput,
+    );
+
+    logger.info({ group: group.name, status: output.status, hasResult: !!output.result, hasError: !!output.error }, 'runAgent: container agent completed');
+
+    if (output.newSessionId) {
+      sessions[group.folder] = output.newSessionId;
+      setSession(group.folder, output.newSessionId);
+    }
+
+    // Non-streaming mode: process the final result after container completes
+    if (!streaming && onOutput) {
+      logger.info({ group: group.name, status: output.status, hasResult: !!output.result }, 'Non-streaming: container completed, processing result');
+      if (output.status === 'success' && output.result) {
+        // Call onOutput directly to handle the result (this triggers the callback in processMessages)
+        await onOutput({
+          status: 'success',
+          result: output.result,
+          newSessionId: output.newSessionId,
+        });
+      } else {
+        logger.warn({ group: group.name, status: output.status, result: output.result, error: output.error }, 'Non-streaming: no result to send');
+      }
+    }
+
+    if (output.status === 'error') {
+      logger.error(
+        { group: group.name, error: output.error },
+        'Container agent error',
+      );
+      return 'error';
+    }
+
+    return 'success';
+  } catch (err) {
+    logger.error({ group: group.name, err }, 'Agent error');
+    return 'error';
+  }
+}
+
+async function startMessageLoop(): Promise<void> {
+  if (messageLoopRunning) {
+    logger.debug('Message loop already running, skipping duplicate start');
+    return;
+  }
+  messageLoopRunning = true;
+
+  logger.info(`NanoClaw running (trigger: @${ASSISTANT_NAME})`);
+
+  while (true) {
+    try {
+      const jids = Object.keys(registeredGroups);
+      const { messages, newTimestamp } = getNewMessages(jids, lastTimestamp, ASSISTANT_NAME);
+
+      if (messages.length > 0) {
+        logger.info({ count: messages.length }, 'New messages');
+
+        // Advance the "seen" cursor for all messages immediately
+        lastTimestamp = newTimestamp;
+        saveState();
+
+        // Deduplicate by group
+        const messagesByGroup = new Map<string, NewMessage[]>();
+        for (const msg of messages) {
+          const existing = messagesByGroup.get(msg.chat_jid);
+          if (existing) {
+            existing.push(msg);
+          } else {
+            messagesByGroup.set(msg.chat_jid, [msg]);
+          }
+        }
+
+        for (const [chatJid, groupMessages] of messagesByGroup) {
+          const group = registeredGroups[chatJid];
+          if (!group) continue;
+
+          const channel = findChannel(channels, chatJid);
+          if (!channel) {
+            console.log(`Warning: no channel owns JID ${chatJid}, skipping messages`);
+            continue;
+          }
+
+          const isMainGroup = group.folder === MAIN_GROUP_FOLDER;
+          const needsTrigger = !isMainGroup && group.requiresTrigger !== false;
+
+          // For non-main groups, only act on trigger messages.
+          // Non-trigger messages accumulate in DB and get pulled as
+          // context when a trigger eventually arrives.
+          if (needsTrigger) {
+            const hasTrigger = groupMessages.some((m) =>
+              TRIGGER_PATTERN.test(m.content.trim()),
+            );
+            if (!hasTrigger) continue;
+          }
+
+          // Pull all messages since lastAgentTimestamp so non-trigger
+          // context that accumulated between triggers is included.
+          const allPending = getMessagesSince(
+            chatJid,
+            lastAgentTimestamp[chatJid] || '',
+            ASSISTANT_NAME,
+          );
+          const messagesToSend =
+            allPending.length > 0 ? allPending : groupMessages;
+          const formatted = formatMessages(messagesToSend);
+
+          if (queue.sendMessage(chatJid, formatted)) {
+            logger.debug(
+              { chatJid, count: messagesToSend.length },
+              'Piped messages to active container',
+            );
+            lastAgentTimestamp[chatJid] =
+              messagesToSend[messagesToSend.length - 1].timestamp;
+            saveState();
+            // Show typing indicator while the container processes the piped message
+            channel.setTyping?.(chatJid, true);
+          } else {
+            // No active container — enqueue for a new one
+            queue.enqueueMessageCheck(chatJid);
+          }
+        }
+      }
+    } catch (err) {
+      logger.error({ err }, 'Error in message loop');
+    }
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL));
+  }
+}
+
+/**
+ * Startup recovery: check for unprocessed messages in registered groups.
+ * Handles crash between advancing lastTimestamp and processing messages.
+ */
+function recoverPendingMessages(): void {
+  for (const [chatJid, group] of Object.entries(registeredGroups)) {
+    const sinceTimestamp = lastAgentTimestamp[chatJid] || '';
+    const pending = getMessagesSince(chatJid, sinceTimestamp, ASSISTANT_NAME);
+    if (pending.length > 0) {
+      logger.info(
+        { group: group.name, pendingCount: pending.length },
+        'Recovery: found unprocessed messages',
+      );
+      queue.enqueueMessageCheck(chatJid);
+    }
+  }
+}
+
+function ensureContainerSystemRunning(): void {
+  ensureContainerRuntimeRunning();
+  cleanupOrphans();
+}
+
+async function main(): Promise<void> {
+  ensureContainerSystemRunning();
+  initDatabase();
+  logger.info('Database initialized');
+  loadState();
+
+  // Graceful shutdown handlers
+  const shutdown = async (signal: string) => {
+    logger.info({ signal }, 'Shutdown signal received');
+    await queue.shutdown(10000);
+    for (const ch of channels) await ch.disconnect();
+    process.exit(0);
+  };
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+  process.on('SIGINT', () => shutdown('SIGINT'));
+
+  // Channel callbacks (shared by all channels)
+  const channelOpts = {
+    onMessage: (_chatJid: string, msg: NewMessage) => storeMessage(msg),
+    onChatMetadata: (chatJid: string, timestamp: string, name?: string, channel?: string, isGroup?: boolean) =>
+      storeChatMetadata(chatJid, timestamp, name, channel, isGroup),
+    registeredGroups: () => registeredGroups,
+  };
+
+  // Create and connect channels
+  // If FEISHU_ONLY is set, skip WhatsApp and only use Feishu
+  if (FEISHU_ONLY && FEISHU_APP_ID && FEISHU_APP_SECRET) {
+    const feishu = new FeishuChannel({
+      appId: FEISHU_APP_ID,
+      appSecret: FEISHU_APP_SECRET,
+      onMessage: (_chatJid: string, msg: NewMessage) => storeMessage(msg),
+      onChatMetadata: (chatJid: string, timestamp: string, name?: string, channel?: string, isGroup?: boolean) =>
+        storeChatMetadata(chatJid, timestamp, name, channel, isGroup),
+      registeredGroups: () => registeredGroups,
+      registerGroup: async (jid: string, group: RegisteredGroup) => registerGroup(jid, group),
+      mainGroupFolder: MAIN_GROUP_FOLDER,
+    });
+    channels.push(feishu);
+    await feishu.connect();
+  } else {
+    // Use WhatsApp by default
+    whatsapp = new WhatsAppChannel(channelOpts);
+    channels.push(whatsapp);
+    await whatsapp.connect();
+
+    // Add Feishu channel if configured ( alongside WhatsApp)
+    if (FEISHU_APP_ID && FEISHU_APP_SECRET) {
+      const feishu = new FeishuChannel({
+        appId: FEISHU_APP_ID,
+        appSecret: FEISHU_APP_SECRET,
+        onMessage: (_chatJid: string, msg: NewMessage) => storeMessage(msg),
+        onChatMetadata: (chatJid: string, timestamp: string, name?: string, channel?: string, isGroup?: boolean) =>
+          storeChatMetadata(chatJid, timestamp, name, channel, isGroup),
+        registeredGroups: () => registeredGroups,
+        registerGroup: async (jid: string, group: RegisteredGroup) => registerGroup(jid, group),
+        mainGroupFolder: MAIN_GROUP_FOLDER,
+      });
+      channels.push(feishu);
+      await feishu.connect();
+    }
+  }
+
+  // Start subsystems (independently of connection handler)
+  startSchedulerLoop({
+    registeredGroups: () => registeredGroups,
+    getSessions: () => sessions,
+    queue,
+    onProcess: (groupJid, proc, containerName, groupFolder) => queue.registerProcess(groupJid, proc, containerName, groupFolder),
+    sendMessage: async (jid, rawText) => {
+      const channel = findChannel(channels, jid);
+      if (!channel) {
+        console.log(`Warning: no channel owns JID ${jid}, cannot send message`);
+        return;
+      }
+      const text = formatOutbound(rawText);
+      if (text) await channel.sendMessage(jid, text);
+    },
+  });
+  startIpcWatcher({
+    sendMessage: (jid, text) => {
+      const channel = findChannel(channels, jid);
+      if (!channel) throw new Error(`No channel for JID: ${jid}`);
+      return channel.sendMessage(jid, text);
+    },
+    registeredGroups: () => registeredGroups,
+    registerGroup,
+    syncGroupMetadata: (force) => whatsapp?.syncGroupMetadata(force) ?? Promise.resolve(),
+    getAvailableGroups,
+    writeGroupsSnapshot: (gf, im, ag, rj) => writeGroupsSnapshot(gf, im, ag, rj),
+  });
+  queue.setProcessMessagesFn(processGroupMessages);
+  recoverPendingMessages();
+  startMessageLoop();
+}
+
+// Guard: only run when executed directly, not when imported by tests
+const isDirectRun =
+  process.argv[1] &&
+  new URL(import.meta.url).pathname === new URL(`file://${process.argv[1]}`).pathname;
+
+if (isDirectRun) {
+  main().catch((err) => {
+    logger.error({ err }, 'Failed to start NanoClaw');
+    process.exit(1);
+  });
+}

--- a/.claude/skills/add-feishu/modify/src/index.ts.intent.md
+++ b/.claude/skills/add-feishu/modify/src/index.ts.intent.md
@@ -1,0 +1,75 @@
+# Intent: src/index.ts modifications for Feishu support
+
+## What Changed
+
+Added Feishu (Lark) channel support alongside existing WhatsApp channel:
+
+1. **Imports**: Added `FeishuChannel` import and `FEISHU_APP_ID`, `FEISHU_APP_SECRET`, `FEISHU_ONLY` config imports
+2. **Channel initialization**: Replaced single WhatsApp initialization with conditional logic:
+   - If `FEISHU_ONLY=true`: Use only Feishu channel
+   - Otherwise: Use WhatsApp + optional Feishu if credentials configured
+
+## Key Sections
+
+### Import Changes
+```typescript
+import { FeishuChannel } from './channels/feishu.js';
+import {
+  // ... existing imports
+  FEISHU_APP_ID,
+  FEISHU_APP_SECRET,
+  FEISHU_ONLY,
+  // ...
+} from './config.js';
+```
+
+### Channel Initialization Logic
+```typescript
+// Create and connect channels
+// If FEISHU_ONLY is set, skip WhatsApp and only use Feishu
+if (FEISHU_ONLY && FEISHU_APP_ID && FEISHU_APP_SECRET) {
+  const feishu = new FeishuChannel({
+    appId: FEISHU_APP_ID,
+    appSecret: FEISHU_APP_SECRET,
+    onMessage: (_chatJid: string, msg: NewMessage) => storeMessage(msg),
+    onChatMetadata: (chatJid: string, timestamp: string, name?: string, channel?: string, isGroup?: boolean) =>
+      storeChatMetadata(chatJid, timestamp, name, channel, isGroup),
+    registeredGroups: () => registeredGroups,
+  });
+  channels.push(feishu);
+  await feishu.connect();
+} else {
+  // Use WhatsApp by default
+  whatsapp = new WhatsAppChannel(channelOpts);
+  channels.push(whatsapp);
+  await whatsapp.connect();
+
+  // Add Feishu channel if configured ( alongside WhatsApp)
+  if (FEISHU_APP_ID && FEISHU_APP_SECRET) {
+    const feishu = new FeishuChannel({
+      appId: FEISHU_APP_ID,
+      appSecret: FEISHU_APP_SECRET,
+      onMessage: (_chatJid: string, msg: NewMessage) => storeMessage(msg),
+      onChatMetadata: (chatJid: string, timestamp: string, name?: string, channel?: string, isGroup?: boolean) =>
+        storeChatMetadata(chatJid, timestamp, name, channel, isGroup),
+      registeredGroups: () => registeredGroups,
+    });
+    channels.push(feishu);
+    await feishu.connect();
+  }
+}
+```
+
+## Invariants (Must NOT Change)
+
+1. **WhatsApp is default**: When no `FEISHU_ONLY` flag is set and no Feishu credentials provided, WhatsApp must still work as before
+2. **Channel callbacks**: The `channelOpts` object structure must remain consistent for all channels
+3. **Multi-channel routing**: `findChannel()` function must continue to work with mixed channel types
+4. **Graceful degradation**: If Feishu connection fails, other channels should continue working
+
+## Must Keep
+
+- `let whatsapp: WhatsAppChannel;` declaration (for WhatsApp users)
+- `const channels: Channel[] = [];` array initialization
+- `channelOpts` callback definitions for message handling
+- Existing shutdown logic that iterates over all channels

--- a/.claude/skills/add-feishu/modify/src/routing.test.ts
+++ b/.claude/skills/add-feishu/modify/src/routing.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { _initTestDatabase, getAllChats, storeChatMetadata } from './db.js';
+import { getAvailableGroups, _setRegisteredGroups } from './index.js';
+
+beforeEach(() => {
+  _initTestDatabase();
+  _setRegisteredGroups({});
+});
+
+// --- JID ownership patterns ---
+
+describe('JID ownership patterns', () => {
+  // These test the patterns that will become ownsJid() on the Channel interface
+
+  it('WhatsApp group JID: ends with @g.us', () => {
+    const jid = '12345678@g.us';
+    expect(jid.endsWith('@g.us')).toBe(true);
+  });
+
+  it('WhatsApp DM JID: ends with @s.whatsapp.net', () => {
+    const jid = '12345678@s.whatsapp.net';
+    expect(jid.endsWith('@s.whatsapp.net')).toBe(true);
+  });
+
+  it('Feishu JID: starts with feishu:', () => {
+    const jid = 'feishu:oc_xxxxxxxxxxxxxxxx';
+    expect(jid.startsWith('feishu:')).toBe(true);
+  });
+});
+
+// --- getAvailableGroups ---
+
+describe('getAvailableGroups', () => {
+  it('returns only groups, excludes DMs', () => {
+    storeChatMetadata('group1@g.us', '2024-01-01T00:00:01.000Z', 'Group 1', 'whatsapp', true);
+    storeChatMetadata('user@s.whatsapp.net', '2024-01-01T00:00:02.000Z', 'User DM', 'whatsapp', false);
+    storeChatMetadata('group2@g.us', '2024-01-01T00:00:03.000Z', 'Group 2', 'whatsapp', true);
+
+    const groups = getAvailableGroups();
+    expect(groups).toHaveLength(2);
+    expect(groups.map((g) => g.jid)).toContain('group1@g.us');
+    expect(groups.map((g) => g.jid)).toContain('group2@g.us');
+    expect(groups.map((g) => g.jid)).not.toContain('user@s.whatsapp.net');
+  });
+
+  it('excludes __group_sync__ sentinel', () => {
+    storeChatMetadata('__group_sync__', '2024-01-01T00:00:00.000Z');
+    storeChatMetadata('group@g.us', '2024-01-01T00:00:01.000Z', 'Group', 'whatsapp', true);
+
+    const groups = getAvailableGroups();
+    expect(groups).toHaveLength(1);
+    expect(groups[0].jid).toBe('group@g.us');
+  });
+
+  it('marks registered groups correctly', () => {
+    storeChatMetadata('reg@g.us', '2024-01-01T00:00:01.000Z', 'Registered', 'whatsapp', true);
+    storeChatMetadata('unreg@g.us', '2024-01-01T00:00:02.000Z', 'Unregistered', 'whatsapp', true);
+
+    _setRegisteredGroups({
+      'reg@g.us': {
+        name: 'Registered',
+        folder: 'registered',
+        trigger: '@Andy',
+        added_at: '2024-01-01T00:00:00.000Z',
+      },
+    });
+
+    const groups = getAvailableGroups();
+    const reg = groups.find((g) => g.jid === 'reg@g.us');
+    const unreg = groups.find((g) => g.jid === 'unreg@g.us');
+
+    expect(reg?.isRegistered).toBe(true);
+    expect(unreg?.isRegistered).toBe(false);
+  });
+
+  it('returns groups ordered by most recent activity', () => {
+    storeChatMetadata('old@g.us', '2024-01-01T00:00:01.000Z', 'Old', 'whatsapp', true);
+    storeChatMetadata('new@g.us', '2024-01-01T00:00:05.000Z', 'New', 'whatsapp', true);
+    storeChatMetadata('mid@g.us', '2024-01-01T00:00:03.000Z', 'Mid', 'whatsapp', true);
+
+    const groups = getAvailableGroups();
+    expect(groups[0].jid).toBe('new@g.us');
+    expect(groups[1].jid).toBe('mid@g.us');
+    expect(groups[2].jid).toBe('old@g.us');
+  });
+
+  it('excludes non-group chats regardless of JID format', () => {
+    // Unknown JID format stored without is_group should not appear
+    storeChatMetadata('unknown-format-123', '2024-01-01T00:00:01.000Z', 'Unknown');
+    // Explicitly non-group with unusual JID
+    storeChatMetadata('custom:abc', '2024-01-01T00:00:02.000Z', 'Custom DM', 'custom', false);
+    // A real group for contrast
+    storeChatMetadata('group@g.us', '2024-01-01T00:00:03.000Z', 'Group', 'whatsapp', true);
+
+    const groups = getAvailableGroups();
+    expect(groups).toHaveLength(1);
+    expect(groups[0].jid).toBe('group@g.us');
+  });
+
+  it('returns empty array when no chats exist', () => {
+    const groups = getAvailableGroups();
+    expect(groups).toHaveLength(0);
+  });
+
+  it('includes Feishu groups when marked as groups', () => {
+    storeChatMetadata('feishu:oc_abc123', '2024-01-01T00:00:01.000Z', 'Feishu Group', 'feishu', true);
+    storeChatMetadata('group@g.us', '2024-01-01T00:00:02.000Z', 'WhatsApp Group', 'whatsapp', true);
+
+    const groups = getAvailableGroups();
+    expect(groups).toHaveLength(2);
+    expect(groups.map((g) => g.jid)).toContain('feishu:oc_abc123');
+    expect(groups.map((g) => g.jid)).toContain('group@g.us');
+  });
+});

--- a/.claude/skills/add-feishu/modify/src/routing.test.ts.intent.md
+++ b/.claude/skills/add-feishu/modify/src/routing.test.ts.intent.md
@@ -1,0 +1,21 @@
+# routing.test.ts Changes
+
+## Purpose
+Add tests for Feishu JID format support in the routing system.
+
+## Changes
+
+### JID Ownership Pattern Tests
+Added a test case for Feishu JID format:
+- Feishu JIDs start with `feishu:` prefix
+- Example: `feishu:oc_xxxxxxxxxxxxxxxx`
+
+### getAvailableGroups Tests
+Added test case `includes Feishu groups when marked as groups`:
+- Verifies Feishu group chats are included in available groups
+- Tests both Feishu and WhatsApp groups can coexist
+
+## Invariants
+- Existing WhatsApp tests remain unchanged
+- All existing assertions preserved
+- New tests follow same patterns as existing tests

--- a/.claude/skills/add-feishu/tests/feishu.test.ts
+++ b/.claude/skills/add-feishu/tests/feishu.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+describe('feishu skill package', () => {
+  const skillDir = path.resolve(__dirname, '..');
+
+  it('has a valid manifest', () => {
+    const manifestPath = path.join(skillDir, 'manifest.yaml');
+    expect(fs.existsSync(manifestPath)).toBe(true);
+
+    const content = fs.readFileSync(manifestPath, 'utf-8');
+    expect(content).toContain('skill: add-feishu');
+    expect(content).toContain('version: 1.0.0');
+    expect(content).toContain('@larksuiteoapi/node-sdk');
+  });
+
+  it('has all files declared in adds', () => {
+    const addFile = path.join(skillDir, 'add', 'src', 'channels', 'feishu.ts');
+    expect(fs.existsSync(addFile)).toBe(true);
+
+    const content = fs.readFileSync(addFile, 'utf-8');
+    expect(content).toContain('class FeishuChannel');
+    expect(content).toContain('implements Channel');
+    expect(content).toContain("name = 'feishu'");
+    expect(content).toContain('WSClient');
+    expect(content).toContain('im.message.receive_v1');
+
+    // Test file for the channel
+    const testFile = path.join(skillDir, 'add', 'src', 'channels', 'feishu.test.ts');
+    expect(fs.existsSync(testFile)).toBe(true);
+
+    const testContent = fs.readFileSync(testFile, 'utf-8');
+    expect(testContent).toContain("describe('FeishuChannel'");
+  });
+
+  it('has all files declared in modifies', () => {
+    const indexFile = path.join(skillDir, 'modify', 'src', 'index.ts');
+    const configFile = path.join(skillDir, 'modify', 'src', 'config.ts');
+    const routingTestFile = path.join(skillDir, 'modify', 'src', 'routing.test.ts');
+
+    expect(fs.existsSync(indexFile)).toBe(true);
+    expect(fs.existsSync(configFile)).toBe(true);
+    expect(fs.existsSync(routingTestFile)).toBe(true);
+
+    const indexContent = fs.readFileSync(indexFile, 'utf-8');
+    expect(indexContent).toContain('FeishuChannel');
+    expect(indexContent).toContain('FEISHU_APP_ID');
+    expect(indexContent).toContain('FEISHU_APP_SECRET');
+    expect(indexContent).toContain('FEISHU_ONLY');
+    expect(indexContent).toContain('findChannel');
+    expect(indexContent).toContain('channels: Channel[]');
+
+    const configContent = fs.readFileSync(configFile, 'utf-8');
+    expect(configContent).toContain('FEISHU_APP_ID');
+    expect(configContent).toContain('FEISHU_APP_SECRET');
+    expect(configContent).toContain('FEISHU_ONLY');
+  });
+
+  it('has intent files for modified files', () => {
+    expect(fs.existsSync(path.join(skillDir, 'modify', 'src', 'index.ts.intent.md'))).toBe(true);
+    expect(fs.existsSync(path.join(skillDir, 'modify', 'src', 'config.ts.intent.md'))).toBe(true);
+    expect(fs.existsSync(path.join(skillDir, 'modify', 'src', 'routing.test.ts.intent.md'))).toBe(true);
+  });
+
+  it('has SKILL.md documentation', () => {
+    const skillMdPath = path.join(skillDir, 'SKILL.md');
+    expect(fs.existsSync(skillMdPath)).toBe(true);
+
+    const content = fs.readFileSync(skillMdPath, 'utf-8');
+    expect(content).toContain('Feishu');
+    expect(content).toContain('飞书');
+    expect(content).toContain('FEISHU_APP_ID');
+    expect(content).toContain('FEISHU_APP_SECRET');
+  });
+
+  it('modified index.ts preserves core structure', () => {
+    const content = fs.readFileSync(
+      path.join(skillDir, 'modify', 'src', 'index.ts'),
+      'utf-8',
+    );
+
+    // Core functions still present
+    expect(content).toContain('function loadState()');
+    expect(content).toContain('function saveState()');
+    expect(content).toContain('function registerGroup(');
+    expect(content).toContain('function getAvailableGroups()');
+    expect(content).toContain('function processGroupMessages(');
+    expect(content).toContain('function runAgent(');
+    expect(content).toContain('function startMessageLoop()');
+    expect(content).toContain('function recoverPendingMessages()');
+    expect(content).toContain('function ensureContainerSystemRunning()');
+    expect(content).toContain('async function main()');
+
+    // Test helper preserved
+    expect(content).toContain('_setRegisteredGroups');
+
+    // Direct-run guard preserved
+    expect(content).toContain('isDirectRun');
+  });
+
+  it('modified index.ts includes Feishu channel creation', () => {
+    const content = fs.readFileSync(
+      path.join(skillDir, 'modify', 'src', 'index.ts'),
+      'utf-8',
+    );
+
+    // Multi-channel architecture
+    expect(content).toContain('const channels: Channel[] = []');
+    expect(content).toContain('channels.push(feishu)');
+
+    // Feishu-only mode support
+    expect(content).toContain('if (FEISHU_ONLY && FEISHU_APP_ID && FEISHU_APP_SECRET)');
+    expect(content).toContain('// Use WhatsApp by default');
+    expect(content).toContain('// Add Feishu channel if configured ( alongside WhatsApp)');
+
+    // Shutdown disconnects all channels
+    expect(content).toContain('for (const ch of channels) await ch.disconnect()');
+  });
+
+  it('modified config.ts preserves all existing exports', () => {
+    const content = fs.readFileSync(
+      path.join(skillDir, 'modify', 'src', 'config.ts'),
+      'utf-8',
+    );
+
+    // All original exports preserved
+    expect(content).toContain('export const ASSISTANT_NAME');
+    expect(content).toContain('export const POLL_INTERVAL');
+    expect(content).toContain('export const TRIGGER_PATTERN');
+    expect(content).toContain('export const CONTAINER_IMAGE');
+    expect(content).toContain('export const DATA_DIR');
+    expect(content).toContain('export const TIMEZONE');
+  });
+
+  it('modified routing.test.ts includes Feishu JID pattern tests', () => {
+    const content = fs.readFileSync(
+      path.join(skillDir, 'modify', 'src', 'routing.test.ts'),
+      'utf-8',
+    );
+
+    expect(content).toContain("Feishu JID: starts with feishu:");
+    expect(content).toContain('feishu:oc_xxxxxxxxxxxxxxxx');
+    expect(content).toContain('includes Feishu groups when marked as groups');
+    expect(content).toContain("'feishu:oc_abc123'");
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds a comprehensive skill for Feishu (Lark) integration (.claude/skills/add-feishu). It supports group chats, private messages (with auto-registration), and rich text (post) messages via WebSocket long connection.

Additionally, this PR includes a critical fix for a container deadlock issue that occurs in non-streaming modes (like Feishu).

## Key Features (Feishu Skill)
- WebSocket Connection: No public URL/webhook needed.
- Auto-Registration: Private chats are automatically registered upon first message.
- Rich Interaction: Supports "Typing" reaction indicators and message threading (replies) in groups.
- Isolated Context: Automatically creates a dedicated CLAUDE.md for new groups to guide the agent's behavior on Feishu.

## Technical Fix: Container Deadlock
During development, we identified a deadlock where the container would hang indefinitely in non-streaming mode because the Host failed to parse stdout markers when no intermediate output was expected.

- The Fix: Introduced an isOneShot flag in the ContainerInput protocol. If true, the container's agent-runner cleanly terminates the Claude SDK's message stream and exits immediately after the first result.
- Robustness: Restored the mandatory onOutput callback in runAgent to ensure the Host's idle-timer and _close sentinel chain always function correctly.

## How to Test
- Apply the skill: npx tsx scripts/apply-skill.ts .claude/skills/add-feishu
- Configure FEISHU_APP_ID and FEISHU_APP_SECRET in .env.
- Run npm run build && npm run start.
- Message the bot on Feishu.
- Verify: The bot responds, and the "Typing" reaction is correctly removed after the response (confirming the container exited cleanly).

## Philosophy Alignment
Following the "Skills over Features" guide, this PR avoids polluting the core codebase with channel-specific logic. All changes are encapsulated within the skill package, allowing users to opt-in to Feishu support without bloating the base system.


## Demo
- User send a messagen and nanoclaw reply with emoji for reacton:
![055e85a2-802d-4e6e-9cea-837b3aee8ef1](https://github.com/user-attachments/assets/1a1d4037-03ce-4896-aabc-5e717e6f5da3)

- Then nanoclaw reply:
![0f8151c8-60f2-4508-984e-5e2202e9bc79](https://github.com/user-attachments/assets/b56222e0-7748-4a3a-b6c5-45553a23470c)




