### PR TITLE
fix: prevent .env secret leakage into containers

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -70,6 +70,18 @@ function buildVolumeMounts(
       readonly: true,
     });
 
+    // Mask .env inside the container to prevent secret leakage.
+    // Secrets are delivered securely via stdin — the .env file must not
+    // be readable from within the container despite the project root mount.
+    const envFile = path.join(projectRoot, '.env');
+    if (fs.existsSync(envFile)) {
+      mounts.push({
+        hostPath: '/dev/null',
+        containerPath: '/workspace/project/.env',
+        readonly: true,
+      });
+    }
+
     // Main also gets its group folder as the working directory
     mounts.push({
       hostPath: groupDir,

--- a/src/db.ts
+++ b/src/db.ts
@@ -531,15 +531,25 @@ export function getRegisteredGroup(
     );
     return undefined;
   }
+  let containerConfig: RegisteredGroup['containerConfig'];
+  if (row.container_config) {
+    try {
+      containerConfig = JSON.parse(row.container_config);
+    } catch (err) {
+      logger.warn(
+        { jid: row.jid, error: err },
+        'Registered group has corrupt container_config',
+      );
+      return undefined;
+    }
+  }
   return {
     jid: row.jid,
     name: row.name,
     folder: row.folder,
     trigger: row.trigger_pattern,
     added_at: row.added_at,
-    containerConfig: row.container_config
-      ? JSON.parse(row.container_config)
-      : undefined,
+    containerConfig,
     requiresTrigger: row.requires_trigger === null ? undefined : row.requires_trigger === 1,
   };
 }
@@ -586,14 +596,24 @@ export function getAllRegisteredGroups(): Record<string, RegisteredGroup> {
       );
       continue;
     }
+    let containerConfig: RegisteredGroup['containerConfig'];
+    if (row.container_config) {
+      try {
+        containerConfig = JSON.parse(row.container_config);
+      } catch (err) {
+        logger.warn(
+          { jid: row.jid, error: err },
+          'Skipping registered group with corrupt container_config',
+        );
+        continue;
+      }
+    }
     result[row.jid] = {
       name: row.name,
       folder: row.folder,
       trigger: row.trigger_pattern,
       added_at: row.added_at,
-      containerConfig: row.container_config
-        ? JSON.parse(row.container_config)
-        : undefined,
+      containerConfig,
       requiresTrigger: row.requires_trigger === null ? undefined : row.requires_trigger === 1,
     };
   }


### PR DESCRIPTION
## Summary

- **Mask `.env` file inside the main group container** by mounting `/dev/null` over `/workspace/project/.env`. Despite secrets being delivered via stdin and sanitized from environment variables by the Bash hook, the project-root bind mount exposed the `.env` file directly — allowing the agent to read API keys with a simple `cat /workspace/project/.env`.
- **Wrap `JSON.parse(container_config)` in `db.ts` with try/catch** to prevent a persistent crash loop if the SQLite database contains corrupt JSON. Without this, a single corrupted row causes `getAllRegisteredGroups()` / `getRegisteredGroup()` to throw on every startup attempt with no recovery path.

## Details

### Secret leakage via mounted `.env` (HIGH severity)

The existing secret protection architecture is thorough:
1. Secrets passed via stdin only (`container.stdin.write`)
2. Deleted from `input` after delivery (`delete input.secrets`)
3. Bash hook unsets secret env vars before every command (`createSanitizeBashHook`)

However, `buildVolumeMounts()` bind-mounts the entire project root read-only at `/workspace/project`, which includes `.env`. Since the agent runs with `permissionMode: 'bypassPermissions'`, it can read the file directly, completely bypassing all three protections above.

**Fix:** Mount `/dev/null` over `/workspace/project/.env` inside the container. Docker's mount overlay behavior ensures the more specific file mount takes precedence, replacing `.env` with empty content.

### Unguarded `JSON.parse` crash loop (MEDIUM severity)

`getAllRegisteredGroups()` and `getRegisteredGroup()` in `db.ts` call `JSON.parse(row.container_config)` without error handling. If the SQLite DB is corrupted (power failure, disk error), a single bad row causes an unhandled exception during `loadState()` at startup — creating a persistent crash loop.

**Fix:** Wrap in try/catch, log a warning, and skip/return undefined for corrupt rows.

## Test plan

- [ ] Verify main container cannot read `.env` contents (`cat /workspace/project/.env` should return empty)
- [ ] Verify secrets are still delivered correctly via stdin (agent can authenticate)
- [ ] Verify startup succeeds with a corrupted `container_config` row in SQLite
- [ ] Run `npx tsc --noEmit` — passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)