### PR TITLE
feat: add Claude Code integration skill

### DIFF
--- a/.claude/skills/add-claude-code/SKILL.md
+++ b/.claude/skills/add-claude-code/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: add-claude-code
+description: Connect container agents to Claude Code on the host for coding tasks. Main group only — delegates file editing, debugging, and development work to a host-side Claude Code instance.
+---
+
+# Add Claude Code Integration
+
+This skill connects your container agents to Claude Code running on the host machine. When the main agent needs to write code, debug, or make changes to the NanoClaw repository (or other allowed directories), it delegates to a Claude Code instance via an MCP tool.
+
+## Architecture
+
+```
+Container (agent)                          Host (Mac Mini)
++----------------------------+    HTTP     +----------------------------+
+| agent-runner/index.ts      |             | src/claude-code-service.ts |
+|   |                        |             |   - HTTP server on :8282   |
+|   +-> MCP: claude-code     |             |   - POST /invoke           |
+|       (claude-code-proxy)  | ---------> |   - Spawns `claude -p`     |
+|       stdio-to-HTTP bridge |  :8282      |   - Returns JSON result    |
++----------------------------+             +----------------------------+
+```
+
+## Phase 1: Pre-flight
+
+### Check if already applied
+
+Read `.nanoclaw/state.yaml`. If `claude-code` is in `applied_skills`, skip to Phase 3 (Verify). The code changes are already in place.
+
+### Check prerequisites
+
+1. Verify Claude Code CLI is installed on the host:
+
+```bash
+which claude
+```
+
+If not found, install it:
+
+```bash
+npm install -g @anthropic-ai/claude-code
+```
+
+2. Verify port 8282 is available:
+
+```bash
+lsof -i :8282
+```
+
+If something is using the port, it needs to be freed first.
+
+3. Verify Claude Code CLI is authenticated. It works with either:
+   - **Claude Max Plan**: CLI handles auth automatically (nothing to configure)
+   - **API key**: Set `ANTHROPIC_API_KEY` in your `.env` file
+   - **OAuth token**: Set `CLAUDE_CODE_OAUTH_TOKEN` in your `.env` file
+
+   Test with:
+
+```bash
+claude -p "Say hi" --output-format text
+```
+
+## Phase 2: Apply Code Changes
+
+Run the skills engine to apply this skill's code package.
+
+### Initialize skills system (if needed)
+
+If `.nanoclaw/` directory doesn't exist yet:
+
+```bash
+npx tsx scripts/apply-skill.ts --init
+```
+
+### Apply the skill
+
+```bash
+npx tsx scripts/apply-skill.ts .claude/skills/add-claude-code
+```
+
+This deterministically:
+- Adds `src/claude-code-service.ts` (host HTTP daemon)
+- Adds `container/agent-runner/src/claude-code-proxy.ts` (container MCP proxy)
+- Three-way merges Claude Code lifecycle into `src/index.ts` (start/stop service)
+- Three-way merges Claude Code MCP server into `container/agent-runner/src/index.ts` (register MCP, allowedTools)
+
+If the apply reports merge conflicts (common when the codebase has drifted since the last skill was applied), apply the changes manually instead:
+
+1. The `add/` files will have been copied already — verify `src/claude-code-service.ts` and `container/agent-runner/src/claude-code-proxy.ts` exist
+2. Read the intent files for what to change manually:
+   - `modify/src/index.ts.intent.md` — 3 additions: import, shutdown call, startup call
+   - `modify/container/agent-runner/src/index.ts.intent.md` — conditional MCP server + allowedTools registration
+3. After manual edits, restore conflicted files from `.nanoclaw/backup/` if the merge left conflict markers
+4. Run `npm run build` to verify, then record the application:
+
+```bash
+npx tsx -e "import{recordSkillApplication}from'./skills-engine/state.js';import{clearBackup}from'./skills-engine/backup.js';import crypto from'crypto';import fs from'fs';const h=(f:string)=>crypto.createHash('sha256').update(fs.readFileSync(f,'utf-8')).digest('hex');const files=['src/claude-code-service.ts','container/agent-runner/src/claude-code-proxy.ts','src/index.ts','container/agent-runner/src/index.ts'];const hashes=Object.fromEntries(files.map(f=>[f,h(f)]));recordSkillApplication('claude-code','1.0.0',hashes);clearBackup();console.log('Done');"
+```
+
+Note: If the inline `npx tsx -e` fails with module resolution errors, save it as a `.ts` file and run `npx tsx <file>.ts` instead.
+
+### Configure CWD allowlist
+
+The `src/claude-code-service.ts` file has a `CWD_ALLOWLIST` array near the top. By default it includes the NanoClaw project directory. If the agent should be able to work in other directories, add them now.
+
+AskUserQuestion: Which directories should Claude Code be allowed to access? (NanoClaw project dir is included by default)
+
+Update the `CWD_ALLOWLIST` in `src/claude-code-service.ts` with any additional paths.
+
+### Validate code changes
+
+```bash
+npm run build
+```
+
+Build must be clean before proceeding.
+
+### Sync agent-runner to session directories
+
+The agent-runner source is mounted from `data/sessions/<group>/agent-runner-src/` at runtime. Sync the new proxy file (and the updated index.ts) to existing sessions:
+
+```bash
+for dir in data/sessions/*/agent-runner-src/; do
+  cp container/agent-runner/src/claude-code-proxy.ts "$dir"
+  cp container/agent-runner/src/index.ts "$dir"
+done
+```
+
+## Phase 3: Verify
+
+### Start the service
+
+```bash
+npm run dev
+```
+
+### Test health check
+
+```bash
+curl http://localhost:8282/health
+```
+
+Should return `{"status":"ok","active":false}`.
+
+### Test a simple invocation
+
+```bash
+curl -X POST http://localhost:8282/invoke \
+  -H 'Content-Type: application/json' \
+  -d '{"prompt":"List the files in the current directory","cwd":"$(pwd)"}'
+```
+
+Should return a JSON response with the file listing.
+
+### Test security (CWD rejection)
+
+```bash
+curl -X POST http://localhost:8282/invoke \
+  -H 'Content-Type: application/json' \
+  -d '{"prompt":"List files","cwd":"/tmp"}'
+```
+
+Should return an error about CWD not being in the allowlist.
+
+### Test via Telegram
+
+Send a message to the main agent asking it to perform a coding task, e.g.:
+
+> "Use the code tool to check what TypeScript version we're using in package.json"
+
+The agent should call `mcp__claude-code__code` and return the result.
+
+## Troubleshooting
+
+### Claude Code CLI not found
+
+The service logs a warning at startup if `claude` isn't on PATH. Install it:
+
+```bash
+npm install -g @anthropic-ai/claude-code
+```
+
+If running via launchd, the CLI may not be in the minimal PATH. The service checks common locations (`/opt/homebrew/bin/claude`, `/usr/local/bin/claude`).
+
+### Port 8282 in use
+
+Another process is using the port. Find it:
+
+```bash
+lsof -i :8282
+```
+
+### Agent doesn't have the code tool
+
+Only the **main group** gets the `claude-code` MCP server. Non-main groups intentionally don't have access. Check that the agent is running as the main group.
+
+### Timeout errors
+
+Claude Code invocations have a 5-minute timeout. For very large tasks, consider breaking them into smaller steps or increasing the timeout in `claude-code-service.ts`.
+
+### Concurrency errors
+
+Only one Claude Code invocation can run at a time. If the agent gets a "Another invocation is already in progress" error, it should wait and retry.
+
+### CLI hangs (no output, no error)
+
+The service uses `spawn` with `stdio: ['ignore', 'pipe', 'pipe']` to close stdin. If you see the CLI hanging with no output, verify that stdin is set to `'ignore'` in the spawn options. Using `execFile` or leaving stdin as `'pipe'` causes the CLI's shell detection subprocesses to hang waiting for input in non-TTY contexts (like launchd/systemd).
+
+## Removal
+
+To remove Claude Code integration:
+
+1. Delete `src/claude-code-service.ts`
+2. Delete `container/agent-runner/src/claude-code-proxy.ts`
+3. Remove `startClaudeCodeService` / `stopClaudeCodeService` import and calls from `src/index.ts`
+4. Remove `claude-code` MCP server registration and `mcp__claude-code__*` from allowed tools in `container/agent-runner/src/index.ts`
+5. Rebuild: `npm run build && launchctl kickstart -k gui/$(id -u)/com.nanoclaw` (macOS) or `npm run build && systemctl --user restart nanoclaw` (Linux)

--- a/.claude/skills/add-claude-code/add/container/agent-runner/src/claude-code-proxy.ts
+++ b/.claude/skills/add-claude-code/add/container/agent-runner/src/claude-code-proxy.ts
@@ -1,0 +1,195 @@
+/**
+ * Claude Code MCP Proxy — stdio-to-HTTP bridge
+ *
+ * Runs inside the container as an MCP server (stdio transport).
+ * Exposes a single "code" tool that forwards requests to the
+ * Claude Code HTTP daemon on the host.
+ *
+ * Unlike qmd-proxy (which transparently forwards MCP protocol),
+ * this implements the MCP server protocol directly with one tool.
+ *
+ * Host address: host.docker.internal:8282 (Docker's host gateway)
+ */
+import { createInterface } from 'readline';
+
+const CLAUDE_CODE_URL = `http://host.docker.internal:${process.env.CLAUDE_CODE_PORT || '8282'}`;
+
+function log(msg: string): void {
+  process.stderr.write(`[claude-code-proxy] ${msg}\n`);
+}
+
+// MCP JSON-RPC helpers
+function jsonRpcResponse(id: unknown, result: unknown): string {
+  return JSON.stringify({ jsonrpc: '2.0', id, result });
+}
+
+function jsonRpcError(id: unknown, code: number, message: string): string {
+  return JSON.stringify({ jsonrpc: '2.0', id, error: { code, message } });
+}
+
+// Tool definition for the MCP tools/list response
+const CODE_TOOL = {
+  name: 'code',
+  description: 'Delegate a coding task to Claude Code running on the host machine. Use this for tasks that require reading, writing, or modifying code in the NanoClaw repository or other allowed directories. Claude Code has full access to the filesystem, git, npm, and other dev tools.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      prompt: {
+        type: 'string',
+        description: 'The coding task to perform. Be specific about what files to change, what behavior to add/fix, and any constraints.',
+      },
+      cwd: {
+        type: 'string',
+        description: 'Working directory for the task. Must be in the allowlist (e.g., /Users/nanoclaw/nanoclaw).',
+      },
+      model: {
+        type: 'string',
+        description: 'Optional model override (e.g., "claude-sonnet-4-6"). Defaults to the host\'s configured model.',
+      },
+      session_id: {
+        type: 'string',
+        description: 'Resume a previous Claude Code session by ID. Useful for multi-step tasks.',
+      },
+    },
+    required: ['prompt', 'cwd'],
+  },
+};
+
+/**
+ * Call the Claude Code HTTP daemon on the host.
+ */
+async function invokeClaudeCode(args: {
+  prompt: string;
+  cwd: string;
+  model?: string;
+  session_id?: string;
+}): Promise<string> {
+  const body = JSON.stringify({
+    prompt: args.prompt,
+    cwd: args.cwd,
+    model: args.model,
+    sessionId: args.session_id,
+  });
+
+  log(`Invoking Claude Code: cwd=${args.cwd}, prompt=${args.prompt.slice(0, 100)}...`);
+
+  const response = await fetch(`${CLAUDE_CODE_URL}/invoke`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+    signal: AbortSignal.timeout(300_000), // 5 minute timeout (matches host)
+  });
+
+  const result = await response.json();
+
+  if (result.status === 'error') {
+    throw new Error(result.error || 'Claude Code invocation failed');
+  }
+
+  const parts: string[] = [];
+  if (result.result) parts.push(result.result);
+  if (result.sessionId) parts.push(`\n[Session ID: ${result.sessionId}]`);
+  if (result.durationMs) parts.push(`[Duration: ${(result.durationMs / 1000).toFixed(1)}s]`);
+  if (result.costUsd) parts.push(`[Cost: $${result.costUsd.toFixed(4)}]`);
+
+  return parts.join('\n');
+}
+
+/**
+ * Handle a single JSON-RPC request from the MCP client (Claude SDK).
+ */
+async function handleRequest(parsed: { id?: unknown; method?: string; params?: unknown }): Promise<string | null> {
+  const { id, method, params } = parsed;
+
+  switch (method) {
+    case 'initialize':
+      return jsonRpcResponse(id, {
+        protocolVersion: '2024-11-05',
+        capabilities: { tools: {} },
+        serverInfo: { name: 'claude-code', version: '1.0.0' },
+      });
+
+    case 'notifications/initialized':
+      // No response needed for notifications
+      return null;
+
+    case 'tools/list':
+      return jsonRpcResponse(id, { tools: [CODE_TOOL] });
+
+    case 'tools/call': {
+      const callParams = params as { name: string; arguments: Record<string, unknown> };
+      if (callParams?.name !== 'code') {
+        return jsonRpcError(id, -32602, `Unknown tool: ${callParams?.name}`);
+      }
+
+      const args = callParams.arguments as {
+        prompt: string;
+        cwd: string;
+        model?: string;
+        session_id?: string;
+      };
+
+      try {
+        const result = await invokeClaudeCode(args);
+        return jsonRpcResponse(id, {
+          content: [{ type: 'text', text: result }],
+        });
+      } catch (err) {
+        const errorMsg = err instanceof Error ? err.message : String(err);
+        log(`Invocation error: ${errorMsg}`);
+        return jsonRpcResponse(id, {
+          content: [{ type: 'text', text: `Error: ${errorMsg}` }],
+          isError: true,
+        });
+      }
+    }
+
+    default:
+      log(`Unknown method: ${method}`);
+      return jsonRpcError(id, -32601, `Method not found: ${method}`);
+  }
+}
+
+async function main(): Promise<void> {
+  log('Starting Claude Code MCP proxy');
+
+  const rl = createInterface({ input: process.stdin });
+
+  rl.on('line', async (line) => {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+
+    let parsed: { id?: unknown; method?: string; params?: unknown };
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      log(`Invalid JSON: ${trimmed.slice(0, 100)}`);
+      return;
+    }
+
+    try {
+      const response = await handleRequest(parsed);
+      if (response !== null) {
+        process.stdout.write(response + '\n');
+      }
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      log(`Handler error: ${errorMsg}`);
+      const errorResponse = jsonRpcError(parsed.id, -32000, `Proxy error: ${errorMsg}`);
+      process.stdout.write(errorResponse + '\n');
+    }
+  });
+
+  rl.on('close', () => {
+    log('Stdin closed, exiting');
+    process.exit(0);
+  });
+
+  process.on('SIGTERM', () => process.exit(0));
+  process.on('SIGINT', () => process.exit(0));
+}
+
+main().catch((err) => {
+  log(`Fatal error: ${err instanceof Error ? err.message : String(err)}`);
+  process.exit(1);
+});

--- a/.claude/skills/add-claude-code/add/src/claude-code-service.ts
+++ b/.claude/skills/add-claude-code/add/src/claude-code-service.ts
@@ -1,0 +1,285 @@
+/**
+ * Claude Code Service — Host HTTP daemon
+ *
+ * Lightweight HTTP server that spawns the Claude Code CLI on behalf of
+ * container agents. Agents call this via the claude-code-proxy MCP bridge.
+ *
+ * - POST /invoke — run a Claude Code task
+ * - GET  /health — health check
+ *
+ * Security: CWD allowlist prevents agents from accessing arbitrary directories.
+ * Concurrency: one active invocation at a time (queued requests are rejected).
+ */
+import http from 'http';
+import { spawn, execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+import { logger } from './logger.js';
+import { readEnvFile } from './env.js';
+
+const CLAUDE_CODE_PORT = 8282;
+
+// Directories Claude Code is allowed to work in.
+// Configurable — add paths here as needed.
+const CWD_ALLOWLIST = [
+  process.env.HOME || '/Users/nanoclaw',
+];
+
+let server: http.Server | null = null;
+let activeInvocation = false;
+
+interface InvokeRequest {
+  prompt: string;
+  cwd: string;
+  model?: string;
+  sessionId?: string;
+}
+
+interface InvokeResponse {
+  status: 'success' | 'error';
+  result: string | null;
+  sessionId?: string;
+  costUsd?: number;
+  durationMs: number;
+  error?: string;
+}
+
+/**
+ * Find the claude CLI binary.
+ * Checks common locations since launchd has a minimal PATH.
+ */
+function claudeBin(): string {
+  const candidates = [
+    `${process.env.HOME}/.local/bin/claude`,
+    '/opt/homebrew/bin/claude',
+    '/usr/local/bin/claude',
+    `${process.env.HOME}/.npm-global/bin/claude`,
+  ];
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+
+  // Fallback to PATH lookup
+  try {
+    return execSync('which claude', { encoding: 'utf-8' }).trim();
+  } catch {
+    throw new Error('Claude Code CLI not found. Install with: npm install -g @anthropic-ai/claude-code');
+  }
+}
+
+/**
+ * Validate that the requested CWD is within the allowlist.
+ */
+function isAllowedCwd(cwd: string): boolean {
+  const resolved = path.resolve(cwd);
+  return CWD_ALLOWLIST.some(allowed => {
+    const resolvedAllowed = path.resolve(allowed);
+    return resolved === resolvedAllowed || resolved.startsWith(resolvedAllowed + path.sep);
+  });
+}
+
+/**
+ * Handle POST /invoke — spawn claude CLI and return the result.
+ */
+async function handleInvoke(body: string): Promise<InvokeResponse> {
+  const startTime = Date.now();
+
+  let req: InvokeRequest;
+  try {
+    req = JSON.parse(body);
+  } catch {
+    return { status: 'error', result: null, durationMs: 0, error: 'Invalid JSON body' };
+  }
+
+  if (!req.prompt || !req.cwd) {
+    return { status: 'error', result: null, durationMs: 0, error: 'Missing required fields: prompt, cwd' };
+  }
+
+  if (!isAllowedCwd(req.cwd)) {
+    return {
+      status: 'error',
+      result: null,
+      durationMs: 0,
+      error: `CWD "${req.cwd}" is not in the allowlist. Allowed: ${CWD_ALLOWLIST.join(', ')}`,
+    };
+  }
+
+  if (activeInvocation) {
+    return { status: 'error', result: null, durationMs: 0, error: 'Another invocation is already in progress' };
+  }
+
+  activeInvocation = true;
+
+  try {
+    const bin = claudeBin();
+    // -p (print mode) runs non-interactively and exits.
+    // --dangerously-skip-permissions prevents interactive permission prompts
+    // that would hang in headless mode. CWD is set via execFile's cwd option.
+    const args = [
+      '-p', req.prompt,
+      '--output-format', 'json',
+      '--dangerously-skip-permissions',
+    ];
+
+    if (req.model) {
+      args.push('--model', req.model);
+    }
+    if (req.sessionId) {
+      args.push('--resume', req.sessionId);
+    }
+
+    logger.info({ prompt: req.prompt.slice(0, 200), cwd: req.cwd, model: req.model }, 'Claude Code invocation starting');
+
+    // Build env: read auth tokens from .env since launchd has a minimal environment.
+    const secrets = readEnvFile(['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_API_KEY']);
+    const env: Record<string, string | undefined> = {
+      ...process.env,
+      ...secrets,
+    };
+    // Strip CLAUDECODE to prevent "nested session" detection.
+    delete env.CLAUDECODE;
+
+    // Use spawn with stdin set to 'ignore' — execFile leaves stdin open as a
+    // pipe which causes the CLI to hang waiting for input in non-TTY contexts.
+    const { stdout, stderr } = await new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+      const child = spawn(bin, args, {
+        cwd: req.cwd,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env,
+      });
+
+      let stdout = '';
+      let stderr = '';
+      child.stdout!.on('data', (chunk: Buffer) => { stdout += chunk.toString(); });
+      child.stderr!.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });
+
+      const timer = setTimeout(() => {
+        child.kill('SIGTERM');
+        reject(new Error('Claude Code invocation timed out after 5 minutes'));
+      }, 300_000);
+
+      child.on('close', (code) => {
+        clearTimeout(timer);
+        if (code !== 0) {
+          reject(new Error(`Claude Code exited with code ${code}. stderr: ${stderr.slice(0, 500)}`));
+        } else {
+          resolve({ stdout, stderr });
+        }
+      });
+
+      child.on('error', (err) => {
+        clearTimeout(timer);
+        reject(err);
+      });
+    });
+
+    if (stderr) {
+      logger.debug({ stderr: stderr.slice(0, 500) }, 'Claude Code stderr');
+    }
+
+    const durationMs = Date.now() - startTime;
+
+    // Try to parse JSON output for structured result
+    let result: string | null = null;
+    let sessionId: string | undefined;
+    let costUsd: number | undefined;
+
+    try {
+      const parsed = JSON.parse(stdout);
+      result = parsed.result || stdout;
+      sessionId = parsed.session_id;
+      costUsd = parsed.cost_usd;
+    } catch {
+      // Not JSON — return raw output
+      result = stdout.trim();
+    }
+
+    logger.info({ durationMs, resultLength: result?.length }, 'Claude Code invocation complete');
+
+    return { status: 'success', result, sessionId, costUsd, durationMs };
+  } catch (err) {
+    const durationMs = Date.now() - startTime;
+    const errorMsg = err instanceof Error ? err.message : String(err);
+    logger.error({ err, durationMs }, 'Claude Code invocation failed');
+    return { status: 'error', result: null, durationMs, error: errorMsg };
+  } finally {
+    activeInvocation = false;
+  }
+}
+
+/**
+ * Start the Claude Code HTTP service.
+ */
+export function startClaudeCodeService(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (server) {
+      logger.warn('Claude Code service already running');
+      resolve();
+      return;
+    }
+
+    // Verify CLI is installed before starting
+    try {
+      claudeBin();
+    } catch (err) {
+      logger.error({ err }, 'Claude Code CLI not available, service will not start');
+      resolve(); // Don't block startup
+      return;
+    }
+
+    server = http.createServer(async (req, res) => {
+      // Health check
+      if (req.method === 'GET' && req.url === '/health') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ status: 'ok', active: activeInvocation }));
+        return;
+      }
+
+      // Invoke
+      if (req.method === 'POST' && req.url === '/invoke') {
+        let body = '';
+        req.on('data', (chunk) => { body += chunk; });
+        req.on('end', async () => {
+          try {
+            const result = await handleInvoke(body);
+            res.writeHead(result.status === 'success' ? 200 : 400, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify(result));
+          } catch (err) {
+            res.writeHead(500, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ status: 'error', result: null, error: 'Internal server error' }));
+          }
+        });
+        return;
+      }
+
+      res.writeHead(404);
+      res.end('Not found');
+    });
+
+    server.listen(CLAUDE_CODE_PORT, '0.0.0.0', () => {
+      logger.info({ port: CLAUDE_CODE_PORT }, 'Claude Code service started');
+      resolve();
+    });
+
+    server.on('error', (err) => {
+      logger.error({ err }, 'Claude Code service error');
+      server = null;
+      reject(err);
+    });
+  });
+}
+
+/**
+ * Stop the Claude Code HTTP service.
+ */
+export function stopClaudeCodeService(): void {
+  if (server) {
+    server.close();
+    server = null;
+    logger.info('Claude Code service stopped');
+  }
+}
+
+export const CLAUDE_CODE_HTTP_PORT = CLAUDE_CODE_PORT;

--- a/.claude/skills/add-claude-code/manifest.yaml
+++ b/.claude/skills/add-claude-code/manifest.yaml
@@ -1,0 +1,14 @@
+skill: claude-code
+version: 1.0.0
+description: "Connect container agents to Claude Code on the host for coding tasks"
+core_version: 0.1.0
+adds:
+  - src/claude-code-service.ts
+  - container/agent-runner/src/claude-code-proxy.ts
+modifies:
+  - src/index.ts
+  - container/agent-runner/src/index.ts
+structured:
+  env_additions: []
+conflicts: []
+depends: []

--- a/.claude/skills/add-claude-code/modify/container/agent-runner/src/index.ts
+++ b/.claude/skills/add-claude-code/modify/container/agent-runner/src/index.ts
@@ -1,0 +1,648 @@
+/**
+ * NanoClaw Agent Runner
+ * Runs inside a container, receives config via stdin, outputs result to stdout
+ *
+ * Input protocol:
+ *   Stdin: Full ContainerInput JSON (read until EOF, like before)
+ *   IPC:   Follow-up messages written as JSON files to /workspace/ipc/input/
+ *          Files: {type:"message", text:"..."}.json — polled and consumed
+ *          Sentinel: /workspace/ipc/input/_close — signals session end
+ *
+ * Stdout protocol:
+ *   Each result is wrapped in OUTPUT_START_MARKER / OUTPUT_END_MARKER pairs.
+ *   Multiple results may be emitted (one per agent teams result).
+ *   Final marker after loop ends signals completion.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { query, HookCallback, PreCompactHookInput, PreToolUseHookInput } from '@anthropic-ai/claude-agent-sdk';
+import { fileURLToPath } from 'url';
+
+interface ContainerInput {
+  prompt: string;
+  sessionId?: string;
+  groupFolder: string;
+  chatJid: string;
+  isMain: boolean;
+  isScheduledTask?: boolean;
+  model?: string;
+  assistantName?: string;
+  secrets?: Record<string, string>;
+}
+
+interface ContainerOutput {
+  status: 'success' | 'error';
+  result: string | null;
+  newSessionId?: string;
+  error?: string;
+}
+
+interface SessionEntry {
+  sessionId: string;
+  fullPath: string;
+  summary: string;
+  firstPrompt: string;
+}
+
+interface SessionsIndex {
+  entries: SessionEntry[];
+}
+
+interface SDKUserMessage {
+  type: 'user';
+  message: { role: 'user'; content: string };
+  parent_tool_use_id: null;
+  session_id: string;
+}
+
+const IPC_INPUT_DIR = '/workspace/ipc/input';
+const IPC_INPUT_CLOSE_SENTINEL = path.join(IPC_INPUT_DIR, '_close');
+const IPC_POLL_MS = 500;
+
+/**
+ * Push-based async iterable for streaming user messages to the SDK.
+ * Keeps the iterable alive until end() is called, preventing isSingleUserTurn.
+ */
+class MessageStream {
+  private queue: SDKUserMessage[] = [];
+  private waiting: (() => void) | null = null;
+  private done = false;
+
+  push(text: string): void {
+    this.queue.push({
+      type: 'user',
+      message: { role: 'user', content: text },
+      parent_tool_use_id: null,
+      session_id: '',
+    });
+    this.waiting?.();
+  }
+
+  end(): void {
+    this.done = true;
+    this.waiting?.();
+  }
+
+  async *[Symbol.asyncIterator](): AsyncGenerator<SDKUserMessage> {
+    while (true) {
+      while (this.queue.length > 0) {
+        yield this.queue.shift()!;
+      }
+      if (this.done) return;
+      await new Promise<void>(r => { this.waiting = r; });
+      this.waiting = null;
+    }
+  }
+}
+
+async function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', chunk => { data += chunk; });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
+  });
+}
+
+const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
+const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
+
+function writeOutput(output: ContainerOutput): void {
+  console.log(OUTPUT_START_MARKER);
+  console.log(JSON.stringify(output));
+  console.log(OUTPUT_END_MARKER);
+}
+
+function log(message: string): void {
+  console.error(`[agent-runner] ${message}`);
+}
+
+function getSessionSummary(sessionId: string, transcriptPath: string): string | null {
+  const projectDir = path.dirname(transcriptPath);
+  const indexPath = path.join(projectDir, 'sessions-index.json');
+
+  if (!fs.existsSync(indexPath)) {
+    log(`Sessions index not found at ${indexPath}`);
+    return null;
+  }
+
+  try {
+    const index: SessionsIndex = JSON.parse(fs.readFileSync(indexPath, 'utf-8'));
+    const entry = index.entries.find(e => e.sessionId === sessionId);
+    if (entry?.summary) {
+      return entry.summary;
+    }
+  } catch (err) {
+    log(`Failed to read sessions index: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  return null;
+}
+
+/**
+ * Archive the full transcript to conversations/ before compaction.
+ */
+function createPreCompactHook(assistantName?: string): HookCallback {
+  return async (input, _toolUseId, _context) => {
+    const preCompact = input as PreCompactHookInput;
+    const transcriptPath = preCompact.transcript_path;
+    const sessionId = preCompact.session_id;
+
+    if (!transcriptPath || !fs.existsSync(transcriptPath)) {
+      log('No transcript found for archiving');
+      return {};
+    }
+
+    try {
+      const content = fs.readFileSync(transcriptPath, 'utf-8');
+      const messages = parseTranscript(content);
+
+      if (messages.length === 0) {
+        log('No messages to archive');
+        return {};
+      }
+
+      const summary = getSessionSummary(sessionId, transcriptPath);
+      const name = summary ? sanitizeFilename(summary) : generateFallbackName();
+
+      const conversationsDir = '/workspace/group/conversations';
+      fs.mkdirSync(conversationsDir, { recursive: true });
+
+      const date = new Date().toISOString().split('T')[0];
+      const filename = `${date}-${name}.md`;
+      const filePath = path.join(conversationsDir, filename);
+
+      const markdown = formatTranscriptMarkdown(messages, summary, assistantName);
+      fs.writeFileSync(filePath, markdown);
+
+      log(`Archived conversation to ${filePath}`);
+
+      // Trigger async memory extraction on the host side
+      try {
+        const tasksDir = '/workspace/ipc/tasks';
+        fs.mkdirSync(tasksDir, { recursive: true });
+        const taskFile = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}.json`;
+        const taskData = {
+          type: 'extract_memories',
+          transcript_path: filePath, // The archived markdown, not raw JSONL
+          group_folder: process.env.NANOCLAW_GROUP_FOLDER || 'main',
+          timestamp: new Date().toISOString(),
+        };
+        const tmpPath = path.join(tasksDir, `${taskFile}.tmp`);
+        fs.writeFileSync(tmpPath, JSON.stringify(taskData, null, 2));
+        fs.renameSync(tmpPath, path.join(tasksDir, taskFile));
+        log(`Triggered memory extraction for ${filePath}`);
+      } catch (extractErr) {
+        log(`Failed to trigger memory extraction: ${extractErr instanceof Error ? extractErr.message : String(extractErr)}`);
+      }
+    } catch (err) {
+      log(`Failed to archive transcript: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    return {};
+  };
+}
+
+// Secrets to strip from Bash tool subprocess environments.
+// These are needed by claude-code for API auth but should never
+// be visible to commands Kit runs.
+const SECRET_ENV_VARS = ['ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN'];
+
+function createSanitizeBashHook(): HookCallback {
+  return async (input, _toolUseId, _context) => {
+    const preInput = input as PreToolUseHookInput;
+    const command = (preInput.tool_input as { command?: string })?.command;
+    if (!command) return {};
+
+    const unsetPrefix = `unset ${SECRET_ENV_VARS.join(' ')} 2>/dev/null; `;
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        updatedInput: {
+          ...(preInput.tool_input as Record<string, unknown>),
+          command: unsetPrefix + command,
+        },
+      },
+    };
+  };
+}
+
+function sanitizeFilename(summary: string): string {
+  return summary
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 50);
+}
+
+function generateFallbackName(): string {
+  const time = new Date();
+  return `conversation-${time.getHours().toString().padStart(2, '0')}${time.getMinutes().toString().padStart(2, '0')}`;
+}
+
+interface ParsedMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+function parseTranscript(content: string): ParsedMessage[] {
+  const messages: ParsedMessage[] = [];
+
+  for (const line of content.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const entry = JSON.parse(line);
+      if (entry.type === 'user' && entry.message?.content) {
+        const text = typeof entry.message.content === 'string'
+          ? entry.message.content
+          : entry.message.content.map((c: { text?: string }) => c.text || '').join('');
+        if (text) messages.push({ role: 'user', content: text });
+      } else if (entry.type === 'assistant' && entry.message?.content) {
+        const textParts = entry.message.content
+          .filter((c: { type: string }) => c.type === 'text')
+          .map((c: { text: string }) => c.text);
+        const text = textParts.join('');
+        if (text) messages.push({ role: 'assistant', content: text });
+      }
+    } catch {
+    }
+  }
+
+  return messages;
+}
+
+function formatTranscriptMarkdown(messages: ParsedMessage[], title?: string | null, assistantName?: string): string {
+  const now = new Date();
+  const formatDateTime = (d: Date) => d.toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true
+  });
+
+  const lines: string[] = [];
+  lines.push(`# ${title || 'Conversation'}`);
+  lines.push('');
+  lines.push(`Archived: ${formatDateTime(now)}`);
+  lines.push('');
+  lines.push('---');
+  lines.push('');
+
+  for (const msg of messages) {
+    const sender = msg.role === 'user' ? 'User' : (assistantName || 'Assistant');
+    const content = msg.content.length > 2000
+      ? msg.content.slice(0, 2000) + '...'
+      : msg.content;
+    lines.push(`**${sender}**: ${content}`);
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Check for _close sentinel.
+ */
+function shouldClose(): boolean {
+  if (fs.existsSync(IPC_INPUT_CLOSE_SENTINEL)) {
+    try { fs.unlinkSync(IPC_INPUT_CLOSE_SENTINEL); } catch { /* ignore */ }
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Drain all pending IPC input messages.
+ * Returns messages found, or empty array.
+ */
+function drainIpcInput(): string[] {
+  try {
+    fs.mkdirSync(IPC_INPUT_DIR, { recursive: true });
+    const files = fs.readdirSync(IPC_INPUT_DIR)
+      .filter(f => f.endsWith('.json'))
+      .sort();
+
+    const messages: string[] = [];
+    for (const file of files) {
+      const filePath = path.join(IPC_INPUT_DIR, file);
+      try {
+        const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+        fs.unlinkSync(filePath);
+        if (data.type === 'message' && data.text) {
+          messages.push(data.text);
+        }
+      } catch (err) {
+        log(`Failed to process input file ${file}: ${err instanceof Error ? err.message : String(err)}`);
+        try { fs.unlinkSync(filePath); } catch { /* ignore */ }
+      }
+    }
+    return messages;
+  } catch (err) {
+    log(`IPC drain error: ${err instanceof Error ? err.message : String(err)}`);
+    return [];
+  }
+}
+
+/**
+ * Wait for a new IPC message or _close sentinel.
+ * Returns the messages as a single string, or null if _close.
+ */
+function waitForIpcMessage(): Promise<string | null> {
+  return new Promise((resolve) => {
+    const poll = () => {
+      if (shouldClose()) {
+        resolve(null);
+        return;
+      }
+      const messages = drainIpcInput();
+      if (messages.length > 0) {
+        resolve(messages.join('\n'));
+        return;
+      }
+      setTimeout(poll, IPC_POLL_MS);
+    };
+    poll();
+  });
+}
+
+/**
+ * Run a single query and stream results via writeOutput.
+ * Uses MessageStream (AsyncIterable) to keep isSingleUserTurn=false,
+ * allowing agent teams subagents to run to completion.
+ * Also pipes IPC messages into the stream during the query.
+ */
+async function runQuery(
+  prompt: string,
+  sessionId: string | undefined,
+  mcpServerPath: string,
+  qmdProxyPath: string,
+  claudeCodeProxyPath: string,
+  containerInput: ContainerInput,
+  sdkEnv: Record<string, string | undefined>,
+  resumeAt?: string,
+): Promise<{ newSessionId?: string; lastAssistantUuid?: string; closedDuringQuery: boolean }> {
+  const stream = new MessageStream();
+  stream.push(prompt);
+
+  // Poll IPC for follow-up messages and _close sentinel during the query
+  let ipcPolling = true;
+  let closedDuringQuery = false;
+  const pollIpcDuringQuery = () => {
+    if (!ipcPolling) return;
+    if (shouldClose()) {
+      log('Close sentinel detected during query, ending stream');
+      closedDuringQuery = true;
+      stream.end();
+      ipcPolling = false;
+      return;
+    }
+    const messages = drainIpcInput();
+    for (const text of messages) {
+      log(`Piping IPC message into active query (${text.length} chars)`);
+      stream.push(text);
+    }
+    setTimeout(pollIpcDuringQuery, IPC_POLL_MS);
+  };
+  setTimeout(pollIpcDuringQuery, IPC_POLL_MS);
+
+  let newSessionId: string | undefined;
+  let lastAssistantUuid: string | undefined;
+  let messageCount = 0;
+  let resultCount = 0;
+
+  // Load global CLAUDE.md as additional system context (shared across all groups)
+  const globalClaudeMdPath = '/workspace/global/CLAUDE.md';
+  let globalClaudeMd: string | undefined;
+  if (!containerInput.isMain && fs.existsSync(globalClaudeMdPath)) {
+    globalClaudeMd = fs.readFileSync(globalClaudeMdPath, 'utf-8');
+  }
+
+  // Discover additional directories mounted at /workspace/extra/*
+  // These are passed to the SDK so their CLAUDE.md files are loaded automatically
+  const extraDirs: string[] = [];
+  const extraBase = '/workspace/extra';
+  if (fs.existsSync(extraBase)) {
+    for (const entry of fs.readdirSync(extraBase)) {
+      const fullPath = path.join(extraBase, entry);
+      if (fs.statSync(fullPath).isDirectory()) {
+        extraDirs.push(fullPath);
+      }
+    }
+  }
+  if (extraDirs.length > 0) {
+    log(`Additional directories: ${extraDirs.join(', ')}`);
+  }
+
+  // Build MCP servers config — claude-code only available to main group
+  const mcpServers: Record<string, { command: string; args: string[]; env?: Record<string, string> }> = {
+    nanoclaw: {
+      command: 'node',
+      args: [mcpServerPath],
+      env: {
+        NANOCLAW_CHAT_JID: containerInput.chatJid,
+        NANOCLAW_GROUP_FOLDER: containerInput.groupFolder,
+        NANOCLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
+      },
+    },
+    qmd: {
+      command: 'node',
+      args: [qmdProxyPath],
+      env: { QMD_PORT: '8181' },
+    },
+    gmail: { command: 'npx', args: ['-y', '@gongrzhe/server-gmail-autoauth-mcp'] },
+    'google-workspace': { command: 'npx', args: ['-y', 'google-workspace-mcp', 'serve'] },
+  };
+
+  // Claude Code MCP — main group only (security: host filesystem access)
+  if (containerInput.isMain) {
+    mcpServers['claude-code'] = {
+      command: 'node',
+      args: [claudeCodeProxyPath],
+      env: { CLAUDE_CODE_PORT: '8282' },
+    };
+  }
+
+  // Build allowed tools list — claude-code tools only for main group
+  const allowedTools = [
+    'Bash',
+    'Read', 'Write', 'Edit', 'Glob', 'Grep',
+    'WebSearch', 'WebFetch',
+    'Task', 'TaskOutput', 'TaskStop',
+    'TeamCreate', 'TeamDelete', 'SendMessage',
+    'TodoWrite', 'ToolSearch', 'Skill',
+    'NotebookEdit',
+    'mcp__nanoclaw__*',
+    'mcp__qmd__*',
+    'mcp__gmail__*',
+    'mcp__google-workspace__*',
+  ];
+
+  if (containerInput.isMain) {
+    allowedTools.push('mcp__claude-code__*');
+  }
+
+  for await (const message of query({
+    prompt: stream,
+    options: {
+      model: containerInput.model,
+      cwd: '/workspace/group',
+      additionalDirectories: extraDirs.length > 0 ? extraDirs : undefined,
+      resume: sessionId,
+      resumeSessionAt: resumeAt,
+      systemPrompt: globalClaudeMd
+        ? { type: 'preset' as const, preset: 'claude_code' as const, append: globalClaudeMd }
+        : undefined,
+      allowedTools,
+      env: sdkEnv,
+      permissionMode: 'bypassPermissions',
+      allowDangerouslySkipPermissions: true,
+      settingSources: ['project', 'user'],
+      mcpServers,
+      hooks: {
+        PreCompact: [{ hooks: [createPreCompactHook(containerInput.assistantName)] }],
+        PreToolUse: [{ matcher: 'Bash', hooks: [createSanitizeBashHook()] }],
+      },
+    }
+  })) {
+    messageCount++;
+    const msgType = message.type === 'system' ? `system/${(message as { subtype?: string }).subtype}` : message.type;
+    log(`[msg #${messageCount}] type=${msgType}`);
+
+    if (message.type === 'assistant' && 'uuid' in message) {
+      lastAssistantUuid = (message as { uuid: string }).uuid;
+    }
+
+    if (message.type === 'system' && message.subtype === 'init') {
+      newSessionId = message.session_id;
+      const initModel = (message as { model?: string }).model;
+      log(`Session initialized: ${newSessionId}, model: ${initModel || 'unknown'}`);
+    }
+
+    if (message.type === 'system' && (message as { subtype?: string }).subtype === 'task_notification') {
+      const tn = message as { task_id: string; status: string; summary: string };
+      log(`Task notification: task=${tn.task_id} status=${tn.status} summary=${tn.summary}`);
+    }
+
+    if (message.type === 'result') {
+      resultCount++;
+      const textResult = 'result' in message ? (message as { result?: string }).result : null;
+      log(`Result #${resultCount}: subtype=${message.subtype}${textResult ? ` text=${textResult.slice(0, 200)}` : ''}`);
+      writeOutput({
+        status: 'success',
+        result: textResult || null,
+        newSessionId
+      });
+    }
+  }
+
+  ipcPolling = false;
+  log(`Query done. Messages: ${messageCount}, results: ${resultCount}, lastAssistantUuid: ${lastAssistantUuid || 'none'}, closedDuringQuery: ${closedDuringQuery}`);
+  return { newSessionId, lastAssistantUuid, closedDuringQuery };
+}
+
+async function main(): Promise<void> {
+  let containerInput: ContainerInput;
+
+  try {
+    const stdinData = await readStdin();
+    containerInput = JSON.parse(stdinData);
+    // Delete the temp file the entrypoint wrote — it contains secrets
+    try { fs.unlinkSync('/tmp/input.json'); } catch { /* may not exist */ }
+    log(`Received input for group: ${containerInput.groupFolder}, model: ${containerInput.model || '(default)'}`);
+
+  } catch (err) {
+    writeOutput({
+      status: 'error',
+      result: null,
+      error: `Failed to parse input: ${err instanceof Error ? err.message : String(err)}`
+    });
+    process.exit(1);
+  }
+
+  // Build SDK env: merge secrets into process.env for the SDK only.
+  // Secrets never touch process.env itself, so Bash subprocesses can't see them.
+  const sdkEnv: Record<string, string | undefined> = { ...process.env };
+  for (const [key, value] of Object.entries(containerInput.secrets || {})) {
+    sdkEnv[key] = value;
+  }
+
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const mcpServerPath = path.join(__dirname, 'ipc-mcp-stdio.js');
+  const qmdProxyPath = path.join(__dirname, 'qmd-proxy.js');
+  const claudeCodeProxyPath = path.join(__dirname, 'claude-code-proxy.js');
+
+  let sessionId = containerInput.sessionId;
+  fs.mkdirSync(IPC_INPUT_DIR, { recursive: true });
+
+  // Clean up stale _close sentinel from previous container runs
+  try { fs.unlinkSync(IPC_INPUT_CLOSE_SENTINEL); } catch { /* ignore */ }
+
+  // Build initial prompt (drain any pending IPC messages too)
+  let prompt = '';
+  if (containerInput.model) {
+    prompt += `[SYSTEM: You are running on model ${containerInput.model}]\n\n`;
+  }
+  prompt += containerInput.prompt;
+  if (containerInput.isScheduledTask) {
+    prompt = `[SCHEDULED TASK - The following message was sent automatically and is not coming directly from the user or group.]\n\n${prompt}`;
+  }
+  const pending = drainIpcInput();
+  if (pending.length > 0) {
+    log(`Draining ${pending.length} pending IPC messages into initial prompt`);
+    prompt += '\n' + pending.join('\n');
+  }
+
+  // Query loop: run query → wait for IPC message → run new query → repeat
+  let resumeAt: string | undefined;
+  try {
+    while (true) {
+      log(`Starting query (session: ${sessionId || 'new'}, resumeAt: ${resumeAt || 'latest'})...`);
+
+      const queryResult = await runQuery(prompt, sessionId, mcpServerPath, qmdProxyPath, claudeCodeProxyPath, containerInput, sdkEnv, resumeAt);
+      if (queryResult.newSessionId) {
+        sessionId = queryResult.newSessionId;
+      }
+      if (queryResult.lastAssistantUuid) {
+        resumeAt = queryResult.lastAssistantUuid;
+      }
+
+      // If _close was consumed during the query, exit immediately.
+      // Don't emit a session-update marker (it would reset the host's
+      // idle timer and cause a 30-min delay before the next _close).
+      if (queryResult.closedDuringQuery) {
+        log('Close sentinel consumed during query, exiting');
+        break;
+      }
+
+      // Emit session update so host can track it
+      writeOutput({ status: 'success', result: null, newSessionId: sessionId });
+
+      log('Query ended, waiting for next IPC message...');
+
+      // Wait for the next message or _close sentinel
+      const nextMessage = await waitForIpcMessage();
+      if (nextMessage === null) {
+        log('Close sentinel received, exiting');
+        break;
+      }
+
+      log(`Got new message (${nextMessage.length} chars), starting new query`);
+      prompt = nextMessage;
+    }
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    log(`Agent error: ${errorMessage}`);
+    writeOutput({
+      status: 'error',
+      result: null,
+      newSessionId: sessionId,
+      error: errorMessage
+    });
+    process.exit(1);
+  }
+}
+
+main();

--- a/.claude/skills/add-claude-code/modify/container/agent-runner/src/index.ts.intent.md
+++ b/.claude/skills/add-claude-code/modify/container/agent-runner/src/index.ts.intent.md
@@ -1,0 +1,36 @@
+# Intent: container/agent-runner/src/index.ts modifications
+
+## What changed
+Added Claude Code MCP server registration so main-group agents can delegate coding tasks to the host.
+
+## Key sections
+
+### runQuery() signature
+- Added: `claudeCodeProxyPath` parameter (5th positional, after `qmdProxyPath`)
+
+### MCP servers config (inside runQuery)
+- Extracted: `mcpServers` from inline object to a variable built conditionally
+- Added: `claude-code` MCP server entry, **only when `containerInput.isMain === true`**
+- Spawn config: `{ command: 'node', args: [claudeCodeProxyPath], env: { CLAUDE_CODE_PORT: '8282' } }`
+- Existing servers (nanoclaw, qmd, gmail, google-workspace) are unchanged
+
+### allowedTools (inside runQuery)
+- Extracted: `allowedTools` from inline array to a variable
+- Added: `'mcp__claude-code__*'` pushed onto array, **only when `containerInput.isMain === true`**
+- All existing tool permissions are unchanged
+
+### main()
+- Added: `claudeCodeProxyPath` constant alongside `mcpServerPath` and `qmdProxyPath`
+- Updated: `runQuery()` calls pass the new path parameter
+
+## Security
+- Non-main groups do NOT get the claude-code MCP server registered
+- Non-main groups do NOT get `mcp__claude-code__*` in allowedTools
+- This prevents non-main agents from accessing host filesystem via Claude Code
+
+## Invariants
+- All existing MCP servers are preserved (nanoclaw, qmd, gmail, google-workspace)
+- All existing tool permissions are preserved
+- MessageStream, IPC polling, hooks are completely unchanged
+- Input/output protocol is unchanged
+- Session management is unchanged

--- a/.claude/skills/add-claude-code/modify/src/index.ts
+++ b/.claude/skills/add-claude-code/modify/src/index.ts
@@ -1,0 +1,635 @@
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+import {
+  ASSISTANT_NAME,
+  DATA_DIR,
+  IDLE_TIMEOUT,
+  MAIN_GROUP_FOLDER,
+  POLL_INTERVAL,
+  TELEGRAM_BOT_TOKEN,
+  TELEGRAM_ONLY,
+  TRIGGER_PATTERN,
+} from './config.js';
+import { WhatsAppChannel } from './channels/whatsapp.js';
+import { TelegramChannel } from './channels/telegram.js';
+import { ensureContainerRuntimeRunning, cleanupOrphans } from './container-runtime.js';
+import {
+  ContainerOutput,
+  runContainerAgent,
+  writeGroupsSnapshot,
+  writeTasksSnapshot,
+} from './container-runner.js';
+import {
+  clearAllSessions,
+  deleteSession,
+  getAllChats,
+  getAllRegisteredGroups,
+  getAllSessions,
+  getAllTasks,
+  getMessagesSince,
+  getModelOverride,
+  getNewMessages,
+  getRouterState,
+  initDatabase,
+  setModelOverride,
+  setRegisteredGroup,
+  setRouterState,
+  setSession,
+  storeChatMetadata,
+  storeMessage,
+} from './db.js';
+import { GroupQueue } from './group-queue.js';
+import { startIpcWatcher } from './ipc.js';
+import { findChannel, formatMessages, formatOutbound } from './router.js';
+import { startSchedulerLoop } from './task-scheduler.js';
+import { Channel, NewMessage, RegisteredGroup } from './types.js';
+import { logger } from './logger.js';
+import { startQmd, stopQmd } from './qmd.js';
+import { startClaudeCodeService, stopClaudeCodeService } from './claude-code-service.js';
+
+// Re-export for backwards compatibility during refactor
+export { escapeXml, formatMessages } from './router.js';
+
+// Model name → model ID mapping
+// IDs must match what the Claude CLI in the container actually supports
+const MODEL_MAP: Record<string, Record<string, string>> = {
+  haiku:  { '4.5': 'claude-haiku-4-5-20251001' },
+  sonnet: { '4': 'claude-sonnet-4-20250514', '4.5': 'claude-sonnet-4-5-20250929', '4.6': 'claude-sonnet-4-6' },
+  opus:   { '4': 'claude-opus-4-20250514', '4.5': 'claude-opus-4-5-20251101', '4.6': 'claude-opus-4-6' },
+};
+
+// Default (latest) version per family
+const MODEL_LATEST: Record<string, string> = {
+  haiku:  '4.5',
+  sonnet: '4.6',
+  opus:   '4.6',
+};
+
+/**
+ * Resolve a friendly model name to a full model ID.
+ * Accepts: "opus", "sonnet 4.5", "claude-opus-4-6-20250918", etc.
+ * Returns the model ID or null if invalid.
+ */
+function resolveModelName(input: string): string | null {
+  const trimmed = input.trim().toLowerCase();
+
+  // Raw model ID (starts with "claude-") — pass through directly
+  if (trimmed.startsWith('claude-')) return trimmed;
+
+  const parts = trimmed.split(/\s+/);
+  const family = parts[0];
+  const version = parts[1];
+
+  if (!MODEL_MAP[family]) return null;
+
+  if (version) {
+    // Specific version: "sonnet 4.5"
+    return MODEL_MAP[family][version] || null;
+  }
+
+  // No version — use latest
+  const latestVersion = MODEL_LATEST[family];
+  return latestVersion ? MODEL_MAP[family][latestVersion] : null;
+}
+
+/** Get a display-friendly name for a model ID */
+function friendlyModelName(modelId: string): string {
+  for (const [family, versions] of Object.entries(MODEL_MAP)) {
+    for (const [ver, id] of Object.entries(versions)) {
+      if (id === modelId) return `${family} ${ver}`;
+    }
+  }
+  return modelId; // Raw ID, no friendly name
+}
+
+/**
+ * Handle a /model command. Returns the response to the user.
+ * Extracted so both processGroupMessages and startMessageLoop can use it.
+ */
+async function handleModelCommand(
+  content: string,
+  chatJid: string,
+  channel: Channel,
+): Promise<void> {
+  const args = content.trim().replace(/^\/model\s*/i, '').trim();
+  const families = Object.keys(MODEL_MAP).join(', ');
+
+  if (!args) {
+    const current = getModelOverride();
+    const display = current ? friendlyModelName(current) : 'sonnet (default)';
+    await channel.sendMessage(chatJid, `Current model: *${display}*`);
+  } else {
+    const resolved = resolveModelName(args);
+    if (resolved) {
+      setModelOverride(resolved);
+      // Close any active container so the next message spawns one with the new model
+      queue.closeStdin(chatJid);
+      // Clear all sessions so the SDK starts fresh with the new model
+      // (resumed sessions lock to their original model)
+      sessions = {};
+      clearAllSessions();
+      await channel.sendMessage(chatJid, `Model switched to *${friendlyModelName(resolved)}* (${resolved})`);
+      logger.info({ model: resolved }, 'Model override set');
+    } else {
+      await channel.sendMessage(
+        chatJid,
+        `Unknown model "${args}". Available: ${families}, or a raw model ID (claude-...)`,
+      );
+    }
+  }
+}
+
+let lastTimestamp = '';
+let sessions: Record<string, string> = {};
+let registeredGroups: Record<string, RegisteredGroup> = {};
+let lastAgentTimestamp: Record<string, string> = {};
+let messageLoopRunning = false;
+
+let whatsapp: WhatsAppChannel;
+const channels: Channel[] = [];
+const queue = new GroupQueue();
+
+function loadState(): void {
+  lastTimestamp = getRouterState('last_timestamp') || '';
+  const agentTs = getRouterState('last_agent_timestamp');
+  try {
+    lastAgentTimestamp = agentTs ? JSON.parse(agentTs) : {};
+  } catch {
+    logger.warn('Corrupted last_agent_timestamp in DB, resetting');
+    lastAgentTimestamp = {};
+  }
+  sessions = getAllSessions();
+  registeredGroups = getAllRegisteredGroups();
+  logger.info(
+    { groupCount: Object.keys(registeredGroups).length },
+    'State loaded',
+  );
+}
+
+function saveState(): void {
+  setRouterState('last_timestamp', lastTimestamp);
+  setRouterState(
+    'last_agent_timestamp',
+    JSON.stringify(lastAgentTimestamp),
+  );
+}
+
+function registerGroup(jid: string, group: RegisteredGroup): void {
+  registeredGroups[jid] = group;
+  setRegisteredGroup(jid, group);
+
+  // Create group folder
+  const groupDir = path.join(DATA_DIR, '..', 'groups', group.folder);
+  fs.mkdirSync(path.join(groupDir, 'logs'), { recursive: true });
+
+  logger.info(
+    { jid, name: group.name, folder: group.folder },
+    'Group registered',
+  );
+}
+
+/**
+ * Get available groups list for the agent.
+ * Returns groups ordered by most recent activity.
+ */
+export function getAvailableGroups(): import('./container-runner.js').AvailableGroup[] {
+  const chats = getAllChats();
+  const registeredJids = new Set(Object.keys(registeredGroups));
+
+  return chats
+    .filter((c) => c.jid !== '__group_sync__' && c.is_group)
+    .map((c) => ({
+      jid: c.jid,
+      name: c.name,
+      lastActivity: c.last_message_time,
+      isRegistered: registeredJids.has(c.jid),
+    }));
+}
+
+/** @internal - exported for testing */
+export function _setRegisteredGroups(groups: Record<string, RegisteredGroup>): void {
+  registeredGroups = groups;
+}
+
+/**
+ * Process all pending messages for a group.
+ * Called by the GroupQueue when it's this group's turn.
+ */
+async function processGroupMessages(chatJid: string): Promise<boolean> {
+  const group = registeredGroups[chatJid];
+  if (!group) return true;
+
+  const channel = findChannel(channels, chatJid);
+  if (!channel) return true;
+
+  const isMainGroup = group.folder === MAIN_GROUP_FOLDER;
+
+  const sinceTimestamp = lastAgentTimestamp[chatJid] || '';
+  const missedMessages = getMessagesSince(chatJid, sinceTimestamp, ASSISTANT_NAME);
+
+  if (missedMessages.length === 0) return true;
+
+  // Intercept /model commands before they reach the agent
+  const modelMsg = missedMessages.find((m) => /^\/model\b/i.test(m.content.trim()));
+  if (modelMsg) {
+    await handleModelCommand(modelMsg.content, chatJid, channel);
+    lastAgentTimestamp[chatJid] = missedMessages[missedMessages.length - 1].timestamp;
+    saveState();
+    return true;
+  }
+
+  // Intercept /new command — start a fresh session
+  const newMsg = missedMessages.find((m) => /^\/new\s*$/i.test(m.content.trim()));
+  if (newMsg) {
+    queue.closeStdin(chatJid);
+    delete sessions[group.folder];
+    deleteSession(group.folder);
+    await channel.sendMessage(chatJid, 'Session cleared. Next message starts fresh.');
+    lastAgentTimestamp[chatJid] = missedMessages[missedMessages.length - 1].timestamp;
+    saveState();
+    logger.info({ group: group.name }, 'Session cleared via /new');
+    return true;
+  }
+
+  // For non-main groups, check if trigger is required and present
+  if (!isMainGroup && group.requiresTrigger !== false) {
+    const hasTrigger = missedMessages.some((m) =>
+      TRIGGER_PATTERN.test(m.content.trim()),
+    );
+    if (!hasTrigger) return true;
+  }
+
+  const prompt = formatMessages(missedMessages);
+
+  // Advance cursor so the piping path in startMessageLoop won't re-fetch
+  // these messages. Save the old cursor so we can roll back on error.
+  const previousCursor = lastAgentTimestamp[chatJid] || '';
+  lastAgentTimestamp[chatJid] =
+    missedMessages[missedMessages.length - 1].timestamp;
+  saveState();
+
+  logger.info(
+    { group: group.name, messageCount: missedMessages.length },
+    'Processing messages',
+  );
+
+  // Track idle timer for closing stdin when agent is idle
+  let idleTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const resetIdleTimer = () => {
+    if (idleTimer) clearTimeout(idleTimer);
+    idleTimer = setTimeout(() => {
+      logger.debug({ group: group.name }, 'Idle timeout, closing container stdin');
+      queue.closeStdin(chatJid);
+    }, IDLE_TIMEOUT);
+  };
+
+  await channel.setTyping?.(chatJid, true);
+  let hadError = false;
+  let outputSentToUser = false;
+
+  const output = await runAgent(group, prompt, chatJid, async (result) => {
+    // Streaming output callback — called for each agent result
+    if (result.result) {
+      const raw = typeof result.result === 'string' ? result.result : JSON.stringify(result.result);
+      // Strip <internal>...</internal> blocks — agent uses these for internal reasoning
+      const text = raw.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
+      logger.info({ group: group.name }, `Agent output: ${raw.slice(0, 200)}`);
+      if (text) {
+        await channel.sendMessage(chatJid, text);
+        outputSentToUser = true;
+      }
+      // Only reset idle timer on actual results, not session-update markers (result: null)
+      resetIdleTimer();
+    }
+
+    if (result.status === 'error') {
+      hadError = true;
+    }
+  });
+
+  await channel.setTyping?.(chatJid, false);
+  if (idleTimer) clearTimeout(idleTimer);
+
+  if (output === 'error' || hadError) {
+    // If we already sent output to the user, don't roll back the cursor —
+    // the user got their response and re-processing would send duplicates.
+    if (outputSentToUser) {
+      logger.warn({ group: group.name }, 'Agent error after output was sent, skipping cursor rollback to prevent duplicates');
+      return true;
+    }
+    // Roll back cursor so retries can re-process these messages
+    lastAgentTimestamp[chatJid] = previousCursor;
+    saveState();
+    logger.warn({ group: group.name }, 'Agent error, rolled back message cursor for retry');
+    return false;
+  }
+
+  return true;
+}
+
+async function runAgent(
+  group: RegisteredGroup,
+  prompt: string,
+  chatJid: string,
+  onOutput?: (output: ContainerOutput) => Promise<void>,
+): Promise<'success' | 'error'> {
+  const isMain = group.folder === MAIN_GROUP_FOLDER;
+  const sessionId = sessions[group.folder];
+
+  // Update tasks snapshot for container to read (filtered by group)
+  const tasks = getAllTasks();
+  writeTasksSnapshot(
+    group.folder,
+    isMain,
+    tasks.map((t) => ({
+      id: t.id,
+      groupFolder: t.group_folder,
+      prompt: t.prompt,
+      schedule_type: t.schedule_type,
+      schedule_value: t.schedule_value,
+      status: t.status,
+      next_run: t.next_run,
+    })),
+  );
+
+  // Update available groups snapshot (main group only can see all groups)
+  const availableGroups = getAvailableGroups();
+  writeGroupsSnapshot(
+    group.folder,
+    isMain,
+    availableGroups,
+    new Set(Object.keys(registeredGroups)),
+  );
+
+  // Wrap onOutput to track session ID from streamed results
+  const wrappedOnOutput = onOutput
+    ? async (output: ContainerOutput) => {
+        if (output.newSessionId) {
+          sessions[group.folder] = output.newSessionId;
+          setSession(group.folder, output.newSessionId);
+        }
+        await onOutput(output);
+      }
+    : undefined;
+
+  try {
+    const output = await runContainerAgent(
+      group,
+      {
+        prompt,
+        sessionId,
+        groupFolder: group.folder,
+        chatJid,
+        isMain,
+        model: getModelOverride(),
+        assistantName: ASSISTANT_NAME,
+      },
+      (proc, containerName) => queue.registerProcess(chatJid, proc, containerName, group.folder),
+      wrappedOnOutput,
+    );
+
+    if (output.newSessionId) {
+      sessions[group.folder] = output.newSessionId;
+      setSession(group.folder, output.newSessionId);
+    }
+
+    if (output.status === 'error') {
+      logger.error(
+        { group: group.name, error: output.error },
+        'Container agent error',
+      );
+      return 'error';
+    }
+
+    return 'success';
+  } catch (err) {
+    logger.error({ group: group.name, err }, 'Agent error');
+    return 'error';
+  }
+}
+
+async function startMessageLoop(): Promise<void> {
+  if (messageLoopRunning) {
+    logger.debug('Message loop already running, skipping duplicate start');
+    return;
+  }
+  messageLoopRunning = true;
+
+  logger.info(`NanoClaw running (trigger: @${ASSISTANT_NAME})`);
+
+  while (true) {
+    try {
+      const jids = Object.keys(registeredGroups);
+      const { messages, newTimestamp } = getNewMessages(jids, lastTimestamp, ASSISTANT_NAME);
+
+      if (messages.length > 0) {
+        logger.info({ count: messages.length }, 'New messages');
+
+        // Advance the "seen" cursor for all messages immediately
+        lastTimestamp = newTimestamp;
+        saveState();
+
+        // Deduplicate by group
+        const messagesByGroup = new Map<string, NewMessage[]>();
+        for (const msg of messages) {
+          const existing = messagesByGroup.get(msg.chat_jid);
+          if (existing) {
+            existing.push(msg);
+          } else {
+            messagesByGroup.set(msg.chat_jid, [msg]);
+          }
+        }
+
+        for (const [chatJid, groupMessages] of messagesByGroup) {
+          const group = registeredGroups[chatJid];
+          if (!group) continue;
+
+          const channel = findChannel(channels, chatJid);
+          if (!channel) continue;
+
+          const isMainGroup = group.folder === MAIN_GROUP_FOLDER;
+          const needsTrigger = !isMainGroup && group.requiresTrigger !== false;
+
+          // For non-main groups, only act on trigger messages.
+          // Non-trigger messages accumulate in DB and get pulled as
+          // context when a trigger eventually arrives.
+          if (needsTrigger) {
+            const hasTrigger = groupMessages.some((m) =>
+              TRIGGER_PATTERN.test(m.content.trim()),
+            );
+            if (!hasTrigger) continue;
+          }
+
+          // Intercept /model commands before they reach the agent
+          const modelCmd = groupMessages.find((m) => /^\/model\b/i.test(m.content.trim()));
+          if (modelCmd) {
+            await handleModelCommand(modelCmd.content, chatJid, channel);
+            lastAgentTimestamp[chatJid] = groupMessages[groupMessages.length - 1].timestamp;
+            saveState();
+            continue;
+          }
+
+          // Intercept /new command — start a fresh session
+          const newCmd = groupMessages.find((m) => /^\/new\s*$/i.test(m.content.trim()));
+          if (newCmd) {
+            queue.closeStdin(chatJid);
+            delete sessions[group.folder];
+            deleteSession(group.folder);
+            await channel.sendMessage(chatJid, 'Session cleared. Next message starts fresh.');
+            lastAgentTimestamp[chatJid] = groupMessages[groupMessages.length - 1].timestamp;
+            saveState();
+            logger.info({ group: group.name }, 'Session cleared via /new');
+            continue;
+          }
+
+          // Pull all messages since lastAgentTimestamp so non-trigger
+          // context that accumulated between triggers is included.
+          const allPending = getMessagesSince(
+            chatJid,
+            lastAgentTimestamp[chatJid] || '',
+            ASSISTANT_NAME,
+          );
+          const messagesToSend =
+            allPending.length > 0 ? allPending : groupMessages;
+          const formatted = formatMessages(messagesToSend);
+
+          if (queue.sendMessage(chatJid, formatted)) {
+            logger.debug(
+              { chatJid, count: messagesToSend.length },
+              'Piped messages to active container',
+            );
+            lastAgentTimestamp[chatJid] =
+              messagesToSend[messagesToSend.length - 1].timestamp;
+            saveState();
+            // Show typing indicator while the container processes the piped message
+            channel.setTyping?.(chatJid, true);
+          } else {
+            // No active container — enqueue for a new one
+            queue.enqueueMessageCheck(chatJid);
+          }
+        }
+      }
+    } catch (err) {
+      logger.error({ err }, 'Error in message loop');
+    }
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL));
+  }
+}
+
+/**
+ * Startup recovery: check for unprocessed messages in registered groups.
+ * Handles crash between advancing lastTimestamp and processing messages.
+ */
+function recoverPendingMessages(): void {
+  for (const [chatJid, group] of Object.entries(registeredGroups)) {
+    const sinceTimestamp = lastAgentTimestamp[chatJid] || '';
+    const pending = getMessagesSince(chatJid, sinceTimestamp, ASSISTANT_NAME);
+    if (pending.length > 0) {
+      logger.info(
+        { group: group.name, pendingCount: pending.length },
+        'Recovery: found unprocessed messages',
+      );
+      queue.enqueueMessageCheck(chatJid);
+    }
+  }
+}
+
+
+async function main(): Promise<void> {
+  ensureContainerRuntimeRunning();
+  cleanupOrphans();
+  initDatabase();
+  logger.info('Database initialized');
+  loadState();
+
+  // Graceful shutdown handlers
+  const shutdown = async (signal: string) => {
+    logger.info({ signal }, 'Shutdown signal received');
+    stopQmd();
+    stopClaudeCodeService();
+    await queue.shutdown(10000);
+    for (const ch of channels) await ch.disconnect();
+    process.exit(0);
+  };
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+  process.on('SIGINT', () => shutdown('SIGINT'));
+
+  // Channel callbacks (shared by all channels)
+  const channelOpts = {
+    onMessage: (_chatJid: string, msg: NewMessage) => storeMessage(msg),
+    onChatMetadata: (chatJid: string, timestamp: string, name?: string, channel?: string, isGroup?: boolean) =>
+      storeChatMetadata(chatJid, timestamp, name, channel, isGroup),
+    registeredGroups: () => registeredGroups,
+  };
+
+  // Create and connect channels
+  if (!TELEGRAM_ONLY) {
+    whatsapp = new WhatsAppChannel(channelOpts);
+    channels.push(whatsapp);
+    await whatsapp.connect();
+  }
+
+  if (TELEGRAM_BOT_TOKEN) {
+    const telegram = new TelegramChannel(TELEGRAM_BOT_TOKEN, channelOpts);
+    channels.push(telegram);
+    await telegram.connect();
+  }
+
+  // Start subsystems (independently of connection handler)
+  startSchedulerLoop({
+    registeredGroups: () => registeredGroups,
+    getSessions: () => sessions,
+    queue,
+    onProcess: (groupJid, proc, containerName, groupFolder) => queue.registerProcess(groupJid, proc, containerName, groupFolder),
+    sendMessage: async (jid, rawText) => {
+      const channel = findChannel(channels, jid);
+      if (!channel) return;
+      const text = formatOutbound(rawText);
+      if (text) await channel.sendMessage(jid, text);
+    },
+  });
+  startIpcWatcher({
+    sendMessage: (jid, text) => {
+      const channel = findChannel(channels, jid);
+      if (!channel) throw new Error(`No channel for JID: ${jid}`);
+      return channel.sendMessage(jid, text);
+    },
+    registeredGroups: () => registeredGroups,
+    registerGroup,
+    syncGroupMetadata: (force) => whatsapp ? whatsapp.syncGroupMetadata(force) : Promise.resolve(),
+    getAvailableGroups,
+    writeGroupsSnapshot: (gf, im, ag, rj) => writeGroupsSnapshot(gf, im, ag, rj),
+  });
+  queue.setProcessMessagesFn(processGroupMessages);
+  recoverPendingMessages();
+  startMessageLoop().catch((err) => {
+    logger.fatal({ err }, 'Message loop crashed unexpectedly');
+    process.exit(1);
+  });
+
+  // Start QMD memory search (replaces old Gemini-based memory indexer)
+  const groupFolders = Object.values(registeredGroups).map((g) => g.folder);
+  startQmd(groupFolders).catch((err) => {
+    logger.error({ err }, 'Failed to start QMD');
+  });
+
+  // Start Claude Code service (host HTTP daemon for container agents)
+  startClaudeCodeService().catch((err) => {
+    logger.error({ err }, 'Failed to start Claude Code service');
+  });
+}
+
+// Guard: only run when executed directly, not when imported by tests
+const isDirectRun =
+  process.argv[1] &&
+  new URL(import.meta.url).pathname === new URL(`file://${process.argv[1]}`).pathname;
+
+if (isDirectRun) {
+  main().catch((err) => {
+    logger.error({ err }, 'Failed to start NanoClaw');
+    process.exit(1);
+  });
+}

--- a/.claude/skills/add-claude-code/modify/src/index.ts.intent.md
+++ b/.claude/skills/add-claude-code/modify/src/index.ts.intent.md
@@ -1,0 +1,31 @@
+# Intent: src/index.ts modifications
+
+## What changed
+Added Claude Code service lifecycle management (start on boot, stop on shutdown).
+
+## Key sections
+
+### Imports (top of file)
+- Added: `startClaudeCodeService`, `stopClaudeCodeService` from `./claude-code-service.js`
+
+### shutdown() handler
+- Added: `stopClaudeCodeService()` call alongside `stopQmd()`
+
+### main() — end of function
+- Added: `startClaudeCodeService().catch(...)` after the QMD startup block
+- Pattern mirrors QMD startup: fire-and-forget with error logging (non-blocking)
+
+## Invariants
+- All existing message processing logic is preserved (triggers, cursors, idle timers)
+- The `runAgent` function is completely unchanged
+- State management (loadState/saveState) is unchanged
+- Recovery logic is unchanged
+- Container runtime check is unchanged
+- Channel creation and connection logic is unchanged
+- QMD startup is unchanged
+
+## Must-keep
+- The `escapeXml` and `formatMessages` re-exports
+- The `_setRegisteredGroups` test helper
+- The `isDirectRun` guard at bottom
+- All error handling and cursor rollback logic in processGroupMessages


### PR DESCRIPTION
## Summary

- Adds `/add-claude-code` skill that connects container agents to Claude Code CLI running on the host machine
- Main group only — delegates file editing, debugging, and development work to a host-side Claude Code instance
- Follows the same architecture pattern as QMD memory search: HTTP daemon on host (port 8282) + stdio-to-HTTP MCP proxy in the container

## What's included

8 skill template files under `.claude/skills/add-claude-code/`:
- `manifest.yaml` — skill metadata
- `SKILL.md` — conversation script (pre-flight, apply, configure, verify phases)
- `add/src/claude-code-service.ts` — host HTTP daemon that spawns `claude -p`
- `add/container/agent-runner/src/claude-code-proxy.ts` — container MCP proxy (stdio-to-HTTP bridge)
- `modify/src/index.ts` + intent — lifecycle integration (start/stop service)
- `modify/container/agent-runner/src/index.ts` + intent — conditional MCP server registration (main group only)

## Key design decisions

- **spawn with `stdio: ['ignore']`** instead of `execFile` — prevents CLI hanging in non-TTY contexts (launchd/systemd)
- **Auth from `.env`** via `readEnvFile()` — supports ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, or CLI's own auth (Claude Max Plan)
- **CWD allowlist** — security boundary preventing agents from accessing arbitrary directories
- **Concurrency limit** — one active invocation at a time

## Test plan

- [x] Health check: `curl http://localhost:8282/health` returns OK
- [x] Direct invocation: POST to `/invoke` returns correct result in ~2.5s
- [x] CWD rejection: requests outside allowlist are blocked
- [x] End-to-end via Telegram: agent calls `mcp__claude-code__code` and returns results
- [x] Read-only codebase scan: Claude Code reads directory structure and describes project

🤖 Generated with [Claude Code](https://claude.com/claude-code)