### PR TITLE
fix: use fetchLatestWaWebVersion to prevent 405 connection failures

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -6,6 +6,7 @@ import makeWASocket, {
   Browsers,
   DisconnectReason,
   WASocket,
+  fetchLatestWaWebVersion,
   makeCacheableSignalKeyStore,
   useMultiFileAuthState,
 } from '@whiskeysockets/baileys';
@@ -55,7 +56,9 @@ export class WhatsAppChannel implements Channel {
 
     const { state, saveCreds } = await useMultiFileAuthState(authDir);
 
+    const { version } = await fetchLatestWaWebVersion({});
     this.sock = makeWASocket({
+      version,
       auth: {
         creds: state.creds,
         keys: makeCacheableSignalKeyStore(state.keys, logger),

--- a/src/whatsapp-auth.ts
+++ b/src/whatsapp-auth.ts
@@ -15,6 +15,7 @@ import readline from 'readline';
 import makeWASocket, {
   Browsers,
   DisconnectReason,
+  fetchLatestWaWebVersion,
   makeCacheableSignalKeyStore,
   useMultiFileAuthState,
 } from '@whiskeysockets/baileys';
@@ -53,7 +54,9 @@ async function connectSocket(phoneNumber?: string, isReconnect = false): Promise
     process.exit(0);
   }
 
+  const { version } = await fetchLatestWaWebVersion({});
   const sock = makeWASocket({
+    version,
     auth: {
       creds: state.creds,
       keys: makeCacheableSignalKeyStore(state.keys, logger),


### PR DESCRIPTION
## Summary
- Baileys' default WhatsApp Web version falls behind when WhatsApp updates their protocol, causing 405 "Method Not Allowed" errors on the websocket handshake
- This prevents both new authentication (pairing/QR) and reconnection after a disconnect
- Now calls `fetchLatestWaWebVersion()` before creating the socket so it always uses a current version

## Files changed
- `src/channels/whatsapp.ts` — runtime connection
- `src/whatsapp-auth.ts` — setup auth flow

## Test plan
- [x] Reproduced 405 error on fresh auth attempt
- [x] Applied fix, successfully authenticated via pairing code
- [x] Service starts and maintains stable WhatsApp connection
- [x] Verified on both macOS and Linux (Hetzner VPS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)