### PR TITLE
fix(setup): use base64 encoding for QR data in shell command

### DIFF
--- a/setup/whatsapp-auth.ts
+++ b/setup/whatsapp-auth.ts
@@ -207,10 +207,12 @@ async function handleQrBrowser(
   }
 
   // Generate QR SVG and HTML
-  const qrData = fs.readFileSync(qrFile, 'utf-8');
+  const qrData = fs.readFileSync(qrFile, 'utf-8').trim();
   try {
+    // Use base64 to safely pass QR data through shell (avoids escaping issues with special chars)
+    const b64 = Buffer.from(qrData).toString('base64');
     const svg = execSync(
-      `node -e "const QR=require('qrcode');const data=${JSON.stringify(qrData)};QR.toString(data,{type:'svg'},(e,s)=>{if(e)process.exit(1);process.stdout.write(s)})"`,
+      `node -e "const QR=require('qrcode');const data=Buffer.from('${b64}','base64').toString();QR.toString(data,{type:'svg'},(e,s)=>{if(e)process.exit(1);process.stdout.write(s)})"`,
       { cwd: projectRoot, encoding: 'utf-8' },
     );
     const html = QR_AUTH_TEMPLATE.replace('{{QR_SVG}}', svg);


### PR DESCRIPTION
## Summary
- Fix QR browser authentication failing due to special characters in QR data
- QR data from WhatsApp contains `@`, `+`, `/` etc. that break shell parsing when passed via `JSON.stringify` to `node -e`
- Solution: encode QR data as base64 before passing through shell, decode inside node command

## Test plan
- [x] Run `/setup` and choose "QR code in browser" for WhatsApp authentication
- [x] Verify QR code displays correctly in browser
- [x] Verify scanning the QR code completes authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)