### PR TITLE
skill: add runtime model switching

### DIFF
--- a/.claude/skills/model-switching/SKILL.md
+++ b/.claude/skills/model-switching/SKILL.md
@@ -1,0 +1,118 @@
+# Skill: Runtime Model Switching
+
+Add a `/model` command that lets users switch Claude models at runtime via chat.
+
+## What It Does
+
+- `/model` — Show the current model
+- `/model sonnet` — Switch to the latest Sonnet
+- `/model opus 4.5` — Switch to a specific version
+- `/model claude-opus-4-6` — Use a raw model ID
+
+Switching models closes the active container and clears all sessions (resumed SDK sessions lock to their original model). The new model takes effect on the next message.
+
+## Phase 1: Pre-flight
+
+Check if this skill has already been applied:
+
+```bash
+grep -q 'MODEL_MAP' src/index.ts && echo "ALREADY APPLIED" || echo "NOT APPLIED"
+```
+
+If already applied, stop and tell the user.
+
+## Phase 2: Apply Code Changes
+
+This skill modifies 4 existing files. No new files or npm dependencies are needed.
+
+Read each intent file in `modify/` for the exact changes. Apply them in this order:
+
+### 2.1 `src/db.ts` — Model override persistence
+
+Add two accessor functions that store the model override in the existing `router_state` table.
+
+See: `modify/src/db.ts.intent.md`
+
+### 2.2 `src/container-runner.ts` — Pass model to container
+
+Add `model?: string` to the `ContainerInput` interface so the host can pass the selected model to the container.
+
+See: `modify/src/container-runner.ts.intent.md`
+
+### 2.3 `container/agent-runner/src/index.ts` — Use model in agent
+
+Add `model?: string` to the agent-runner's `ContainerInput` interface, pass it to the SDK's `options.model`, and inject a `[SYSTEM: ...]` line into the prompt so the agent knows which model it's running on.
+
+See: `modify/container/agent-runner/src/index.ts.intent.md`
+
+### 2.4 `src/index.ts` — Command handling and interception
+
+This is the largest change. Add:
+- `MODEL_MAP` and `MODEL_LATEST` constants
+- `resolveModelName()`, `friendlyModelName()`, `handleModelCommand()` functions
+- Import `getModelOverride`, `setModelOverride`, `clearAllSessions` from `./db.js`
+- Pass `model: getModelOverride()` when building `ContainerInput` in `runAgent()`
+- Intercept `/model` in **both** `processGroupMessages()` and `startMessageLoop()`
+
+See: `modify/src/index.ts.intent.md`
+
+## Phase 3: Verify
+
+1. Build the project:
+   ```bash
+   npm run build
+   ```
+
+2. Restart the service:
+   ```bash
+   launchctl unload ~/Library/LaunchAgents/com.nanoclaw.plist
+   launchctl load ~/Library/LaunchAgents/com.nanoclaw.plist
+   ```
+
+3. Send `/model` in your chat — it should reply with the current model.
+
+4. Send `/model haiku` — it should confirm the switch.
+
+5. Send a test message — the agent should respond using the new model.
+
+## Troubleshooting
+
+### Model ID not recognized
+
+The model IDs in `MODEL_MAP` must match what the Claude CLI installed in the container actually supports. To check available models:
+
+```bash
+docker run --rm nanoclaw-agent grep -o 'claude-[a-z0-9-]*' /usr/local/bin/claude | sort -u
+```
+
+If a new model isn't listed, rebuild the container with `--no-cache` to pull a fresh CLI:
+
+```bash
+docker build --no-cache -t nanoclaw-agent container/
+```
+
+### Model doesn't actually change
+
+Resumed SDK sessions lock to their original model. The `/model` command handles this by clearing all sessions (`clearAllSessions()`), but if you're seeing stale behavior:
+
+1. Send `/new` to clear the session manually
+2. Check that `handleModelCommand` calls both `queue.closeStdin()` AND `clearAllSessions()`
+
+### Agent doesn't know its model
+
+The agent can't introspect which model it's running on. The agent-runner injects a `[SYSTEM: You are running on model X]` line at the top of the prompt. If the agent reports the wrong model, check that `container/agent-runner/src/index.ts` is reading `containerInput.model` and prepending it.
+
+## Document Updates
+
+After applying, update `CLAUDE.md` to document the `/model` command under "Runtime Commands":
+
+```markdown
+## Runtime Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/model` | Show current model |
+| `/model <name>` | Switch model: `haiku`, `sonnet`, `opus`, `sonnet 4.5`, or raw ID `claude-opus-4-6` |
+```
+
+Note: Model override is global (all groups), persisted in SQLite `router_state` table. Switching models clears all sessions.

--- a/.claude/skills/model-switching/modify/container/agent-runner/src/index.ts.intent.md
+++ b/.claude/skills/model-switching/modify/container/agent-runner/src/index.ts.intent.md
@@ -1,0 +1,67 @@
+# Intent: container/agent-runner/src/index.ts — Use Model in Agent
+
+## What Changes
+
+Three changes to the agent-runner so it uses the model selected by the user:
+
+1. Add `model?: string` to the `ContainerInput` interface
+2. Pass `containerInput.model` to the SDK's `options.model`
+3. Inject a `[SYSTEM: ...]` line into the prompt so the agent knows which model it's running on
+
+## Change 1: ContainerInput Interface
+
+Add `model` to the interface near the top of the file:
+
+```typescript
+interface ContainerInput {
+  prompt: string;
+  sessionId?: string;
+  groupFolder: string;
+  chatJid: string;
+  isMain: boolean;
+  isScheduledTask?: boolean;
+  model?: string;          // <-- ADD THIS
+  secrets?: Record<string, string>;
+}
+```
+
+## Change 2: Pass Model to SDK
+
+In the `runQuery()` function, the `query()` call already has an `options` object. Add `model: containerInput.model` to it:
+
+```typescript
+for await (const message of query({
+  prompt: stream,
+  options: {
+    model: containerInput.model,   // <-- ADD THIS
+    cwd: '/workspace/group',
+    // ... rest of existing options
+  }
+})) {
+```
+
+## Change 3: Inject Model into Prompt
+
+In the `main()` function, before the query loop, prepend the model info to the initial prompt. Place this after reading stdin but before the query loop:
+
+```typescript
+// Build initial prompt (drain any pending IPC messages too)
+let prompt = '';
+if (containerInput.model) {
+  prompt += `[SYSTEM: You are running on model ${containerInput.model}]\n\n`;
+}
+prompt += containerInput.prompt;
+```
+
+This goes in `main()` where the initial prompt is assembled, before any IPC messages are drained.
+
+## Why the System Line
+
+The Claude Agent SDK doesn't expose the model to the running agent. Without this injection, the agent has no way to tell the user which model it's running on when asked. The `[SYSTEM: ...]` prefix is a convention the agent recognizes as metadata, not user content.
+
+## Invariants
+
+- `model` is optional — when undefined, the SDK uses its default and no system line is injected
+- The `[SYSTEM: ...]` line must come before the user's prompt content
+- Do NOT modify any other SDK options (allowedTools, permissionMode, etc.)
+- The model line is only injected into the initial prompt, not follow-up IPC messages

--- a/.claude/skills/model-switching/modify/src/container-runner.ts.intent.md
+++ b/.claude/skills/model-switching/modify/src/container-runner.ts.intent.md
@@ -1,0 +1,28 @@
+# Intent: src/container-runner.ts — Pass Model to Container
+
+## What Changes
+
+Add `model?: string` to the `ContainerInput` interface so the host can pass the user's model selection to the container.
+
+## Where to Add
+
+In the `ContainerInput` interface, add the `model` field:
+
+```typescript
+export interface ContainerInput {
+  prompt: string;
+  sessionId?: string;
+  groupFolder: string;
+  chatJid: string;
+  isMain: boolean;
+  isScheduledTask?: boolean;
+  model?: string;          // <-- ADD THIS
+  secrets?: Record<string, string>;
+}
+```
+
+## Invariants
+
+- The field is optional (`model?: string`) — when undefined, the SDK uses its default model
+- No other changes to this file are needed — the model value flows through the existing stdin JSON protocol to the container
+- The `secrets` field must remain last (it's deleted after writing to stdin for security)

--- a/.claude/skills/model-switching/modify/src/db.ts.intent.md
+++ b/.claude/skills/model-switching/modify/src/db.ts.intent.md
@@ -1,0 +1,28 @@
+# Intent: src/db.ts — Model Override Persistence
+
+## What Changes
+
+Add two accessor functions for reading/writing the model override. These use the existing `router_state` table — no schema changes needed.
+
+## Where to Add
+
+After the existing `setRouterState()` function (around the "Router state accessors" section), add:
+
+```typescript
+// --- Model override accessors ---
+
+export function getModelOverride(): string | undefined {
+  return getRouterState('model_override') || undefined;
+}
+
+export function setModelOverride(model: string): void {
+  setRouterState('model_override', model);
+}
+```
+
+## Invariants
+
+- Do NOT modify the `router_state` table schema — it already has `key TEXT PRIMARY KEY, value TEXT NOT NULL`
+- Do NOT modify any existing functions
+- The model override is stored as `key = 'model_override'` in the `router_state` table
+- `getModelOverride()` returns `undefined` (not `null`) when no override is set, matching the pattern used by `getRouterState()`

--- a/.claude/skills/model-switching/modify/src/index.ts.intent.md
+++ b/.claude/skills/model-switching/modify/src/index.ts.intent.md
@@ -1,0 +1,196 @@
+# Intent: src/index.ts — Command Handling and Interception
+
+## What Changes
+
+This is the largest modification. It adds:
+1. Model name mapping constants
+2. Three helper functions
+3. New imports from `./db.js`
+4. Model override passed to container input
+5. `/model` interception in **two** message processing paths
+
+## Change 1: Imports
+
+Add `getModelOverride`, `setModelOverride`, and `clearAllSessions` to the import from `./db.js`:
+
+```typescript
+import {
+  clearAllSessions,
+  // ... existing imports ...
+  getModelOverride,
+  // ... existing imports ...
+  setModelOverride,
+  // ... existing imports ...
+} from './db.js';
+```
+
+## Change 2: Model Constants and Functions
+
+Add these after the imports but before any state variables (`let lastTimestamp`, etc.):
+
+```typescript
+// Model name -> model ID mapping
+// IDs must match what the Claude CLI in the container actually supports
+const MODEL_MAP: Record<string, Record<string, string>> = {
+  haiku:  { '4.5': 'claude-haiku-4-5-20251001' },
+  sonnet: { '4': 'claude-sonnet-4-20250514', '4.5': 'claude-sonnet-4-5-20250929', '4.6': 'claude-sonnet-4-6' },
+  opus:   { '4': 'claude-opus-4-20250514', '4.5': 'claude-opus-4-5-20251101', '4.6': 'claude-opus-4-6' },
+};
+
+// Default (latest) version per family
+const MODEL_LATEST: Record<string, string> = {
+  haiku:  '4.5',
+  sonnet: '4.6',
+  opus:   '4.6',
+};
+
+/**
+ * Resolve a friendly model name to a full model ID.
+ * Accepts: "opus", "sonnet 4.5", "claude-opus-4-6-20250918", etc.
+ * Returns the model ID or null if invalid.
+ */
+function resolveModelName(input: string): string | null {
+  const trimmed = input.trim().toLowerCase();
+
+  // Raw model ID (starts with "claude-") -- pass through directly
+  if (trimmed.startsWith('claude-')) return trimmed;
+
+  const parts = trimmed.split(/\s+/);
+  const family = parts[0];
+  const version = parts[1];
+
+  if (!MODEL_MAP[family]) return null;
+
+  if (version) {
+    // Specific version: "sonnet 4.5"
+    return MODEL_MAP[family][version] || null;
+  }
+
+  // No version -- use latest
+  const latestVersion = MODEL_LATEST[family];
+  return latestVersion ? MODEL_MAP[family][latestVersion] : null;
+}
+
+/** Get a display-friendly name for a model ID */
+function friendlyModelName(modelId: string): string {
+  for (const [family, versions] of Object.entries(MODEL_MAP)) {
+    for (const [ver, id] of Object.entries(versions)) {
+      if (id === modelId) return `${family} ${ver}`;
+    }
+  }
+  return modelId; // Raw ID, no friendly name
+}
+
+/**
+ * Handle a /model command. Returns the response to the user.
+ * Extracted so both processGroupMessages and startMessageLoop can use it.
+ */
+async function handleModelCommand(
+  content: string,
+  chatJid: string,
+  channel: Channel,
+): Promise<void> {
+  const args = content.trim().replace(/^\/model\s*/i, '').trim();
+  const families = Object.keys(MODEL_MAP).join(', ');
+
+  if (!args) {
+    const current = getModelOverride();
+    const display = current ? friendlyModelName(current) : 'sonnet (default)';
+    await channel.sendMessage(chatJid, `Current model: *${display}*`);
+  } else {
+    const resolved = resolveModelName(args);
+    if (resolved) {
+      setModelOverride(resolved);
+      // Close any active container so the next message spawns one with the new model
+      queue.closeStdin(chatJid);
+      // Clear all sessions so the SDK starts fresh with the new model
+      // (resumed sessions lock to their original model)
+      sessions = {};
+      clearAllSessions();
+      await channel.sendMessage(chatJid, `Model switched to *${friendlyModelName(resolved)}* (${resolved})`);
+      logger.info({ model: resolved }, 'Model override set');
+    } else {
+      await channel.sendMessage(
+        chatJid,
+        `Unknown model "${args}". Available: ${families}, or a raw model ID (claude-...)`,
+      );
+    }
+  }
+}
+```
+
+**Important**: `handleModelCommand` references `queue`, `sessions`, and `logger` which are module-level variables. It must be placed after the imports but can be before or after the state variable declarations as long as it's in the same module scope.
+
+## Change 3: Pass Model to Container
+
+In the `runAgent()` function, add `model: getModelOverride()` to the `ContainerInput` object passed to `runContainerAgent()`:
+
+```typescript
+const output = await runContainerAgent(
+  group,
+  {
+    prompt,
+    sessionId,
+    groupFolder: group.folder,
+    chatJid,
+    isMain,
+    model: getModelOverride(),   // <-- ADD THIS
+  },
+  // ... rest of args
+);
+```
+
+## Change 4: Intercept in processGroupMessages()
+
+In `processGroupMessages()`, add `/model` interception **before** the trigger check and prompt formatting. Place it after getting `missedMessages` but before the trigger pattern check:
+
+```typescript
+// Intercept /model commands before they reach the agent
+const modelMsg = missedMessages.find((m) => /^\/model\b/i.test(m.content.trim()));
+if (modelMsg) {
+  await handleModelCommand(modelMsg.content, chatJid, channel);
+  lastAgentTimestamp[chatJid] = missedMessages[missedMessages.length - 1].timestamp;
+  saveState();
+  return true;
+}
+```
+
+## Change 5: Intercept in startMessageLoop()
+
+In `startMessageLoop()`, add `/model` interception inside the `for (const [chatJid, groupMessages])` loop, **after** the trigger check but **before** pulling pending messages and sending to the container:
+
+```typescript
+// Intercept /model commands before they reach the agent
+const modelCmd = groupMessages.find((m) => /^\/model\b/i.test(m.content.trim()));
+if (modelCmd) {
+  await handleModelCommand(modelCmd.content, chatJid, channel);
+  lastAgentTimestamp[chatJid] = groupMessages[groupMessages.length - 1].timestamp;
+  saveState();
+  continue;
+}
+```
+
+## Critical: Why Both Paths
+
+Messages can reach the agent via two paths:
+1. **processGroupMessages** — called by GroupQueue when spawning a new container
+2. **startMessageLoop** — the polling loop that can pipe messages to an active container via `queue.sendMessage()`
+
+If you only intercept in one path, `/model` will sometimes be sent to the agent as a regular message instead of being handled as a command. Both interception points must exist.
+
+## Critical: Session Clearing
+
+When switching models, `handleModelCommand` must:
+1. Call `queue.closeStdin(chatJid)` to close the active container
+2. Reset `sessions = {}` (in-memory)
+3. Call `clearAllSessions()` (database)
+
+This is because the Claude Agent SDK locks a resumed session to its original model. If you only close the container without clearing sessions, the next container will resume with the old model.
+
+## Invariants
+
+- Do NOT modify the trigger pattern logic, message cursor advancement, or IPC piping
+- The `/model` check must use `/^\/model\b/i` (case-insensitive, word boundary) to avoid matching messages that start with "model"
+- `handleModelCommand` must advance `lastAgentTimestamp` and call `saveState()` so the command message isn't reprocessed
+- In `processGroupMessages`, return `true` after handling (success, don't retry)
+- In `startMessageLoop`, use `continue` after handling (skip to next group)


### PR DESCRIPTION
## Summary

- Adds a `/model` skill that teaches Claude how to add runtime model switching to any NanoClaw installation
- Users can switch Claude models via chat: `/model opus`, `/model sonnet 4.5`, `/model claude-opus-4-6`
- Modifies 4 files: `src/index.ts`, `src/db.ts`, `src/container-runner.ts`, `container/agent-runner/src/index.ts`
- No new files or npm dependencies needed

## Skill structure

```
.claude/skills/model-switching/
├── SKILL.md                                              # Main instructions
└── modify/
    ├── src/index.ts.intent.md                            # Command handling + dual-path interception
    ├── src/db.ts.intent.md                               # Model override persistence
    ├── src/container-runner.ts.intent.md                  # Pass model to container
    └── container/agent-runner/src/index.ts.intent.md     # SDK model option + prompt injection
```

## Key design decisions captured in the skill

1. `/model` intercepted in **both** `processGroupMessages()` and `startMessageLoop()` — messages reach agents via either path
2. Switching models **closes the active container** and **clears all sessions** — resumed SDK sessions lock to their original model
3. Agent can't introspect its model — agent-runner injects `[SYSTEM: You are running on model X]` into the prompt
4. Includes troubleshooting for stale CLI in container builds and session locking

## Test plan

- [ ] Clone fresh upstream, apply skill instructions to verify they produce working code
- [ ] Verify `/model` shows current model
- [ ] Verify `/model haiku` switches and confirms
- [ ] Verify model actually changes (check container logs for model parameter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)