### PR TITLE
fix: ensure docker session dir writable and document verification

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -108,6 +108,9 @@ function buildVolumeMounts(
     '.claude',
   );
   fs.mkdirSync(groupSessionsDir, { recursive: true });
+  // Container runs as non-root "node" user (uid 1000); ensure writable.
+  // Host-created dirs default to root:root 755, which blocks SDK debug/session files.
+  fs.chmodSync(groupSessionsDir, 0o777);
   const settingsFile = path.join(groupSessionsDir, 'settings.json');
   if (!fs.existsSync(settingsFile)) {
     fs.writeFileSync(settingsFile, JSON.stringify({


### PR DESCRIPTION
## Summary

This PR fixes a Docker runtime permission issue where agent containers fail to start with:

  EACCES: permission denied, mkdir '/home/node/.claude/debug'

The problem occurs because per-group session directories under data/sessions/*/.claude are created on the host as root:root with default 755, while the container runs as non-root user node (uid 1000).

## Changes

- src/container-runner.ts
      - After creating groupSessionsDir, explicitly set permissions:
      - fs.chmodSync(groupSessionsDir, 0o777)
      - Added a short comment explaining why this is required for Docker bind mounts and non-root container execution.
- .claude/skills/convert-to-docker/SKILL.md
      - Added an explicit required patch step for groupSessionsDir writeability.
      - Added a required message-processing verification step to check logs for permission errors.
      - Added targeted troubleshooting guidance for:
          - EACCES: permission denied, mkdir '/home/node/.claude/debug'

## Why this fix

Without writable .claude session mounts, Docker-mode message intake can reach container launch but fail during runtime startup, causing retries and no successful agent execution.

## Validation

- Confirmed code includes writable permission enforcement on per-group .claude session directory.
- Skill documentation now includes concrete verification/troubleshooting steps to prevent regression in future Docker conversions.

## Scope

This PR is intentionally narrow and only addresses the .claude mount permission bug and related skill instructions.

