### PR TITLE
fix: pass TZ env var from .env to agent containers

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -198,6 +198,11 @@ function buildContainerArgs(mounts: VolumeMount[], containerName: string): strin
     args.push('-e', 'HOME=/home/node');
   }
 
+  const tz = readEnvFile(['TZ']).TZ;
+  if (tz) {
+    args.push('-e', `TZ=${tz}`);
+  }
+
   for (const mount of mounts) {
     if (mount.readonly) {
       args.push(...readonlyMountArgs(mount.hostPath, mount.containerPath));


### PR DESCRIPTION
## Summary

- Reads `TZ` from the `.env` file via `readEnvFile` and passes it as a `-e TZ=...` flag when spawning agent containers
- Without this, containers always run in UTC regardless of the `TZ` setting in `.env`, because `env.ts` deliberately does not populate `process.env`

## Test plan

- [ ] Add `TZ=America/Chicago` (or your local timezone) to `.env` and restart nanoclaw
- [ ] Send a message asking the agent to report `process.env.TZ` — should now return the configured timezone
- [ ] Schedule a `once` task using a wall-clock time and verify it fires at the correct local time

Fixes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)