### PR TITLE
fix: gracefully stop Docker containers on shutdown

### DIFF
--- a/nanoclaw.service.new
+++ b/nanoclaw.service.new
@@ -1,0 +1,28 @@
+[Unit]
+Description=NanoClaw WhatsApp Assistant
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=tiger
+Group=tiger
+SupplementaryGroups=docker
+WorkingDirectory=/home/tiger/nanoclaw
+ExecStart=/home/tiger/.nvm/versions/node/v24.13.0/bin/node /home/tiger/nanoclaw/dist/index.js
+Restart=always
+RestartSec=10
+Environment=PATH=/usr/local/bin:/usr/bin:/bin:/home/tiger/.nvm/versions/node/v24.13.0/bin:/home/tiger/.local/bin
+Environment=HOME=/home/tiger
+Environment=NODE_ENV=production
+EnvironmentFile=/home/tiger/nanoclaw/.env
+
+# Graceful shutdown: give containers 30s to stop before SIGKILL
+TimeoutStopSec=30
+KillMode=mixed
+
+StandardOutput=append:/home/tiger/nanoclaw/logs/nanoclaw.log
+StandardError=append:/home/tiger/nanoclaw/logs/nanoclaw.error.log
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
Fixes the issue where systemd times out (90s) and force-kills Docker containers during service shutdown.

## Changes
- Extract container cleanup logic into dedicated `cleanupOrphanedContainers()`
- Call `cleanupOrphanedContainers()` in shutdown handler before exit
- Add 15s timeout to `container stop` command
- Update systemd service with `TimeoutStopSec=30` and `KillMode=mixed`

## Testing
This ensures containers stop gracefully within 30s instead of being force-killed after 90s timeout.

## Problem
From systemd logs, the service was repeatedly failing with:
```
nanoclaw.service: State 'stop-final-sigterm' timed out. Killing.
nanoclaw.service: Killing process XXX (docker) with signal SIGKILL.
nanoclaw.service: Failed with result 'timeout'.
```

This happened because the shutdown handler only closed the WhatsApp connection and queue, but didn't stop running Docker containers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)