### PR TITLE
feat: add webhook server for receiving external events

### DIFF
--- a/.claude/skills/add-github-webhooks/SKILL.md
+++ b/.claude/skills/add-github-webhooks/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: add-github-webhooks
+description: Receive GitHub webhook events (issues, pull requests, push) as agent messages. Creates a webhook token, registers it with GitHub repos, and teaches the agent how to parse and respond to events.
+---
+
+# Add GitHub Webhooks
+
+This skill connects NanoClaw to GitHub repositories via webhooks. When someone opens an issue, comments, creates a PR, or pushes code, the agent receives it as a message and can act on it.
+
+NanoClaw's webhook server is already running — this skill wires it to GitHub.
+
+## Phase 1: Pre-flight
+
+### Check if already applied
+
+Read `.nanoclaw/state.yaml`. If `add-github-webhooks` is in `applied_skills`, skip to Phase 4 (Register a Repo). The infrastructure is already in place.
+
+### Check webhook server
+
+The webhook server starts automatically with NanoClaw on port 3333 (configurable via `WEBHOOK_PORT` in `.env`). Confirm it is running:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" http://localhost:3333/webhook/test
+```
+
+Expected: `401` (server running, invalid token) or `404`. Any response confirms the server is up. If the command hangs or errors, check that NanoClaw is running.
+
+### Ask the user
+
+1. **Which group** should receive GitHub events? (Default: main group)
+2. **Do they have a GitHub Personal Access Token** with `admin:repo_hook` scope? This is needed to register webhooks via the API. If no, they can register manually via the GitHub web UI and skip Phase 3.
+3. **Public URL** for the webhook: do they have ngrok, a Cloudflare tunnel, or another way to expose port 3333? If not, explain the options and wait.
+
+## Phase 2: Create Webhook Token
+
+Create a webhook token scoped to the group's JID:
+
+```bash
+npx tsx scripts/webhook-token.ts create github
+```
+
+This prints the token and registers it in `data/webhooks.json`. Save the token — you'll need it for the webhook URL.
+
+The webhook URL will be:
+
+```
+https://<public-url>/webhook/<token>
+```
+
+Example: `https://abc123.ngrok-free.dev/webhook/8b5aea47-b490-4ecc-b801-5dc63e75d2af`
+
+Show this URL to the user — they need it for manual registration or to confirm the registration script used it correctly.
+
+## Phase 3: Create Helper Scripts
+
+Create a `skills/webhook/` directory in the group folder (e.g., `groups/main/skills/webhook/`).
+
+### parse-github-event.js
+
+Create `groups/main/skills/webhook/parse-github-event.js`. This script takes a raw GitHub webhook payload (JSON string) and returns a human-readable summary. It should handle:
+
+- **issue_comment** (payload has both `comment` and `issue`): extract action, issue number and title, commenter login, comment body (truncated to 300 chars), and comment URL
+- **issue** (payload has `issue` but no `comment`): extract action, issue number and title, opener login, body preview, and issue URL; mark as urgent if `action === 'opened'`
+- **pull_request** (payload has `pull_request`): extract action, PR number and title, author login, body preview, and PR URL; mark as urgent if action is `opened` or `review_requested`
+- **push** (payload has `ref` and `commits`): extract branch name, commit count, first 3 commits (message + author); not urgent
+- **ping** (payload has `zen`): return the zen string and hook ID; not urgent
+- **unknown**: return raw JSON truncated to 200 chars
+
+The script should accept JSON via `process.argv[2]` or stdin, print the summary, and export `parseGitHubEvent(payload)` for programmatic use.
+
+### github-register.js
+
+Create `groups/main/skills/webhook/github-register.js`. This script registers Orac's webhook with a GitHub repository via the GitHub API. It should:
+
+- Accept `<owner/repo>` as the first argument, optional event names as subsequent args
+- Default events: `['issues', 'issue_comment', 'pull_request', 'push']`
+- Read the public URL from a local config file (`webhook-config.json` in the same directory)
+- Read the webhook token from `data/webhooks.json` (find the entry where `source === 'github'`)
+- Read `GITHUB_TOKEN` from `secrets/github.env` or the project `.env`
+- POST to `https://api.github.com/repos/<owner/repo>/hooks` with the webhook URL and events
+- On success: print the hook ID and save a registration record to `registrations.json` in the same directory
+- On failure: print the GitHub API error and exit nonzero
+
+Also create `groups/main/skills/webhook/webhook-config.json`:
+
+```json
+{
+  "public_base_url": "",
+  "comment": "Set public_base_url to the tunnel URL exposing port 3333 (e.g. https://xxxx.ngrok-free.dev). Full webhook URL: {public_base_url}/webhook/{token}"
+}
+```
+
+Ask the user for their public URL and fill it in.
+
+### registrations.json
+
+Create an empty `groups/main/skills/webhook/registrations.json`:
+
+```json
+{}
+```
+
+This will be populated by `github-register.js` as repos are registered.
+
+## Phase 4: Update Group Memory
+
+Add a section to the group's `CLAUDE.md` that tells the agent how to handle GitHub webhook events. The section should cover:
+
+1. **Identifying webhook messages**: they arrive with `[WEBHOOK from github]` at the start of the content, followed by the JSON payload.
+
+2. **Parsing them**: run `node skills/webhook/parse-github-event.js '<json>'` to get a human-readable summary.
+
+3. **OKG recording**: if the payload's `sender.login` is not the agent's own GitHub account, record an OKG encounter for that actor via the OKG API.
+
+4. **Event handling priorities**:
+   - `issue_comment` → notify the collaborator immediately with summary and URL
+   - `issue` opened → notify the collaborator immediately
+   - `pull_request` opened or `review_requested` → notify immediately
+   - `push` → log silently unless it is a repo being actively tracked
+   - `ping` → confirm webhook is live, no notification needed
+
+5. **Registering new repos**: run `node skills/webhook/github-register.js <owner/repo>` to register a webhook with a new repository.
+
+## Phase 5: Register a Repo (Optional)
+
+If the user has a GitHub PAT and wants to register a repo now:
+
+```bash
+node groups/main/skills/webhook/github-register.js <owner/repo>
+```
+
+Example:
+
+```bash
+node groups/main/skills/webhook/github-register.js myorg/my-project
+```
+
+If they want to register manually: direct them to their repo's **Settings > Webhooks > Add webhook**, set the Payload URL to the webhook URL from Phase 2, Content type to `application/json`, and select the desired events.
+
+## Phase 6: Record Skill as Applied
+
+Update `.nanoclaw/state.yaml` to record that this skill has been applied:
+
+```bash
+npx tsx scripts/apply-skill.ts --record add-github-webhooks
+```
+
+If the `--record` flag does not exist, add `add-github-webhooks` to the `applied_skills` list in `.nanoclaw/state.yaml` manually.
+
+## Phase 7: Verify
+
+### Send a test ping
+
+After registering at least one repo, send a ping from GitHub:
+
+> GitHub repo > Settings > Webhooks > select webhook > **Redeliver** (or use the ping button)
+
+The agent should receive a message starting with `[WEBHOOK from github]` and containing `"zen":`.
+
+### Check webhook server logs
+
+```bash
+tail -f logs/nanoclaw.log | grep webhook
+```
+
+Expected: `Webhook received` log line with `source: github`.
+
+## Troubleshooting
+
+### 401 from webhook server
+
+Token was not created or `data/webhooks.json` was not saved. Re-run Phase 2.
+
+### Webhook events not arriving
+
+1. Confirm the public URL is reachable from the internet: `curl -s https://<public-url>/webhook/test` should return `{"error":"Invalid token"}` (401), confirming the server is reachable.
+2. Confirm the tunnel is running and pointed at port 3333.
+3. Check GitHub's delivery log: repo > Settings > Webhooks > select webhook > Recent Deliveries.
+
+### Events arriving but not being processed
+
+The group's CLAUDE.md must contain the `[WEBHOOK from github]` handling instructions (Phase 4). Check that they were added correctly.
+
+### Token shows up in data/webhooks.json but the group JID is wrong
+
+Delete the token and recreate: `npx tsx scripts/webhook-token.ts revoke <token>`, then `npx tsx scripts/webhook-token.ts create github`. Confirm the correct group JID is used.

--- a/.claude/skills/add-github-webhooks/manifest.yaml
+++ b/.claude/skills/add-github-webhooks/manifest.yaml
@@ -1,0 +1,10 @@
+skill: add-github-webhooks
+version: 1.0.0
+description: "Receive GitHub webhook events (issues, PRs, push) as agent messages"
+core_version: 0.1.0
+adds: []
+modifies: []
+structured:
+  env_additions: []
+conflicts: []
+depends: []

--- a/scripts/webhook-token.ts
+++ b/scripts/webhook-token.ts
@@ -1,0 +1,115 @@
+/**
+ * Manage webhook tokens.
+ *
+ * Usage:
+ *   npx tsx scripts/webhook-token.ts create <source> [groupJid]
+ *   npx tsx scripts/webhook-token.ts list
+ *   npx tsx scripts/webhook-token.ts revoke <token>
+ */
+
+import path from 'path';
+import fs from 'fs';
+
+const DATA_DIR = path.resolve(process.cwd(), 'data');
+const TOKENS_PATH = path.join(DATA_DIR, 'webhooks.json');
+
+// Inline token helpers to avoid importing the full app (which triggers logger/db init)
+import crypto from 'crypto';
+
+interface TokenEntry { source: string; groupJid: string; created: string }
+interface TokensFile { tokens: Record<string, TokenEntry> }
+
+function readFile(): TokensFile {
+  try {
+    return JSON.parse(fs.readFileSync(TOKENS_PATH, 'utf-8'));
+  } catch {
+    return { tokens: {} };
+  }
+}
+
+function writeFile(data: TokensFile): void {
+  fs.mkdirSync(path.dirname(TOKENS_PATH), { recursive: true });
+  fs.writeFileSync(TOKENS_PATH, JSON.stringify(data, null, 2));
+}
+
+// Resolve default group JID from the DB
+import { createRequire } from 'module';
+function getMainGroupJid(): string | null {
+  try {
+    const req = createRequire(import.meta.url);
+    const Database = req('better-sqlite3');
+    const dbPath = path.resolve(process.cwd(), 'store', 'messages.db');
+    const db = new Database(dbPath);
+    const row = db.prepare(
+      "SELECT jid FROM registered_groups WHERE folder = 'main' LIMIT 1",
+    ).get() as { jid: string } | undefined;
+    db.close();
+    return row?.jid ?? null;
+  } catch {
+    return null;
+  }
+}
+
+const [, , command, ...args] = process.argv;
+
+switch (command) {
+  case 'create': {
+    const source = args[0];
+    if (!source) {
+      console.error('Usage: webhook-token.ts create <source> [groupJid]');
+      process.exit(1);
+    }
+    const groupJid = args[1] || getMainGroupJid();
+    if (!groupJid) {
+      console.error('No group JID provided and could not determine main group from DB.');
+      process.exit(1);
+    }
+    const data = readFile();
+    const token = crypto.randomUUID();
+    data.tokens[token] = { source, groupJid, created: new Date().toISOString() };
+    writeFile(data);
+    console.log(`Token created for "${source}":`);
+    console.log(`  ${token}`);
+    console.log(`  Group: ${groupJid}`);
+    console.log(`\nTest with:`);
+    console.log(`  curl -X POST http://localhost:3333/webhook/${token} -H 'Content-Type: application/json' -d '{"test":true}'`);
+    break;
+  }
+
+  case 'list': {
+    const data = readFile();
+    const entries = Object.entries(data.tokens);
+    if (entries.length === 0) {
+      console.log('No webhook tokens configured.');
+    } else {
+      for (const [token, entry] of entries) {
+        console.log(`${token}  source=${entry.source}  group=${entry.groupJid}  created=${entry.created}`);
+      }
+    }
+    break;
+  }
+
+  case 'revoke': {
+    const token = args[0];
+    if (!token) {
+      console.error('Usage: webhook-token.ts revoke <token>');
+      process.exit(1);
+    }
+    const data = readFile();
+    if (!data.tokens[token]) {
+      console.error('Token not found.');
+      process.exit(1);
+    }
+    delete data.tokens[token];
+    writeFile(data);
+    console.log('Token revoked.');
+    break;
+  }
+
+  default:
+    console.log('Usage:');
+    console.log('  npx tsx scripts/webhook-token.ts create <source> [groupJid]');
+    console.log('  npx tsx scripts/webhook-token.ts list');
+    console.log('  npx tsx scripts/webhook-token.ts revoke <token>');
+    process.exit(command ? 1 : 0);
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -66,3 +66,5 @@ export const TRIGGER_PATTERN = new RegExp(
 // Uses system timezone by default
 export const TIMEZONE =
   process.env.TZ || Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+export const WEBHOOK_PORT = parseInt(process.env.WEBHOOK_PORT || '3333', 10);

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import {
   MAIN_GROUP_FOLDER,
   POLL_INTERVAL,
   TRIGGER_PATTERN,
+  WEBHOOK_PORT,
 } from './config.js';
 import { WhatsAppChannel } from './channels/whatsapp.js';
 import {
@@ -31,9 +32,11 @@ import {
   setSession,
   storeChatMetadata,
   storeMessage,
+  storeMessageDirect,
 } from './db.js';
 import { GroupQueue } from './group-queue.js';
 import { startIpcWatcher } from './ipc.js';
+import { startWebhookServer } from './webhook-server.js';
 import { findChannel, formatMessages, formatOutbound } from './router.js';
 import { startSchedulerLoop } from './task-scheduler.js';
 import { Channel, NewMessage, RegisteredGroup } from './types.js';
@@ -517,6 +520,7 @@ async function main(): Promise<void> {
     getAvailableGroups,
     writeGroupsSnapshot: (gf, im, ag, rj) => writeGroupsSnapshot(gf, im, ag, rj),
   });
+  startWebhookServer({ port: WEBHOOK_PORT, storeMessage: storeMessageDirect });
   queue.setProcessMessagesFn(processGroupMessages);
   recoverPendingMessages();
   startMessageLoop();

--- a/src/webhook-server.ts
+++ b/src/webhook-server.ts
@@ -1,0 +1,144 @@
+import crypto from 'crypto';
+import http from 'http';
+
+import { logger } from './logger.js';
+import { validateToken } from './webhook-tokens.js';
+
+// Deduplication: prevent processing the same webhook event twice.
+// Providers retry failed deliveries with exponential backoff — without this,
+// a slow handler or transient error causes duplicate messages.
+const DEDUP_WINDOW_MS = 24 * 60 * 60 * 1000; // 24 hours
+const seenEventIds = new Map<string, number>(); // eventId -> timestamp (ms)
+
+function extractEventId(headers: http.IncomingHttpHeaders, body: string): string {
+  // Check standard event ID headers across common providers
+  for (const h of ['x-github-delivery', 'x-request-id', 'x-webhook-id', 'x-event-id']) {
+    const val = headers[h];
+    if (val && typeof val === 'string') return val;
+  }
+  // Fall back to SHA-256 of body — deterministic across retries of the same payload
+  return crypto.createHash('sha256').update(body).digest('hex').slice(0, 32);
+}
+
+function isDuplicate(eventId: string): boolean {
+  if (seenEventIds.has(eventId)) return true;
+
+  // Evict stale entries to keep memory bounded
+  const now = Date.now();
+  if (seenEventIds.size > 10_000) {
+    for (const [id, ts] of seenEventIds) {
+      if (now - ts > DEDUP_WINDOW_MS) seenEventIds.delete(id);
+    }
+  }
+
+  seenEventIds.set(eventId, now);
+  return false;
+}
+
+const MAX_BODY_SIZE = 1_048_576; // 1MB
+
+interface WebhookServerOpts {
+  port: number;
+  storeMessage: (msg: {
+    id: string;
+    chat_jid: string;
+    sender: string;
+    sender_name: string;
+    content: string;
+    timestamp: string;
+    is_from_me: boolean;
+  }) => void;
+}
+
+export function startWebhookServer(opts: WebhookServerOpts): http.Server {
+  const { port, storeMessage } = opts;
+
+  const server = http.createServer((req, res) => {
+    // Only accept POST /webhook/:token
+    if (req.method !== 'POST') {
+      res.writeHead(405, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Method not allowed' }));
+      return;
+    }
+
+    const match = req.url?.match(/^\/webhook\/([a-f0-9-]+)$/);
+    if (!match) {
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Not found' }));
+      return;
+    }
+
+    const token = match[1];
+    const tokenInfo = validateToken(token);
+    if (!tokenInfo) {
+      res.writeHead(401, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Invalid token' }));
+      return;
+    }
+
+    let body = '';
+    let exceeded = false;
+
+    req.on('data', (chunk: Buffer) => {
+      body += chunk.toString();
+      if (body.length > MAX_BODY_SIZE) {
+        exceeded = true;
+        req.destroy();
+      }
+    });
+
+    req.on('end', () => {
+      if (exceeded) {
+        res.writeHead(413, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Payload too large' }));
+        return;
+      }
+
+      const eventId = extractEventId(req.headers, body);
+      if (isDuplicate(eventId)) {
+        logger.info({ source: tokenInfo.source, eventId }, 'Duplicate webhook event ignored');
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: true, duplicate: true }));
+        return;
+      }
+
+      let payload: unknown;
+      try {
+        payload = body ? JSON.parse(body) : {};
+      } catch {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Invalid JSON' }));
+        return;
+      }
+
+      const now = new Date().toISOString();
+      const msgId = `webhook-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const content = `[WEBHOOK from ${tokenInfo.source}]\n${JSON.stringify(payload, null, 2)}`;
+
+      storeMessage({
+        id: msgId,
+        chat_jid: tokenInfo.groupJid,
+        sender: 'webhook',
+        sender_name: tokenInfo.source,
+        content,
+        timestamp: now,
+        is_from_me: false,
+      });
+
+      logger.info({ source: tokenInfo.source, groupJid: tokenInfo.groupJid }, 'Webhook received');
+
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+    });
+  });
+
+  server.on('error', (err) => {
+    logger.error({ err }, 'Webhook server error');
+  });
+
+  server.listen(port, '127.0.0.1', () => {
+    logger.info({ port }, 'Webhook server listening');
+  });
+
+  return server;
+}

--- a/src/webhook-tokens.ts
+++ b/src/webhook-tokens.ts
@@ -1,0 +1,55 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+
+import { DATA_DIR } from './config.js';
+
+interface TokenEntry {
+  source: string;
+  groupJid: string;
+  created: string;
+}
+
+interface TokensFile {
+  tokens: Record<string, TokenEntry>;
+}
+
+const TOKENS_PATH = path.join(DATA_DIR, 'webhooks.json');
+
+function readFile(): TokensFile {
+  try {
+    return JSON.parse(fs.readFileSync(TOKENS_PATH, 'utf-8'));
+  } catch {
+    return { tokens: {} };
+  }
+}
+
+function writeFile(data: TokensFile): void {
+  fs.mkdirSync(path.dirname(TOKENS_PATH), { recursive: true });
+  fs.writeFileSync(TOKENS_PATH, JSON.stringify(data, null, 2));
+}
+
+export function loadTokens(): Record<string, TokenEntry> {
+  return readFile().tokens;
+}
+
+export function validateToken(token: string): { source: string; groupJid: string } | null {
+  const entry = readFile().tokens[token];
+  return entry ? { source: entry.source, groupJid: entry.groupJid } : null;
+}
+
+export function generateToken(source: string, groupJid: string): string {
+  const data = readFile();
+  const token = crypto.randomUUID();
+  data.tokens[token] = { source, groupJid, created: new Date().toISOString() };
+  writeFile(data);
+  return token;
+}
+
+export function revokeToken(token: string): boolean {
+  const data = readFile();
+  if (!data.tokens[token]) return false;
+  delete data.tokens[token];
+  writeFile(data);
+  return true;
+}

--- a/src/webhook.test.ts
+++ b/src/webhook.test.ts
@@ -1,0 +1,221 @@
+import http from 'http';
+import fs from 'fs';
+import path from 'path';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { startWebhookServer } from './webhook-server.js';
+
+// --- Token module tests ---
+// We test tokens via the file they read/write, using a temp dir
+
+const tmpDir = path.join(__dirname, '..', '.test-webhook-tmp');
+const tokensPath = path.join(tmpDir, 'webhooks.json');
+
+// Mock config.DATA_DIR so webhook-tokens reads/writes our temp dir
+vi.mock('./config.js', () => ({
+  DATA_DIR: path.join(__dirname, '..', '.test-webhook-tmp'),
+}));
+
+// Import after mock is set up
+const tokens = await import('./webhook-tokens.js');
+
+beforeEach(() => {
+  fs.mkdirSync(tmpDir, { recursive: true });
+  // Clean slate
+  try { fs.unlinkSync(tokensPath); } catch { /* ok */ }
+});
+
+afterEach(() => {
+  try { fs.rmSync(tmpDir, { recursive: true }); } catch { /* ok */ }
+});
+
+describe('webhook-tokens', () => {
+  it('generates a token and validates it', () => {
+    const token = tokens.generateToken('github', 'main@g.us');
+    expect(token).toMatch(/^[a-f0-9-]+$/);
+
+    const info = tokens.validateToken(token);
+    expect(info).toEqual({ source: 'github', groupJid: 'main@g.us' });
+  });
+
+  it('returns null for unknown token', () => {
+    expect(tokens.validateToken('nonexistent')).toBeNull();
+  });
+
+  it('loads all tokens', () => {
+    tokens.generateToken('github', 'main@g.us');
+    tokens.generateToken('email', 'other@g.us');
+
+    const all = tokens.loadTokens();
+    expect(Object.keys(all)).toHaveLength(2);
+  });
+
+  it('revokes a token', () => {
+    const token = tokens.generateToken('github', 'main@g.us');
+    expect(tokens.revokeToken(token)).toBe(true);
+    expect(tokens.validateToken(token)).toBeNull();
+  });
+
+  it('returns false when revoking nonexistent token', () => {
+    expect(tokens.revokeToken('nope')).toBe(false);
+  });
+
+  it('handles missing webhooks.json gracefully', () => {
+    // No file exists — loadTokens should return empty
+    expect(tokens.loadTokens()).toEqual({});
+    expect(tokens.validateToken('anything')).toBeNull();
+  });
+});
+
+// --- Webhook server tests ---
+
+describe('webhook-server', () => {
+  let server: http.Server;
+  let port: number;
+  const stored: Array<{ id: string; chat_jid: string; sender: string; sender_name: string; content: string }> = [];
+
+  beforeEach(async () => {
+    stored.length = 0;
+
+    // Create a test token
+    tokens.generateToken('test-source', 'group@g.us');
+
+    // Find the token we just created
+    const all = tokens.loadTokens();
+    const testToken = Object.keys(all)[0];
+
+    // Start server on a random port
+    server = startWebhookServer({
+      port: 0, // OS picks a free port
+      storeMessage: (msg) => { stored.push(msg); },
+    });
+
+    // Wait for listen
+    await new Promise<void>((resolve) => server.once('listening', resolve));
+    const addr = server.address() as { port: number };
+    port = addr.port;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  function getTestToken(): string {
+    const all = tokens.loadTokens();
+    return Object.keys(all)[0];
+  }
+
+  function request(
+    method: string,
+    urlPath: string,
+    body?: string,
+  ): Promise<{ status: number; body: string }> {
+    return new Promise((resolve, reject) => {
+      const req = http.request(
+        { hostname: '127.0.0.1', port, path: urlPath, method, headers: { 'Content-Type': 'application/json' } },
+        (res) => {
+          let data = '';
+          res.on('data', (chunk) => { data += chunk; });
+          res.on('end', () => resolve({ status: res.statusCode!, body: data }));
+        },
+      );
+      req.on('error', reject);
+      if (body) req.write(body);
+      req.end();
+    });
+  }
+
+  it('accepts valid webhook POST and stores message', async () => {
+    const token = getTestToken();
+    const res = await request('POST', `/webhook/${token}`, JSON.stringify({ event: 'push', repo: 'foo' }));
+
+    expect(res.status).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ ok: true });
+    expect(stored).toHaveLength(1);
+    expect(stored[0].chat_jid).toBe('group@g.us');
+    expect(stored[0].sender).toBe('webhook');
+    expect(stored[0].sender_name).toBe('test-source');
+    expect(stored[0].content).toContain('[WEBHOOK from test-source]');
+    expect(stored[0].content).toContain('"event": "push"');
+  });
+
+  it('returns 401 for invalid token', async () => {
+    const res = await request('POST', '/webhook/00000000-0000-0000-0000-000000000000', '{}');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 for bad path', async () => {
+    const res = await request('POST', '/other', '{}');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 405 for non-POST method', async () => {
+    const token = getTestToken();
+    const res = await request('GET', `/webhook/${token}`);
+    expect(res.status).toBe(405);
+  });
+
+  it('returns 400 for invalid JSON', async () => {
+    const token = getTestToken();
+    const res = await request('POST', `/webhook/${token}`, 'not json{{{');
+    expect(res.status).toBe(400);
+  });
+
+  it('accepts empty body as empty object', async () => {
+    const token = getTestToken();
+    const res = await request('POST', `/webhook/${token}`, '');
+    expect(res.status).toBe(200);
+    expect(stored).toHaveLength(1);
+    expect(stored[0].content).toContain('{}');
+  });
+
+  it('deduplicates identical payloads without an event ID header', async () => {
+    const token = getTestToken();
+    // Use a unique payload to avoid collision with other tests that share module-level seenEventIds
+    const body = JSON.stringify({ event: 'dedup-test', unique: 'payload-for-dedup-test' });
+
+    const res1 = await request('POST', `/webhook/${token}`, body);
+    expect(res1.status).toBe(200);
+    expect(JSON.parse(res1.body)).toEqual({ ok: true });
+    expect(stored).toHaveLength(1);
+
+    // Same payload again — should be ignored
+    const res2 = await request('POST', `/webhook/${token}`, body);
+    expect(res2.status).toBe(200);
+    expect(JSON.parse(res2.body)).toEqual({ ok: true, duplicate: true });
+    expect(stored).toHaveLength(1); // still 1, not 2
+  });
+
+  it('deduplicates by x-github-delivery header', async () => {
+    const token = getTestToken();
+    const deliveryId = 'abc-123-delivery-id';
+
+    function requestWithHeader(body: string): Promise<{ status: number; body: string }> {
+      return new Promise((resolve, reject) => {
+        const req = http.request(
+          {
+            hostname: '127.0.0.1', port, path: `/webhook/${token}`, method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'x-github-delivery': deliveryId },
+          },
+          (res) => {
+            let data = '';
+            res.on('data', (chunk) => { data += chunk; });
+            res.on('end', () => resolve({ status: res.statusCode!, body: data }));
+          },
+        );
+        req.on('error', reject);
+        req.write(body);
+        req.end();
+      });
+    }
+
+    const res1 = await requestWithHeader(JSON.stringify({ event: 'push' }));
+    expect(JSON.parse(res1.body)).toEqual({ ok: true });
+    expect(stored).toHaveLength(1);
+
+    // Different body, same delivery ID — still duplicate
+    const res2 = await requestWithHeader(JSON.stringify({ event: 'different' }));
+    expect(JSON.parse(res2.body)).toEqual({ ok: true, duplicate: true });
+    expect(stored).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds an HTTP webhook server (port 3333, configurable via `WEBHOOK_PORT`) that accepts `POST /webhook/:token`, validates bearer tokens, deduplicates events (by provider header or payload hash), and stores messages in the DB for agent processing
- Token management CLI (`scripts/webhook-token.ts`) for create/list/revoke operations
- Standalone modules (`webhook-server.ts`, `webhook-tokens.ts`) with minimal integration: 1 line in `config.ts`, 3 lines in `index.ts`
- Skill guide (`.claude/skills/add-github-webhooks/`) for wiring GitHub repos to the webhook endpoint
- 14 tests covering token CRUD, HTTP status codes, JSON validation, deduplication, and header-based event ID extraction

Supersedes #359 (skill docs only — this PR includes the full implementation).

## Test plan

- [x] `npm run build` compiles clean
- [x] `npx vitest run src/webhook.test.ts` — all 14 tests pass
- [ ] Manual: `curl -X POST http://localhost:3333/webhook/<token> -H 'Content-Type: application/json' -d '{"test":true}'` returns `{"ok":true}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)