### PR TITLE
feat: add Windows support to setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,10 +121,10 @@ Skills we'd like to see:
 
 ## Requirements
 
-- macOS or Linux
+- macOS, Linux, or Windows 11
 - Node.js 20+
 - [Claude Code](https://claude.ai/download)
-- [Apple Container](https://github.com/apple/container) (macOS) or [Docker](https://docker.com/products/docker-desktop) (macOS/Linux)
+- [Apple Container](https://github.com/apple/container) (macOS) or [Docker](https://docker.com/products/docker-desktop) (macOS/Linux/Windows)
 
 ## Architecture
 
@@ -153,11 +153,15 @@ Because I use WhatsApp. Fork it and run a skill to change it. That's the whole p
 
 **Why Docker?**
 
-Docker provides cross-platform support (macOS and Linux) and a mature ecosystem. On macOS, you can optionally switch to Apple Container via `/convert-to-apple-container` for a lighter-weight native runtime.
+Docker provides cross-platform support (macOS, Linux, and Windows) and a mature ecosystem. On macOS, you can optionally switch to Apple Container via `/convert-to-apple-container` for a lighter-weight native runtime.
 
 **Can I run this on Linux?**
 
-Yes. Docker is the default runtime and works on both macOS and Linux. Just run `/setup`.
+Yes. Docker is the default runtime and works on macOS, Linux, and Windows. Just run `/setup`.
+
+**Can I run this on Windows?**
+
+Yes. Install [Docker Desktop](https://docker.com/products/docker-desktop) and the [Visual C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) (needed to compile native Node modules), then run `/setup`. The setup wizard handles the rest and generates `start.bat` / `stop.bat` / `restart.bat` scripts for service management.
 
 **Is this secure?**
 

--- a/setup/whatsapp-auth.ts
+++ b/setup/whatsapp-auth.ts
@@ -2,9 +2,11 @@
  * Step: whatsapp-auth — Full WhatsApp auth flow with polling.
  * Replaces 04-auth-whatsapp.sh
  */
-import { execSync, spawn } from 'child_process';
+import { spawn } from 'child_process';
 import fs from 'fs';
 import path from 'path';
+
+import QRCode from 'qrcode';
 
 import { logger } from '../src/logger.js';
 import { openBrowser, isHeadless } from './platform.js';
@@ -156,6 +158,7 @@ export async function run(args: string[]): Promise<void> {
     cwd: projectRoot,
     stdio: ['ignore', 'pipe', 'pipe'],
     detached: false,
+    shell: process.platform === 'win32',
   });
 
   const logFile = path.join(projectRoot, 'logs', 'setup.log');
@@ -209,10 +212,7 @@ async function handleQrBrowser(
   // Generate QR SVG and HTML
   const qrData = fs.readFileSync(qrFile, 'utf-8');
   try {
-    const svg = execSync(
-      `node -e "const QR=require('qrcode');const data=${JSON.stringify(qrData)};QR.toString(data,{type:'svg'},(e,s)=>{if(e)process.exit(1);process.stdout.write(s)})"`,
-      { cwd: projectRoot, encoding: 'utf-8' },
-    );
+    const svg = await QRCode.toString(qrData, { type: 'svg' });
     const html = QR_AUTH_TEMPLATE.replace('{{QR_SVG}}', svg);
     const htmlPath = path.join(projectRoot, 'store', 'qr-auth.html');
     fs.writeFileSync(htmlPath, html);


### PR DESCRIPTION
## Summary

- **`setup/platform.ts`**: add `'windows'` platform type and `'task-scheduler'` service manager; fix `commandExists()` to use `where` on Windows; fix `getNodePath()` to use `where node`; fix `openBrowser()` for Windows
- **`setup/whatsapp-auth.ts`**: fix `spawn('npx', ...)` with `shell: true` on Windows; replace shell-subprocess QR SVG generation with direct `qrcode` import (avoids `cmd.exe` quote mangling)
- **`setup/service.ts`**: add `setupWindows()` — generates `nanoclaw-ctl.ps1` and `start/stop/restart.bat` control scripts, starts the service, reports status; replaces `unsupported_platform` exit on Windows
- **`README.md`**: add Windows to requirements and FAQ

## Windows-specific behaviour

On Windows, the service step generates three files in the project root:
- `nanoclaw-ctl.ps1` — PowerShell controller (`start`, `stop`, `restart`, `status`)
- `start.bat` / `stop.bat` / `restart.bat` — convenience wrappers

No Task Scheduler registration is done automatically — users run `start.bat` manually (or add it to startup themselves).

## Test plan

- [ ] Run `/setup` on a Windows machine with Docker Desktop installed
- [ ] Verify WhatsApp QR code renders correctly in the browser
- [ ] Verify `start.bat` / `stop.bat` / `restart.bat` work as expected
- [ ] Verify macOS and Linux setup paths are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)