### PR TITLE
Fix QR data handling in WhatsApp auth

### DIFF
--- a/setup/whatsapp-auth.ts
+++ b/setup/whatsapp-auth.ts
@@ -210,7 +210,7 @@ async function handleQrBrowser(
   const qrData = fs.readFileSync(qrFile, 'utf-8');
   try {
     const svg = execSync(
-      `node -e "const QR=require('qrcode');const data=${JSON.stringify(qrData)};QR.toString(data,{type:'svg'},(e,s)=>{if(e)process.exit(1);process.stdout.write(s)})"`,
+      `node -e "const QR=require('qrcode');const data='${qrData}';QR.toString(data,{type:'svg'},(e,s)=>{if(e)process.exit(1);process.stdout.write(s)})"`,
       { cwd: projectRoot, encoding: 'utf-8' },
     );
     const html = QR_AUTH_TEMPLATE.replace('{{QR_SVG}}', svg);


### PR DESCRIPTION
Running WhatsApp setup fails because the string interpolation of `qrData` does not inject quotes.

## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description
Running WhatsApp setup is failing because the string interpolation is not working with `${JSON.stringify(qrData)}`. Prior to this fix, the output would look like `const QR=require('qrcode');const data=abc.123;zyx.456;QR.toString...`.