### PR TITLE
fix: pre-create /home/node/.claude in container to avoid EACCES on startup

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -56,7 +56,8 @@ RUN mkdir -p /workspace/group /workspace/global /workspace/extra /workspace/ipc/
 RUN printf '#!/bin/bash\nset -e\ncd /app && npx tsc --outDir /tmp/dist 2>&1 >&2\nln -s /app/node_modules /tmp/dist/node_modules\nchmod -R a-w /tmp/dist\ncat > /tmp/input.json\nnode /tmp/dist/index.js < /tmp/input.json\n' > /app/entrypoint.sh && chmod +x /app/entrypoint.sh
 
 # Set ownership to node user (non-root) for writable directories
-RUN chown -R node:node /workspace && chmod 777 /home/node
+RUN chown -R node:node /workspace && chmod 777 /home/node \
+    && mkdir -p /home/node/.claude && chown -R node:node /home/node/.claude
 
 # Switch to non-root user (required for --dangerously-skip-permissions)
 USER node


### PR DESCRIPTION
## Summary
- The Claude Agent SDK tries to `mkdir /home/node/.claude/debug` on init
- When the host-mounted `.claude` directory is owned by root, the container's `node` user gets `EACCES` and crashes before responding
- Fix: pre-create `/home/node/.claude` in the Dockerfile and set ownership to `node`

## Test plan
- [ ] Build container with `./container/build.sh`
- [ ] Send a message in the registered WhatsApp group and confirm the agent responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)