### PR TITLE
fix: refresh current_tasks.json snapshot after IPC task mutations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -465,6 +465,7 @@ async function main(): Promise<void> {
     syncGroupMetadata: (force) => whatsapp?.syncGroupMetadata(force) ?? Promise.resolve(),
     getAvailableGroups,
     writeGroupsSnapshot: (gf, im, ag, rj) => writeGroupsSnapshot(gf, im, ag, rj),
+    writeTasksSnapshot: (gf, im, tasks) => writeTasksSnapshot(gf, im, tasks),
   });
   queue.setProcessMessagesFn(processGroupMessages);
   recoverPendingMessages();

--- a/src/ipc-auth.test.ts
+++ b/src/ipc-auth.test.ts
@@ -61,6 +61,7 @@ beforeEach(() => {
     syncGroupMetadata: async () => {},
     getAvailableGroups: () => [],
     writeGroupsSnapshot: () => {},
+    writeTasksSnapshot: () => {},
   };
 });
 


### PR DESCRIPTION
## Summary

- When the agent creates, pauses, resumes, or cancels a task via IPC during a running container session, `current_tasks.json` was never updated until the *next* agent run
- This caused the agent to see a stale task list within the same session — e.g. creating a task and immediately listing tasks would not show the new one
- Fix: call `writeTasksSnapshot` immediately after each task mutation in `processTaskIpc`, so the agent sees the updated list within the same container session

## Test plan

- [ ] Add `writeTasksSnapshot` mock to `ipc-auth.test.ts` (included — required for build)
- [ ] Start a container session, create a task via IPC, then immediately list tasks — new task should appear
- [ ] Pause/resume/cancel a task within the same session and verify the snapshot reflects the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)