### PR TITLE
feat: add @mention support to send_message for WhatsApp

### DIFF
--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -45,13 +45,15 @@ server.tool(
   {
     text: z.string().describe('The message text to send'),
     sender: z.string().optional().describe('Your role/identity name (e.g. "Researcher"). When set, messages appear from a dedicated bot in Telegram.'),
+    mentions: z.array(z.string()).optional().describe('Phone numbers to @mention in the message (e.g. ["31612345678"]). The host will resolve these to WhatsApp participant IDs.'),
   },
   async (args) => {
-    const data: Record<string, string | undefined> = {
+    const data: Record<string, string | string[] | undefined> = {
       type: 'message',
       chatJid,
       text: args.text,
       sender: args.sender || undefined,
+      mentions: args.mentions?.map((n) => `${n}@s.whatsapp.net`),
       groupFolder,
       timestamp: new Date().toISOString(),
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -497,10 +497,10 @@ async function main(): Promise<void> {
     },
   });
   startIpcWatcher({
-    sendMessage: (jid, text) => {
+    sendMessage: (jid, text, mentions) => {
       const channel = findChannel(channels, jid);
       if (!channel) throw new Error(`No channel for JID: ${jid}`);
-      return channel.sendMessage(jid, text);
+      return channel.sendMessage(jid, text, mentions);
     },
     registeredGroups: () => registeredGroups,
     registerGroup,

--- a/src/router.ts
+++ b/src/router.ts
@@ -31,10 +31,11 @@ export function routeOutbound(
   channels: Channel[],
   jid: string,
   text: string,
+  mentions?: string[],
 ): Promise<void> {
   const channel = channels.find((c) => c.ownsJid(jid) && c.isConnected());
   if (!channel) throw new Error(`No channel for JID: ${jid}`);
-  return channel.sendMessage(jid, text);
+  return channel.sendMessage(jid, text, mentions);
 }
 
 export function findChannel(

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,7 +81,7 @@ export interface TaskRunLog {
 export interface Channel {
   name: string;
   connect(): Promise<void>;
-  sendMessage(jid: string, text: string): Promise<void>;
+  sendMessage(jid: string, text: string, mentions?: string[]): Promise<void>;
   isConnected(): boolean;
   ownsJid(jid: string): boolean;
   disconnect(): Promise<void>;


### PR DESCRIPTION
Add a `mentions` parameter to the `send_message` MCP tool so agents can @mention users in WhatsApp messages. Phone numbers are resolved to the correct participant JIDs at send time, handling both phone-based and LID-based group addressing modes.

The pipeline threads mentions through IPC → router → WhatsApp channel. The WhatsApp channel resolves phone numbers by:
- Fetching group metadata and matching against participant phoneNumber fields
- Falling back to the lidToPhoneMap for DM chats
- Rewriting @phone in the message text to @resolved_id so WhatsApp can correlate the text with the mention JIDs for clickable display

## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description


## For Skills

- [ ] I have not made any changes to source code
- [ ] My skill contains instructions for Claude to follow (not pre-built code)
- [ ] I tested this skill on a fresh clone
