### PR TITLE
fix: mount project root read-only to prevent container escape

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -40,6 +40,10 @@ private_key, .secret
 - Container path validation (rejects `..` and absolute paths)
 - `nonMainReadOnly` option forces read-only for non-main groups
 
+**Read-Only Project Root:**
+
+The main group's project root is mounted read-only. Writable paths the agent needs (group folder, IPC, `.claude/`) are mounted separately. This prevents the agent from modifying host application code (`src/`, `dist/`, `package.json`, etc.) which would bypass the sandbox entirely on next restart.
+
 ### 3. Session Isolation
 
 Each group has isolated Claude sessions at `data/sessions/{group}/.claude/`:
@@ -82,7 +86,7 @@ const allowedVars = ['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_API_KEY'];
 
 | Capability | Main Group | Non-Main Group |
 |------------|------------|----------------|
-| Project root access | `/workspace/project` (rw) | None |
+| Project root access | `/workspace/project` (ro) | None |
 | Group folder | `/workspace/group` (rw) | `/workspace/group` (rw) |
 | Global memory | Implicit via project | `/workspace/global` (ro) |
 | Additional mounts | Configurable | Read-only unless allowed |

--- a/groups/main/CLAUDE.md
+++ b/groups/main/CLAUDE.md
@@ -61,11 +61,11 @@ This is the **main channel**, which has elevated privileges.
 
 ## Container Mounts
 
-Main has access to the entire project:
+Main has read-only access to the project and read-write access to its group folder:
 
 | Container Path | Host Path | Access |
 |----------------|-----------|--------|
-| `/workspace/project` | Project root | read-write |
+| `/workspace/project` | Project root | read-only |
 | `/workspace/group` | `groups/main/` | read-write |
 
 Key paths inside the container:

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -67,11 +67,15 @@ function buildVolumeMounts(
   const projectRoot = process.cwd();
 
   if (isMain) {
-    // Main gets the entire project root mounted
+    // Main gets the project root read-only. Writable paths the agent needs
+    // (group folder, IPC, .claude/) are mounted separately below.
+    // Read-only prevents the agent from modifying host application code
+    // (src/, dist/, package.json, etc.) which would bypass the sandbox
+    // entirely on next restart.
     mounts.push({
       hostPath: projectRoot,
       containerPath: '/workspace/project',
-      readonly: false,
+      readonly: true,
     });
 
     // Main also gets its group folder as the working directory
@@ -155,13 +159,18 @@ function buildVolumeMounts(
     readonly: false,
   });
 
-  // Mount agent-runner source from host — recompiled on container startup.
-  // Bypasses sticky build cache for code changes.
+  // Copy agent-runner source into a per-group writable location so agents
+  // can customize it (add tools, change behavior) without affecting other
+  // groups. Recompiled on container startup via entrypoint.sh.
   const agentRunnerSrc = path.join(projectRoot, 'container', 'agent-runner', 'src');
+  const groupAgentRunnerDir = path.join(DATA_DIR, 'sessions', group.folder, 'agent-runner-src');
+  if (!fs.existsSync(groupAgentRunnerDir) && fs.existsSync(agentRunnerSrc)) {
+    fs.cpSync(agentRunnerSrc, groupAgentRunnerDir, { recursive: true });
+  }
   mounts.push({
-    hostPath: agentRunnerSrc,
+    hostPath: groupAgentRunnerDir,
     containerPath: '/app/src',
-    readonly: true,
+    readonly: false,
   });
 
   // Additional mounts validated against external allowlist (tamper-proof from containers)


### PR DESCRIPTION
## Summary
- Mount the main group's project root **read-only** instead of read-write
- Copy agent-runner source into a per-group writable location so agents can still customize container-side behavior
- Update SECURITY.md and main group CLAUDE.md to reflect new mount permissions

## Security impact
The main group's project root was mounted read-write at `/workspace/project`. A container agent could modify `dist/container-runner.js` to inject arbitrary host mounts (e.g. `$HOME`), which would take effect on the next NanoClaw restart — a full sandbox escape. [Reported by @ZackKorman](https://x.com/ZackKorman).

Since the agent can modify any host application code, not just mount config, the entire project root must be read-only. Writable paths the agent needs (group folder, IPC, `.claude/`) are already mounted separately. The agent-runner source is now copied into a per-group writable location (`data/sessions/{group}/agent-runner-src/`) so agents can still add tools and customize behavior without touching host code.

## Test plan
- [ ] Verify main group container starts with project root read-only (`touch /workspace/project/test` should fail)
- [ ] Verify agent-runner source is copied and writable (`ls /app/src/`, modify a file)
- [ ] Verify agent-runner modifications persist across invocations
- [ ] Verify agent-runner changes are group-isolated (one group's changes don't affect another)
- [ ] Verify existing writable mounts still work (`/workspace/group`, `/workspace/ipc`, `/home/node/.claude`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)