### PR TITLE
fix: Add YAML frontmatter to 2 'broken' skill files for Copilot CLI discovery

### DIFF
--- a/.claude/skills/add-discord/SKILL.md
+++ b/.claude/skills/add-discord/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: add-discord
+description: Add Discord as a channel. Can replace WhatsApp entirely or run alongside it. Also configurable as a control-only channel (triggers actions) or passive channel (receives notifications only).
+---
+
 # Add Discord Channel
 
 This skill adds Discord support to NanoClaw using the skills engine for deterministic code changes, then walks through interactive setup.

--- a/.claude/skills/add-parallel/SKILL.md
+++ b/.claude/skills/add-parallel/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: add-parallel
+description: Add Parallel AI MCP integration for advanced web research. Includes Quick Search API and Deep Research capabilities with non-blocking polling.
+---
+
 # Add Parallel AI Integration
 
 Adds Parallel AI MCP integration to NanoClaw for advanced web research capabilities.


### PR DESCRIPTION
## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description

Add name and description frontmatter to add-discord and add-parallel SKILL.md files so GitHub Copilot CLI can parse and load them as available skills.

<img width="1241" height="1066" alt="image" src="https://github.com/user-attachments/assets/8aba99a7-25d6-4997-b726-32388843fbd2" />

## For Skills

- [x] I have not made any changes to source code
- [x] My skill contains instructions for Claude to follow (not pre-built code)
- [x] I tested this skill on a fresh clone
