### PR TITLE
fix(security): replace shell exec with execFile for container stop commands

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -2,7 +2,7 @@
  * Container Runner for NanoClaw
  * Spawns agent execution in containers and handles IPC
  */
-import { ChildProcess, exec, spawn } from 'child_process';
+import { ChildProcess, execFile, spawn } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 
@@ -18,7 +18,7 @@ import {
 import { readEnvFile } from './env.js';
 import { resolveGroupFolderPath, resolveGroupIpcPath } from './group-folder.js';
 import { logger } from './logger.js';
-import { CONTAINER_RUNTIME_BIN, readonlyMountArgs, stopContainer } from './container-runtime.js';
+import { CONTAINER_RUNTIME_BIN, readonlyMountArgs, stopContainerArgs } from './container-runtime.js';
 import { validateAdditionalMounts } from './mount-security.js';
 import { RegisteredGroup } from './types.js';
 
@@ -365,7 +365,8 @@ export async function runContainerAgent(
     const killOnTimeout = () => {
       timedOut = true;
       logger.error({ group: group.name, containerName }, 'Container timeout, stopping gracefully');
-      exec(stopContainer(containerName), { timeout: 15000 }, (err) => {
+      const [bin, args] = stopContainerArgs(containerName);
+      execFile(bin, args, { timeout: 15000 }, (err) => {
         if (err) {
           logger.warn({ group: group.name, containerName, err }, 'Graceful stop failed, force killing');
           container.kill('SIGKILL');

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -2,7 +2,7 @@
  * Container runtime abstraction for NanoClaw.
  * All runtime-specific logic lives here so swapping runtimes means changing one file.
  */
-import { execSync } from 'child_process';
+import { execFileSync, execSync } from 'child_process';
 
 import { logger } from './logger.js';
 
@@ -14,9 +14,9 @@ export function readonlyMountArgs(hostPath: string, containerPath: string): stri
   return ['-v', `${hostPath}:${containerPath}:ro`];
 }
 
-/** Returns the shell command to stop a container by name. */
-export function stopContainer(name: string): string {
-  return `${CONTAINER_RUNTIME_BIN} stop ${name}`;
+/** Returns the arguments to stop a container by name (no shell interpolation). */
+export function stopContainerArgs(name: string): [string, string[]] {
+  return [CONTAINER_RUNTIME_BIN, ['stop', name]];
 }
 
 /** Ensure the container runtime is running, starting it if needed. */
@@ -64,7 +64,8 @@ export function cleanupOrphans(): void {
     const orphans = output.trim().split('\n').filter(Boolean);
     for (const name of orphans) {
       try {
-        execSync(stopContainer(name), { stdio: 'pipe' });
+        const [bin, args] = stopContainerArgs(name);
+        execFileSync(bin, args, { stdio: 'pipe' });
       } catch { /* already stopped */ }
     }
     if (orphans.length > 0) {


### PR DESCRIPTION
## Summary

- Replace string-interpolated `exec()`/`execSync()` with `execFile()`/`execFileSync()` for all container stop operations, eliminating shell interpretation of container names
- Rename `stopContainer()` to `stopContainerArgs()` returning a `[bin, args]` tuple instead of a shell command string
- Update all call sites and tests

## Motivation

`stopContainer()` returned a shell command string like `` `docker stop ${name}` `` which was passed to `exec()`. While container names are currently sanitized by `isValidGroupFolder()`, the `stopContainer()` function itself performed no validation. If any future code path called it with unsanitized input, it would be a command injection vector (CWE-78).

Using `execFile()` invokes the binary directly without a shell, making the function safe regardless of its caller.

## Changes

| File | Change |
|------|--------|
| `src/container-runtime.ts` | `stopContainer()` → `stopContainerArgs()` returning `[bin, args]` tuple; `cleanupOrphans()` uses `execFileSync` |
| `src/container-runner.ts` | Import `execFile` instead of `exec`; timeout handler uses `execFile` with args array |
| `src/container-runtime.test.ts` | Tests verify `execFileSync` called with separate binary + args (no shell) |

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 380/380 tests pass (including 8 in `container-runtime.test.ts`)

Closes #457