### PR TITLE
fix: QR code generation on Node.js 25

### DIFF
--- a/setup/whatsapp-auth.ts
+++ b/setup/whatsapp-auth.ts
@@ -209,10 +209,11 @@ async function handleQrBrowser(
   // Generate QR SVG and HTML
   const qrData = fs.readFileSync(qrFile, 'utf-8');
   try {
-    const svg = execSync(
-      `node -e "const QR=require('qrcode');const data=${JSON.stringify(qrData)};QR.toString(data,{type:'svg'},(e,s)=>{if(e)process.exit(1);process.stdout.write(s)})"`,
-      { cwd: projectRoot, encoding: 'utf-8' },
-    );
+    // Write a temp script to avoid shell quoting issues with QR data
+    const tmpScript = path.join(projectRoot, 'store', '.qr-gen.cjs');
+    fs.writeFileSync(tmpScript, `const QR=require('qrcode');const data=${JSON.stringify(qrData)};QR.toString(data,{type:'svg'},(e,s)=>{if(e)process.exit(1);process.stdout.write(s)});`);
+    const svg = execSync(`node ${tmpScript}`, { cwd: projectRoot, encoding: 'utf-8' });
+    fs.unlinkSync(tmpScript);
     const html = QR_AUTH_TEMPLATE.replace('{{QR_SVG}}', svg);
     const htmlPath = path.join(projectRoot, 'store', 'qr-auth.html');
     fs.writeFileSync(htmlPath, html);


### PR DESCRIPTION
## Summary

- Node.js 25 enables `--experimental-strip-types` by default, causing `node -e` to parse inline scripts as TypeScript
- The QR data string contains `@`, `=`, and `/` characters that break the TypeScript parser when shell quoting strips the surrounding double quotes
- Fix: write a temp `.cjs` script file instead of using inline `node -e`, avoiding both the TypeScript parsing and shell quoting issues

## Repro

1. Install Node.js 25
2. Run `/setup` and choose "QR code in browser" for WhatsApp auth
3. Setup fails with `SyntaxError: Invalid or unexpected token` / `Expected a semicolon`

## Test plan

- [ ] Run WhatsApp QR browser auth on Node.js 25
- [ ] Verify QR code displays in browser and auth completes
- [ ] Verify it still works on Node.js 22

🤖 Generated with [Claude Code](https://claude.com/claude-code)