### PR TITLE
feat: add X (Twitter) reading capabilities via X API v2

### DIFF
--- a/.claude/skills/add-x-reader/SKILL.md
+++ b/.claude/skills/add-x-reader/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: add-x-reader
+description: Add X (Twitter) reading capabilities — search tweets by topic and get posts from specific accounts via the X API. Triggers on "add x reader", "x reader", "read tweets", "search x", "x search".
+---
+
+# Add X Reader
+
+Add the ability to search tweets by topic and retrieve posts from specific X (Twitter) accounts using the X API v2.
+
+## Prerequisites
+
+- Existing NanoClaw installation
+- X Developer account with API access (Basic plan or pay-per-use)
+- X API Bearer Token
+
+## What This Adds
+
+Two new MCP tools available to the agent:
+
+| Tool | Purpose |
+|------|---------|
+| `x_search` | Search recent tweets (last 7 days) by keyword/topic |
+| `x_user_posts` | Get recent tweets from a specific @username |
+
+Results are returned as formatted text. The agent can save them to files for future reference.
+
+## Setup Steps
+
+### 1. Get X API Bearer Token
+
+1. Go to https://developer.x.com/en/portal/dashboard
+2. Create a project and app (or use existing)
+3. Generate a Bearer Token (App-only access)
+4. Copy the token
+
+### 2. Add Bearer Token to `.env`
+
+```bash
+echo 'X_BEARER_TOKEN=your_bearer_token_here' >> .env
+```
+
+### 3. Apply Code Changes
+
+The following files need to be modified. Apply each change:
+
+#### 3a. Add API scripts
+
+Create these files (they already exist in this skill directory):
+
+- Copy `scripts/lib/api.ts` to `.claude/skills/add-x-reader/scripts/lib/api.ts`
+- Copy `scripts/search-tweets.ts` to `.claude/skills/add-x-reader/scripts/search-tweets.ts`
+- Copy `scripts/user-timeline.ts` to `.claude/skills/add-x-reader/scripts/user-timeline.ts`
+
+#### 3b. Modify `src/x-handler.ts`
+
+Add two new cases to the switch statement in `handleXIpc()`:
+
+```typescript
+case 'x_search':
+  if (!data.query) {
+    result = { success: false, message: 'Missing query' };
+    break;
+  }
+  result = await runXApiScript('search-tweets', {
+    query: data.query,
+    maxResults: data.maxResults || 10,
+  });
+  break;
+
+case 'x_user_timeline':
+  if (!data.username) {
+    result = { success: false, message: 'Missing username' };
+    break;
+  }
+  result = await runXApiScript('user-timeline', {
+    username: data.username,
+    maxResults: data.maxResults || 10,
+  });
+  break;
+```
+
+Also add the `runXApiScript()` helper that reads `X_BEARER_TOKEN` from `.env` and passes it to the script.
+
+#### 3c. Modify `container/agent-runner/src/ipc-mcp-stdio.ts`
+
+Add two new MCP tool definitions after the existing X tools:
+
+- `x_search` — takes `query` (string) and optional `max_results` (number, default 10, max 100)
+- `x_user_posts` — takes `username` (string) and optional `max_results` (number, default 10, max 100)
+
+Both use the same IPC pattern: write to tasks dir, poll for result via `waitForXResult()`.
+
+#### 3d. Update `groups/main/CLAUDE.md`
+
+Add the new tools to the X Integration section:
+
+```
+- `mcp__nanoclaw__x_search` — Search recent tweets. Parameters: `query` (string), `max_results` (number, optional)
+- `mcp__nanoclaw__x_user_posts` — Get posts from a user. Parameters: `username` (string), `max_results` (number, optional)
+```
+
+#### 3e. Update `.env.example`
+
+Add:
+```
+X_BEARER_TOKEN=
+```
+
+### 4. Rebuild Container
+
+```bash
+./container/build.sh
+```
+
+### 5. Verify
+
+Restart NanoClaw and test:
+```
+@Andy search X for recent posts about "AI safety"
+@Andy get the latest posts from @elaborateclaw
+```
+
+## API Limits
+
+- **Search:** 450 requests per 15 minutes (app-only auth)
+- **User timeline:** 1,500 requests per 15 minutes
+- **Search range:** Last 7 days only (Basic/pay-per-use tier)
+- **Results per request:** Max 100
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| 401 Unauthorized | Check X_BEARER_TOKEN in .env |
+| 403 Forbidden | Your API plan may not include this endpoint |
+| 429 Rate Limited | Wait 15 minutes, reduce request frequency |
+| Empty results | Try broader search terms, check spelling |

--- a/.claude/skills/add-x-reader/scripts/lib/api.ts
+++ b/.claude/skills/add-x-reader/scripts/lib/api.ts
@@ -1,0 +1,165 @@
+/**
+ * X API v2 - Shared utilities for reading tweets
+ */
+
+const X_API_BASE = 'https://api.x.com/2';
+
+/** Fields to request for each tweet */
+const TWEET_FIELDS = 'created_at,public_metrics,author_id,entities';
+const USER_FIELDS = 'name,username,public_metrics';
+const EXPANSIONS = 'author_id';
+
+export interface ScriptResult {
+  success: boolean;
+  message: string;
+  data?: unknown;
+}
+
+export interface Tweet {
+  id: string;
+  text: string;
+  created_at?: string;
+  author_id?: string;
+  public_metrics?: {
+    retweet_count: number;
+    reply_count: number;
+    like_count: number;
+    quote_count: number;
+    impression_count: number;
+  };
+}
+
+export interface User {
+  id: string;
+  name: string;
+  username: string;
+  public_metrics?: {
+    followers_count: number;
+    following_count: number;
+    tweet_count: number;
+  };
+}
+
+export interface SearchResponse {
+  data?: Tweet[];
+  includes?: { users?: User[] };
+  meta?: { result_count: number; next_token?: string };
+}
+
+export interface UserLookupResponse {
+  data?: { id: string; name: string; username: string };
+  errors?: Array<{ title: string; detail: string }>;
+}
+
+export interface TimelineResponse {
+  data?: Tweet[];
+  meta?: { result_count: number; next_token?: string };
+}
+
+/**
+ * Read input from stdin
+ */
+export async function readInput<T>(): Promise<T> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk: string) => { data += chunk; });
+    process.stdin.on('end', () => {
+      try {
+        resolve(JSON.parse(data));
+      } catch (err) {
+        reject(new Error(`Invalid JSON input: ${err}`));
+      }
+    });
+    process.stdin.on('error', reject);
+  });
+}
+
+/**
+ * Write result to stdout (last line is parsed by host)
+ */
+export function writeResult(result: ScriptResult): void {
+  console.log(JSON.stringify(result));
+}
+
+/**
+ * Make an authenticated GET request to the X API v2
+ */
+export async function xApiGet<T>(endpoint: string, params: Record<string, string>, bearerToken: string): Promise<T> {
+  const url = new URL(`${X_API_BASE}${endpoint}`);
+  for (const [key, value] of Object.entries(params)) {
+    if (value) url.searchParams.set(key, value);
+  }
+
+  const response = await fetch(url.toString(), {
+    headers: {
+      'Authorization': `Bearer ${bearerToken}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`X API error ${response.status}: ${body}`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+/**
+ * Format a tweet for display
+ */
+export function formatTweet(tweet: Tweet, author?: User): string {
+  const parts: string[] = [];
+
+  const name = author ? `@${author.username} (${author.name})` : `user:${tweet.author_id}`;
+  parts.push(`${name}`);
+
+  if (tweet.created_at) {
+    parts.push(`  ${new Date(tweet.created_at).toLocaleString()}`);
+  }
+
+  parts.push(`  ${tweet.text}`);
+
+  if (tweet.public_metrics) {
+    const m = tweet.public_metrics;
+    const metrics = [];
+    if (m.like_count > 0) metrics.push(`${m.like_count} likes`);
+    if (m.retweet_count > 0) metrics.push(`${m.retweet_count} retweets`);
+    if (m.reply_count > 0) metrics.push(`${m.reply_count} replies`);
+    if (m.quote_count > 0) metrics.push(`${m.quote_count} quotes`);
+    if (metrics.length > 0) parts.push(`  [${metrics.join(', ')}]`);
+  }
+
+  parts.push(`  https://x.com/i/status/${tweet.id}`);
+
+  return parts.join('\n');
+}
+
+/**
+ * Format a list of tweets with author resolution
+ */
+export function formatTweets(tweets: Tweet[], users?: User[]): string {
+  const userMap = new Map<string, User>();
+  if (users) {
+    for (const user of users) {
+      userMap.set(user.id, user);
+    }
+  }
+
+  return tweets
+    .map(tweet => formatTweet(tweet, tweet.author_id ? userMap.get(tweet.author_id) : undefined))
+    .join('\n\n---\n\n');
+}
+
+/**
+ * Common tweet fields query params
+ */
+export function tweetQueryParams(maxResults: number): Record<string, string> {
+  return {
+    'tweet.fields': TWEET_FIELDS,
+    'user.fields': USER_FIELDS,
+    'expansions': EXPANSIONS,
+    'max_results': String(Math.min(Math.max(maxResults, 10), 100)),
+  };
+}

--- a/.claude/skills/add-x-reader/scripts/search-tweets.ts
+++ b/.claude/skills/add-x-reader/scripts/search-tweets.ts
@@ -1,0 +1,74 @@
+/**
+ * X API v2 - Search recent tweets by query
+ *
+ * Input (stdin JSON): { query: string, maxResults?: number, bearerToken: string }
+ * Output (stdout JSON): { success: boolean, message: string, data?: object }
+ */
+
+import {
+  readInput,
+  writeResult,
+  xApiGet,
+  formatTweets,
+  tweetQueryParams,
+  type SearchResponse,
+} from './lib/api.js';
+
+interface Input {
+  query: string;
+  maxResults?: number;
+  bearerToken: string;
+}
+
+async function main() {
+  try {
+    const input = await readInput<Input>();
+
+    if (!input.bearerToken) {
+      writeResult({ success: false, message: 'Missing X_BEARER_TOKEN. Add it to your .env file.' });
+      return;
+    }
+
+    if (!input.query) {
+      writeResult({ success: false, message: 'Missing search query.' });
+      return;
+    }
+
+    const maxResults = input.maxResults || 10;
+    const params = {
+      query: input.query,
+      ...tweetQueryParams(maxResults),
+    };
+
+    const response = await xApiGet<SearchResponse>('/tweets/search/recent', params, input.bearerToken);
+
+    if (!response.data || response.data.length === 0) {
+      writeResult({
+        success: true,
+        message: `No tweets found for query: "${input.query}"`,
+        data: { resultCount: 0 },
+      });
+      return;
+    }
+
+    const formatted = formatTweets(response.data, response.includes?.users);
+    const count = response.meta?.result_count || response.data.length;
+
+    writeResult({
+      success: true,
+      message: `Found ${count} tweets for "${input.query}":\n\n${formatted}`,
+      data: {
+        resultCount: count,
+        tweets: response.data,
+        users: response.includes?.users,
+      },
+    });
+  } catch (err) {
+    writeResult({
+      success: false,
+      message: `Search failed: ${err instanceof Error ? err.message : String(err)}`,
+    });
+  }
+}
+
+main();

--- a/.claude/skills/add-x-reader/scripts/user-timeline.ts
+++ b/.claude/skills/add-x-reader/scripts/user-timeline.ts
@@ -1,0 +1,103 @@
+/**
+ * X API v2 - Get recent tweets from a specific user
+ *
+ * Input (stdin JSON): { username: string, maxResults?: number, bearerToken: string }
+ * Output (stdout JSON): { success: boolean, message: string, data?: object }
+ *
+ * Two-step process:
+ * 1. Resolve @username to numeric user ID
+ * 2. Fetch user's recent tweets
+ */
+
+import {
+  readInput,
+  writeResult,
+  xApiGet,
+  formatTweets,
+  tweetQueryParams,
+  type UserLookupResponse,
+  type TimelineResponse,
+} from './lib/api.js';
+
+interface Input {
+  username: string;
+  maxResults?: number;
+  bearerToken: string;
+}
+
+async function main() {
+  try {
+    const input = await readInput<Input>();
+
+    if (!input.bearerToken) {
+      writeResult({ success: false, message: 'Missing X_BEARER_TOKEN. Add it to your .env file.' });
+      return;
+    }
+
+    if (!input.username) {
+      writeResult({ success: false, message: 'Missing username.' });
+      return;
+    }
+
+    // Strip leading @ if present
+    const username = input.username.replace(/^@/, '');
+
+    // Step 1: Resolve username to user ID
+    const userResponse = await xApiGet<UserLookupResponse>(
+      `/users/by/username/${encodeURIComponent(username)}`,
+      { 'user.fields': 'name,username,public_metrics' },
+      input.bearerToken,
+    );
+
+    if (!userResponse.data) {
+      const errorDetail = userResponse.errors?.[0]?.detail || 'User not found';
+      writeResult({ success: false, message: `Could not find user @${username}: ${errorDetail}` });
+      return;
+    }
+
+    const userId = userResponse.data.id;
+    const displayName = userResponse.data.name;
+
+    // Step 2: Fetch user's recent tweets
+    const maxResults = input.maxResults || 10;
+    const timelineResponse = await xApiGet<TimelineResponse>(
+      `/users/${userId}/tweets`,
+      tweetQueryParams(maxResults),
+      input.bearerToken,
+    );
+
+    if (!timelineResponse.data || timelineResponse.data.length === 0) {
+      writeResult({
+        success: true,
+        message: `No recent tweets found from @${username} (${displayName}).`,
+        data: { resultCount: 0, user: userResponse.data },
+      });
+      return;
+    }
+
+    // Add author info to each tweet for formatting
+    const user = { id: userId, name: displayName, username };
+    const formatted = formatTweets(
+      timelineResponse.data,
+      [user],
+    );
+    const count = timelineResponse.meta?.result_count || timelineResponse.data.length;
+
+    writeResult({
+      success: true,
+      message: `${count} recent tweets from @${username} (${displayName}):\n\n${formatted}`,
+      data: {
+        resultCount: count,
+        user: userResponse.data,
+        tweets: timelineResponse.data,
+      },
+    });
+  } catch (err) {
+    writeResult({
+      success: false,
+      message: `Failed to get timeline: ${err instanceof Error ? err.message : String(err)}`,
+    });
+  }
+}
+
+main();

--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,9 @@
 
+
+# Added by skill
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_ONLY=
+
+# X (Twitter) API - for reading tweets (search, user timelines)
+# Get from: https://developer.x.com/en/portal/dashboard
+X_BEARER_TOKEN=

--- a/src/x-handler.ts
+++ b/src/x-handler.ts
@@ -1,0 +1,205 @@
+/**
+ * X Integration IPC Handler
+ *
+ * Handles all x_* IPC messages from container agents.
+ * Spawns browser automation scripts on the host.
+ */
+
+import { spawn } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+import { logger } from './logger.js';
+import { readEnvFile } from './env.js';
+
+interface SkillResult {
+  success: boolean;
+  message: string;
+  data?: unknown;
+}
+
+// Run a skill script as subprocess
+async function runScript(scriptPath: string, args: object): Promise<SkillResult> {
+
+  return new Promise((resolve) => {
+    const npxPath = process.env.NPX_PATH || '/opt/homebrew/bin/npx';
+    // Ensure PATH includes Homebrew bin for node/npx (launchd has limited PATH)
+    const scriptEnv = {
+      ...process.env,
+      NANOCLAW_ROOT: process.cwd(),
+      PATH: `/opt/homebrew/bin:${process.env.PATH || '/usr/local/bin:/usr/bin:/bin'}`,
+    };
+    const proc = spawn(npxPath, ['tsx', scriptPath], {
+      cwd: process.cwd(),
+      env: scriptEnv,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    proc.stdout.on('data', (data) => { stdout += data.toString(); });
+    proc.stdin.write(JSON.stringify(args));
+    proc.stdin.end();
+
+    const timer = setTimeout(() => {
+      proc.kill('SIGTERM');
+      resolve({ success: false, message: 'Script timed out (120s)' });
+    }, 120000);
+
+    proc.on('close', (code) => {
+      clearTimeout(timer);
+      if (code !== 0) {
+        resolve({ success: false, message: `Script exited with code: ${code}` });
+        return;
+      }
+      try {
+        const lines = stdout.trim().split('\n');
+        resolve(JSON.parse(lines[lines.length - 1]));
+      } catch {
+        resolve({ success: false, message: `Failed to parse output: ${stdout.slice(0, 200)}` });
+      }
+    });
+
+    proc.on('error', (err) => {
+      clearTimeout(timer);
+      resolve({ success: false, message: `Failed to spawn: ${err.message}` });
+    });
+  });
+}
+
+// Resolve a skill script path
+function skillScriptPath(skill: string, script: string): string {
+  return path.join(process.cwd(), '.claude', 'skills', skill, 'scripts', `${script}.ts`);
+}
+
+// Run an X API script (uses bearer token, not browser automation)
+async function runXApiScript(script: string, args: object): Promise<SkillResult> {
+  const envConfig = readEnvFile(['X_BEARER_TOKEN']);
+  const bearerToken = process.env.X_BEARER_TOKEN || envConfig.X_BEARER_TOKEN;
+  if (!bearerToken) {
+    return { success: false, message: 'X_BEARER_TOKEN not configured. Add it to your .env file.' };
+  }
+
+  const scriptPath = skillScriptPath('add-x-reader', script);
+  if (!fs.existsSync(scriptPath)) {
+    return { success: false, message: `X reader script not found: ${script}. Run /add-x-reader to install.` };
+  }
+
+  return runScript(scriptPath, { ...args, bearerToken });
+}
+
+// Write result to IPC results directory
+function writeResult(dataDir: string, sourceGroup: string, requestId: string, result: SkillResult): void {
+  const resultsDir = path.join(dataDir, 'ipc', sourceGroup, 'x_results');
+  fs.mkdirSync(resultsDir, { recursive: true });
+  fs.writeFileSync(path.join(resultsDir, `${requestId}.json`), JSON.stringify(result));
+}
+
+/**
+ * Handle X integration IPC messages
+ *
+ * @returns true if message was handled, false if not an X message
+ */
+export async function handleXIpc(
+  data: Record<string, unknown>,
+  sourceGroup: string,
+  isMain: boolean,
+  dataDir: string,
+): Promise<boolean> {
+  const type = data.type as string;
+
+  // Only handle x_* types
+  if (!type?.startsWith('x_')) {
+    return false;
+  }
+
+  // Only main group can use X integration
+  if (!isMain) {
+    logger.warn({ sourceGroup, type }, 'X integration blocked: not main group');
+    return true;
+  }
+
+  const requestId = data.requestId as string;
+  if (!requestId) {
+    logger.warn({ type }, 'X integration blocked: missing requestId');
+    return true;
+  }
+
+  logger.info({ type, requestId }, 'Processing X request');
+
+  let result: SkillResult;
+
+  switch (type) {
+    case 'x_post':
+      if (!data.content) {
+        result = { success: false, message: 'Missing content' };
+        break;
+      }
+      result = await runScript(skillScriptPath('x-integration', 'post'), { content: data.content });
+      break;
+
+    case 'x_like':
+      if (!data.tweetUrl) {
+        result = { success: false, message: 'Missing tweetUrl' };
+        break;
+      }
+      result = await runScript(skillScriptPath('x-integration', 'like'), { tweetUrl: data.tweetUrl });
+      break;
+
+    case 'x_reply':
+      if (!data.tweetUrl || !data.content) {
+        result = { success: false, message: 'Missing tweetUrl or content' };
+        break;
+      }
+      result = await runScript(skillScriptPath('x-integration', 'reply'), { tweetUrl: data.tweetUrl, content: data.content });
+      break;
+
+    case 'x_retweet':
+      if (!data.tweetUrl) {
+        result = { success: false, message: 'Missing tweetUrl' };
+        break;
+      }
+      result = await runScript(skillScriptPath('x-integration', 'retweet'), { tweetUrl: data.tweetUrl });
+      break;
+
+    case 'x_quote':
+      if (!data.tweetUrl || !data.comment) {
+        result = { success: false, message: 'Missing tweetUrl or comment' };
+        break;
+      }
+      result = await runScript(skillScriptPath('x-integration', 'quote'), { tweetUrl: data.tweetUrl, comment: data.comment });
+      break;
+
+    case 'x_search':
+      if (!data.query) {
+        result = { success: false, message: 'Missing query' };
+        break;
+      }
+      result = await runXApiScript('search-tweets', {
+        query: data.query,
+        maxResults: data.maxResults || 10,
+      });
+      break;
+
+    case 'x_user_timeline':
+      if (!data.username) {
+        result = { success: false, message: 'Missing username' };
+        break;
+      }
+      result = await runXApiScript('user-timeline', {
+        username: data.username,
+        maxResults: data.maxResults || 10,
+      });
+      break;
+
+    default:
+      return false;
+  }
+
+  writeResult(dataDir, sourceGroup, requestId, result);
+  if (result.success) {
+    logger.info({ type, requestId }, 'X request completed');
+  } else {
+    logger.error({ type, requestId, message: result.message }, 'X request failed');
+  }
+  return true;
+}


### PR DESCRIPTION
Add /add-x-reader skill with search and user timeline tools. Uses bearer token auth (App-Only) for read-only API access.

New MCP tools:
- x_search: search recent tweets by keyword/topic
- x_user_posts: get recent posts from a specific @username

Also includes X write tools (post, like, reply, retweet, quote) via browser automation IPC, and host-side x-handler for all X integration message routing.

## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description


## For Skills

- [ ] I have not made any changes to source code
- [ ] My skill contains instructions for Claude to follow (not pre-built code)
- [ ] I tested this skill on a fresh clone
