### PR TITLE
feat(skills): add /add-slack skill for Slack channel integration

### DIFF
--- a/.claude/skills/add-slack/SKILL.md
+++ b/.claude/skills/add-slack/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: add-slack
+description: Add Slack as a channel using @slack/bolt with Socket Mode. Can replace WhatsApp entirely or run alongside it.
+---
+
+# Add Slack Channel
+
+This skill adds Slack support to NanoClaw using the skills engine for deterministic code changes, then walks through interactive setup.
+
+## Phase 1: Pre-flight
+
+### Check if already applied
+
+Read `.nanoclaw/state.yaml`. If `slack` is in `applied_skills`, skip to Phase 3 (Setup). The code changes are already in place.
+
+### Ask the user
+
+Use `AskUserQuestion` to collect configuration:
+
+AskUserQuestion: Should Slack replace WhatsApp or run alongside it?
+- **Replace WhatsApp** - Slack will be the only channel (sets SLACK_ONLY=true)
+- **Alongside** - Both Slack and WhatsApp channels active
+
+AskUserQuestion: Do you have a Slack app with Socket Mode tokens, or do you need to create one?
+
+If they have tokens, collect them now. If not, we'll create the app in Phase 3.
+
+## Phase 2: Apply Code Changes
+
+Run the skills engine to apply this skill's code package. The package files are in this directory alongside this SKILL.md.
+
+### Initialize skills system (if needed)
+
+If `.nanoclaw/` directory doesn't exist yet:
+
+```bash
+npx tsx scripts/apply-skill.ts --init
+```
+
+Or call `initSkillsSystem()` from `skills-engine/migrate.ts`.
+
+### Apply the skill
+
+```bash
+npx tsx scripts/apply-skill.ts .claude/skills/add-slack
+```
+
+This deterministically:
+- Adds `src/channels/slack.ts` (SlackChannel class implementing Channel interface)
+- Adds `src/channels/slack.test.ts` (unit tests)
+- Three-way merges Slack support into `src/index.ts` (multi-channel support)
+- Three-way merges Slack config into `src/config.ts` (SLACK_BOT_TOKEN, SLACK_APP_TOKEN, SLACK_ONLY exports)
+- Three-way merges updated routing tests into `src/routing.test.ts`
+- Installs the `@slack/bolt` npm dependency
+- Updates `.env.example` with `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, and `SLACK_ONLY`
+- Records the application in `.nanoclaw/state.yaml`
+
+If the apply reports merge conflicts, read the intent files:
+- `modify/src/index.ts.intent.md` — what changed and invariants for index.ts
+- `modify/src/config.ts.intent.md` — what changed for config.ts
+
+### Validate code changes
+
+```bash
+npm test
+npm run build
+```
+
+All tests must pass (including the new slack tests) and build must be clean before proceeding.
+
+## Phase 3: Setup
+
+### Create Slack App (if needed)
+
+If the user doesn't have tokens, tell them:
+
+> I need you to create a Slack app with Socket Mode:
+>
+> 1. Go to https://api.slack.com/apps and click **Create New App**
+> 2. Choose **From scratch**, name it (e.g., "Andy Assistant"), and select your workspace
+>
+> **Enable Socket Mode:**
+> 3. Go to **Socket Mode** in the left sidebar
+> 4. Toggle **Enable Socket Mode** ON
+> 5. Create an app-level token with `connections:write` scope — name it "socket-token"
+> 6. **Copy the `xapp-` token** — this is your `SLACK_APP_TOKEN`
+>
+> **Add Bot Token Scopes:**
+> 7. Go to **OAuth & Permissions** in the left sidebar
+> 8. Under **Bot Token Scopes**, add:
+>    - `chat:write` — send messages
+>    - `channels:history` — read channel messages
+>    - `groups:history` — read private channel messages
+>    - `im:history` — read DM messages
+>    - `mpim:history` — read group DM messages
+>    - `users:read` — get user display names
+>    - `channels:read` — get channel info
+>    - `files:read` — read file metadata
+>
+> **Install the App:**
+> 9. Go to **Install App** in the left sidebar
+> 10. Click **Install to Workspace** and authorize
+> 11. **Copy the `xoxb-` Bot User OAuth Token** — this is your `SLACK_BOT_TOKEN`
+>
+> **Subscribe to Events:**
+> 12. Go to **Event Subscriptions** in the left sidebar
+> 13. Toggle **Enable Events** ON
+> 14. Under **Subscribe to bot events**, add:
+>     - `message.channels` — messages in public channels
+>     - `message.groups` — messages in private channels
+>     - `message.im` — direct messages
+>     - `message.mpim` — group direct messages
+>     - `app_mention` — when someone @mentions the bot
+>     - `file_shared` — when files are shared
+> 15. Click **Save Changes**
+
+Wait for the user to provide both tokens.
+
+### Configure environment
+
+Add to `.env`:
+
+```bash
+SLACK_BOT_TOKEN=xoxb-your-bot-token
+SLACK_APP_TOKEN=xapp-your-app-token
+```
+
+If they chose to replace WhatsApp:
+
+```bash
+SLACK_ONLY=true
+```
+
+Sync to container environment:
+
+```bash
+mkdir -p data/env && cp .env data/env/env
+```
+
+The container reads environment from `data/env/env`, not `.env` directly.
+
+### Build and restart
+
+```bash
+npm run build
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw  # macOS
+# Linux: systemctl --user restart nanoclaw
+```
+
+## Phase 4: Registration
+
+### Get Channel ID
+
+Tell the user:
+
+> To get a Slack channel ID:
+>
+> 1. Open Slack and go to the channel you want to register
+> 2. Right-click the channel name and select **View channel details** (or click the channel name at the top)
+> 3. Scroll to the bottom of the **About** tab — you'll see **Channel ID** (e.g., `C1234567890`)
+>
+> The JID format for registration is: `slack:C1234567890`
+
+Wait for the user to provide the channel ID.
+
+### Register the channel
+
+Use the IPC register flow or register directly. The channel ID, name, and folder name are needed.
+
+For a main channel (responds to all messages, uses the `main` folder):
+
+```typescript
+registerGroup("slack:<channel-id>", {
+  name: "<channel-name>",
+  folder: "main",
+  trigger: `@${ASSISTANT_NAME}`,
+  added_at: new Date().toISOString(),
+  requiresTrigger: false,
+});
+```
+
+For additional channels (trigger-only):
+
+```typescript
+registerGroup("slack:<channel-id>", {
+  name: "<channel-name>",
+  folder: "<folder-name>",
+  trigger: `@${ASSISTANT_NAME}`,
+  added_at: new Date().toISOString(),
+  requiresTrigger: true,
+});
+```
+
+### Invite the Bot to the Channel
+
+Tell the user:
+
+> **Important:** The bot must be invited to the channel to see messages.
+>
+> In Slack, go to the channel and type:
+> ```
+> /invite @YourBotName
+> ```
+>
+> Or mention the bot: `@YourBotName` — Slack will prompt you to invite it.
+
+## Phase 5: Verify
+
+### Test the connection
+
+Tell the user:
+
+> Send a message to your registered Slack channel:
+> - For main channel: Any message works
+> - For non-main: `@Andy hello` or @mention the bot
+>
+> The bot should respond within a few seconds.
+
+### Check logs if needed
+
+```bash
+tail -f logs/nanoclaw.log
+```
+
+## Troubleshooting
+
+### Bot not responding
+
+Check:
+1. Both `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN` are set in `.env` AND synced to `data/env/env`
+2. Socket Mode is enabled in the Slack app settings
+3. Bot is invited to the channel (use `/invite @botname`)
+4. Channel is registered in SQLite (check with: `sqlite3 store/messages.db "SELECT * FROM registered_groups WHERE jid LIKE 'slack:%'"`)
+5. For non-main channels: message includes trigger pattern
+6. Service is running: `launchctl list | grep nanoclaw` (macOS) or `systemctl --user status nanoclaw` (Linux)
+
+### Bot only sees @mentions
+
+Event subscriptions may be incomplete. Check:
+1. Go to **Event Subscriptions** in your Slack app settings
+2. Verify `message.channels`, `message.groups`, `message.im`, `message.mpim` are all subscribed
+3. If you added new events, you may need to reinstall the app to your workspace
+
+### "not_in_channel" errors
+
+The bot must be explicitly invited to channels:
+```
+/invite @YourBotName
+```
+
+### Socket Mode connection issues
+
+1. Verify `SLACK_APP_TOKEN` starts with `xapp-`
+2. Verify Socket Mode is enabled in app settings
+3. Check the app-level token has `connections:write` scope
+
+### Getting channel ID
+
+Alternative methods:
+- In Slack desktop: Right-click channel > **Copy** > **Copy link** — the ID is in the URL
+- Use Slack API: `curl -H "Authorization: Bearer $SLACK_BOT_TOKEN" https://slack.com/api/conversations.list`
+
+## After Setup
+
+If running `npm run dev` while the service is active:
+```bash
+# macOS:
+launchctl unload ~/Library/LaunchAgents/com.nanoclaw.plist
+npm run dev
+# When done testing:
+launchctl load ~/Library/LaunchAgents/com.nanoclaw.plist
+# Linux:
+# systemctl --user stop nanoclaw
+# npm run dev
+# systemctl --user start nanoclaw
+```
+
+## Removal
+
+To remove Slack integration:
+
+1. Delete `src/channels/slack.ts` and `src/channels/slack.test.ts`
+2. Remove `SlackChannel` import and creation from `src/index.ts`
+3. Remove `SLACK_ONLY` from the WhatsApp conditional in `main()`
+4. Remove Slack config (`SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, `SLACK_ONLY`) from `src/config.ts`
+5. Remove Slack registrations from SQLite: `sqlite3 store/messages.db "DELETE FROM registered_groups WHERE jid LIKE 'slack:%'"`
+6. Uninstall: `npm uninstall @slack/bolt`
+7. Rebuild: `npm run build && launchctl kickstart -k gui/$(id -u)/com.nanoclaw` (macOS) or `npm run build && systemctl --user restart nanoclaw` (Linux)

--- a/.claude/skills/add-slack/add/src/channels/slack.test.ts
+++ b/.claude/skills/add-slack/add/src/channels/slack.test.ts
@@ -1,0 +1,851 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+// --- Mocks ---
+
+// Mock config
+vi.mock('../config.js', () => ({
+  ASSISTANT_NAME: 'Andy',
+  TRIGGER_PATTERN: /^@Andy\b/i,
+}));
+
+// Mock logger
+vi.mock('../logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// --- Slack Bolt mock ---
+
+type EventHandler = (args: any) => Promise<void>;
+
+const appRef = vi.hoisted(() => ({ current: null as any }));
+
+vi.mock('@slack/bolt', () => ({
+  App: class MockApp {
+    token: string;
+    appToken: string;
+    socketMode: boolean;
+    eventHandlers = new Map<string, EventHandler[]>();
+
+    client = {
+      auth: {
+        test: vi.fn().mockResolvedValue({ user_id: 'U_BOT_123' }),
+      },
+      users: {
+        info: vi.fn().mockResolvedValue({
+          user: {
+            profile: { display_name: 'Test User', real_name: 'Test' },
+            name: 'testuser',
+          },
+        }),
+      },
+      conversations: {
+        info: vi.fn().mockResolvedValue({
+          channel: { name: 'test-channel', is_im: false, is_mpim: false },
+        }),
+      },
+      chat: {
+        postMessage: vi.fn().mockResolvedValue({ ok: true }),
+      },
+      files: {
+        info: vi.fn().mockResolvedValue({
+          file: {
+            name: 'document.pdf',
+            mimetype: 'application/pdf',
+            user: 'U_USER_1',
+          },
+        }),
+      },
+    };
+
+    constructor(opts: any) {
+      this.token = opts.token;
+      this.appToken = opts.appToken;
+      this.socketMode = opts.socketMode;
+      appRef.current = this;
+    }
+
+    event(eventType: string, handler: EventHandler) {
+      const existing = this.eventHandlers.get(eventType) || [];
+      existing.push(handler);
+      this.eventHandlers.set(eventType, existing);
+    }
+
+    async start() {
+      // No-op for tests
+    }
+
+    async stop() {
+      // No-op for tests
+    }
+  },
+  LogLevel: { WARN: 'warn' },
+}));
+
+import { SlackChannel, SlackChannelOpts } from './slack.js';
+
+// --- Test helpers ---
+
+function createTestOpts(
+  overrides?: Partial<SlackChannelOpts>,
+): SlackChannelOpts {
+  return {
+    onMessage: vi.fn(),
+    onChatMetadata: vi.fn(),
+    registeredGroups: vi.fn(() => ({
+      'slack:C_TEST_123': {
+        name: 'Test Channel',
+        folder: 'test-channel',
+        trigger: '@Andy',
+        added_at: '2024-01-01T00:00:00.000Z',
+      },
+    })),
+    ...overrides,
+  };
+}
+
+function createMessageEvent(overrides: {
+  channel?: string;
+  text: string;
+  user?: string;
+  ts?: string;
+  bot_id?: string;
+  subtype?: string;
+}) {
+  return {
+    channel: overrides.channel ?? 'C_TEST_123',
+    text: overrides.text,
+    user: overrides.user ?? 'U_USER_1',
+    ts: overrides.ts ?? '1704067200.000000',
+    ...(overrides.bot_id && { bot_id: overrides.bot_id }),
+    ...(overrides.subtype && { subtype: overrides.subtype }),
+  };
+}
+
+function createAppMentionEvent(overrides: {
+  channel?: string;
+  text: string;
+  user?: string;
+  ts?: string;
+}) {
+  return {
+    channel: overrides.channel ?? 'C_TEST_123',
+    text: overrides.text,
+    user: overrides.user ?? 'U_USER_1',
+    ts: overrides.ts ?? '1704067200.000000',
+  };
+}
+
+function createFileSharedEvent(overrides: {
+  channel_id?: string;
+  file_id?: string;
+  event_ts?: string;
+}) {
+  return {
+    channel_id: overrides.channel_id ?? 'C_TEST_123',
+    file_id: overrides.file_id ?? 'F_FILE_1',
+    event_ts: overrides.event_ts ?? '1704067200.000000',
+  };
+}
+
+function currentApp() {
+  return appRef.current;
+}
+
+async function triggerEvent(eventType: string, event: any) {
+  const handlers = currentApp().eventHandlers.get(eventType) || [];
+  for (const h of handlers) {
+    await h({ event, client: currentApp().client });
+  }
+}
+
+// --- Tests ---
+
+describe('SlackChannel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // --- Connection lifecycle ---
+
+  describe('connection lifecycle', () => {
+    it('resolves connect() when app starts', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+
+      await channel.connect();
+
+      expect(channel.isConnected()).toBe(true);
+    });
+
+    it('calls auth.test to get bot user ID', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+
+      await channel.connect();
+
+      expect(currentApp().client.auth.test).toHaveBeenCalled();
+    });
+
+    it('registers message and app_mention event handlers', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+
+      await channel.connect();
+
+      expect(currentApp().eventHandlers.has('message')).toBe(true);
+      expect(currentApp().eventHandlers.has('app_mention')).toBe(true);
+      expect(currentApp().eventHandlers.has('file_shared')).toBe(true);
+    });
+
+    it('disconnects cleanly', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+
+      await channel.connect();
+      expect(channel.isConnected()).toBe(true);
+
+      await channel.disconnect();
+      expect(channel.isConnected()).toBe(false);
+    });
+
+    it('isConnected() returns false before connect', () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+
+      expect(channel.isConnected()).toBe(false);
+    });
+  });
+
+  // --- Message event handling ---
+
+  describe('message event handling', () => {
+    it('delivers message for registered channel', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+      await channel.connect();
+
+      const event = createMessageEvent({ text: 'Hello everyone' });
+      await triggerEvent('message', event);
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        'slack:C_TEST_123',
+        expect.any(String),
+        'test-channel',
+        'slack',
+        true,
+      );
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'slack:C_TEST_123',
+        expect.objectContaining({
+          id: '1704067200.000000',
+          chat_jid: 'slack:C_TEST_123',
+          sender: 'U_USER_1',
+          sender_name: 'Test User',
+          content: 'Hello everyone',
+          is_from_me: false,
+        }),
+      );
+    });
+
+    it('only emits metadata for unregistered channels', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+      await channel.connect();
+
+      const event = createMessageEvent({
+        channel: 'C_UNKNOWN',
+        text: 'Unknown channel',
+      });
+      await triggerEvent('message', event);
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        'slack:C_UNKNOWN',
+        expect.any(String),
+        'test-channel',
+        'slack',
+        true,
+      );
+      expect(opts.onMessage).not.toHaveBeenCalled();
+    });
+
+    it('skips bot messages', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+      await channel.connect();
+
+      const event = createMessageEvent({
+        text: 'Bot message',
+        bot_id: 'B_BOT_1',
+      });
+      await triggerEvent('message', event);
+
+      expect(opts.onMessage).not.toHaveBeenCalled();
+      expect(opts.onChatMetadata).not.toHaveBeenCalled();
+    });
+
+    it('skips message subtypes (edits, deletes)', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+      await channel.connect();
+
+      const event = createMessageEvent({
+        text: 'Edited message',
+        subtype: 'message_changed',
+      });
+      await triggerEvent('message', event);
+
+      expect(opts.onMessage).not.toHaveBeenCalled();
+    });
+
+    it('skips messages without text', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+      await channel.connect();
+
+      const event = { channel: 'C_TEST_123', user: 'U_USER_1', ts: '123' };
+      await triggerEvent('message', event);
+
+      expect(opts.onMessage).not.toHaveBeenCalled();
+    });
+
+    it('fetches sender display name from users.info', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+      await channel.connect();
+
+      const event = createMessageEvent({ text: 'Hi' });
+      await triggerEvent('message', event);
+
+      expect(currentApp().client.users.info).toHaveBeenCalledWith({
+        user: 'U_USER_1',
+      });
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'slack:C_TEST_123',
+        expect.objectContaining({ sender_name: 'Test User' }),
+      );
+    });
+
+    it('falls back to user ID when users.info fails', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+      await channel.connect();
+
+      currentApp().client.users.info.mockRejectedValueOnce(
+        new Error('API error'),
+      );
+
+      const event = createMessageEvent({ text: 'Hi', user: 'U_FALLBACK' });
+      await triggerEvent('message', event);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'slack:C_TEST_123',
+        expect.objectContaining({ sender_name: 'U_FALLBACK' }),
+      );
+    });
+
+    it('converts ts to ISO timestamp', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+      await channel.connect();
+
+      const event = createMessageEvent({
+        text: 'Hello',
+        ts: '1704067200.000000', // 2024-01-01T00:00:00.000Z
+      });
+      await triggerEvent('message', event);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'slack:C_TEST_123',
+        expect.objectContaining({
+          timestamp: '2024-01-01T00:00:00.000Z',
+        }),
+      );
+    });
+  });
+
+  // --- @mention translation ---
+
+  describe('@mention translation', () => {
+    it('translates <@botUserId> mention to trigger format', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+      await channel.connect();
+
+      const event = createMessageEvent({
+        text: '<@U_BOT_123> what time is it?',
+      });
+      await triggerEvent('message', event);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'slack:C_TEST_123',
+        expect.objectContaining({
+          content: '@Andy <@U_BOT_123> what time is it?',
+        }),
+      );
+    });
+
+    it('does not translate if message already matches trigger', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+      await channel.connect();
+
+      const event = createMessageEvent({
+        text: '@Andy <@U_BOT_123> hello',
+      });
+      await triggerEvent('message', event);
+
+      // Should NOT double-prepend — already starts with @Andy
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'slack:C_TEST_123',
+        expect.objectContaining({
+          content: '@Andy <@U_BOT_123> hello',
+        }),
+      );
+    });
+
+    it('does not translate mentions of other users', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+      await channel.connect();
+
+      const event = createMessageEvent({
+        text: '<@U_OTHER_USER> hi',
+      });
+      await triggerEvent('message', event);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'slack:C_TEST_123',
+        expect.objectContaining({
+          content: '<@U_OTHER_USER> hi', // No translation
+        }),
+      );
+    });
+
+    it('handles message without any mentions', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+      await channel.connect();
+
+      const event = createMessageEvent({ text: 'plain message' });
+      await triggerEvent('message', event);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'slack:C_TEST_123',
+        expect.objectContaining({
+          content: 'plain message',
+        }),
+      );
+    });
+  });
+
+  // --- app_mention event ---
+
+  describe('app_mention event', () => {
+    it('delivers app_mention for registered channel', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+      await channel.connect();
+
+      const event = createAppMentionEvent({
+        text: '<@U_BOT_123> help me',
+      });
+      await triggerEvent('app_mention', event);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'slack:C_TEST_123',
+        expect.objectContaining({
+          content: '@Andy <@U_BOT_123> help me',
+        }),
+      );
+    });
+
+    it('ignores app_mention from unregistered channels', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+      await channel.connect();
+
+      const event = createAppMentionEvent({
+        channel: 'C_UNKNOWN',
+        text: '<@U_BOT_123> hi',
+      });
+      await triggerEvent('app_mention', event);
+
+      expect(opts.onChatMetadata).toHaveBeenCalled();
+      expect(opts.onMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- file_shared event ---
+
+  describe('file_shared event', () => {
+    it('stores file with placeholder', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+      await channel.connect();
+
+      const event = createFileSharedEvent({});
+      await triggerEvent('file_shared', event);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'slack:C_TEST_123',
+        expect.objectContaining({ content: '[File: document.pdf]' }),
+      );
+    });
+
+    it('stores image with Image placeholder', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+      await channel.connect();
+
+      currentApp().client.files.info.mockResolvedValueOnce({
+        file: {
+          name: 'screenshot.png',
+          mimetype: 'image/png',
+          user: 'U_USER_1',
+        },
+      });
+
+      const event = createFileSharedEvent({});
+      await triggerEvent('file_shared', event);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'slack:C_TEST_123',
+        expect.objectContaining({ content: '[Image: screenshot.png]' }),
+      );
+    });
+
+    it('stores video with Video placeholder', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+      await channel.connect();
+
+      currentApp().client.files.info.mockResolvedValueOnce({
+        file: {
+          name: 'clip.mp4',
+          mimetype: 'video/mp4',
+          user: 'U_USER_1',
+        },
+      });
+
+      const event = createFileSharedEvent({});
+      await triggerEvent('file_shared', event);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'slack:C_TEST_123',
+        expect.objectContaining({ content: '[Video: clip.mp4]' }),
+      );
+    });
+
+    it('stores audio with Audio placeholder', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+      await channel.connect();
+
+      currentApp().client.files.info.mockResolvedValueOnce({
+        file: {
+          name: 'voice.mp3',
+          mimetype: 'audio/mpeg',
+          user: 'U_USER_1',
+        },
+      });
+
+      const event = createFileSharedEvent({});
+      await triggerEvent('file_shared', event);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'slack:C_TEST_123',
+        expect.objectContaining({ content: '[Audio: voice.mp3]' }),
+      );
+    });
+
+    it('ignores file_shared from unregistered channels', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+      await channel.connect();
+
+      const event = createFileSharedEvent({ channel_id: 'C_UNKNOWN' });
+      await triggerEvent('file_shared', event);
+
+      expect(opts.onMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- sendMessage ---
+
+  describe('sendMessage', () => {
+    it('sends message via chat.postMessage', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+      await channel.connect();
+
+      await channel.sendMessage('slack:C_TEST_123', 'Hello');
+
+      expect(currentApp().client.chat.postMessage).toHaveBeenCalledWith({
+        channel: 'C_TEST_123',
+        text: 'Hello',
+      });
+    });
+
+    it('strips slack: prefix from JID', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+      await channel.connect();
+
+      await channel.sendMessage('slack:C_CHANNEL_ID', 'Message');
+
+      expect(currentApp().client.chat.postMessage).toHaveBeenCalledWith({
+        channel: 'C_CHANNEL_ID',
+        text: 'Message',
+      });
+    });
+
+    it('splits messages exceeding 4000 characters', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+      await channel.connect();
+
+      const longText = 'x'.repeat(5000);
+      await channel.sendMessage('slack:C_TEST_123', longText);
+
+      expect(currentApp().client.chat.postMessage).toHaveBeenCalledTimes(2);
+      expect(currentApp().client.chat.postMessage).toHaveBeenNthCalledWith(1, {
+        channel: 'C_TEST_123',
+        text: 'x'.repeat(4000),
+      });
+      expect(currentApp().client.chat.postMessage).toHaveBeenNthCalledWith(2, {
+        channel: 'C_TEST_123',
+        text: 'x'.repeat(1000),
+      });
+    });
+
+    it('sends exactly one message at 4000 characters', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+      await channel.connect();
+
+      const exactText = 'y'.repeat(4000);
+      await channel.sendMessage('slack:C_TEST_123', exactText);
+
+      expect(currentApp().client.chat.postMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles send failure gracefully', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+      await channel.connect();
+
+      currentApp().client.chat.postMessage.mockRejectedValueOnce(
+        new Error('Network error'),
+      );
+
+      // Should not throw
+      await expect(
+        channel.sendMessage('slack:C_TEST_123', 'Will fail'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('does nothing when app is not initialized', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+
+      // Don't connect — app is null
+      await channel.sendMessage('slack:C_TEST_123', 'No app');
+
+      // No error, no API call
+    });
+  });
+
+  // --- ownsJid ---
+
+  describe('ownsJid', () => {
+    it('owns slack: JIDs', () => {
+      const channel = new SlackChannel(
+        'xoxb-token',
+        'xapp-token',
+        createTestOpts(),
+      );
+      expect(channel.ownsJid('slack:C123456')).toBe(true);
+    });
+
+    it('owns slack: JIDs with various channel ID formats', () => {
+      const channel = new SlackChannel(
+        'xoxb-token',
+        'xapp-token',
+        createTestOpts(),
+      );
+      expect(channel.ownsJid('slack:C_CHANNEL_ID')).toBe(true);
+      expect(channel.ownsJid('slack:D_DM_ID')).toBe(true);
+      expect(channel.ownsJid('slack:G_GROUP_ID')).toBe(true);
+    });
+
+    it('does not own WhatsApp group JIDs', () => {
+      const channel = new SlackChannel(
+        'xoxb-token',
+        'xapp-token',
+        createTestOpts(),
+      );
+      expect(channel.ownsJid('12345@g.us')).toBe(false);
+    });
+
+    it('does not own WhatsApp DM JIDs', () => {
+      const channel = new SlackChannel(
+        'xoxb-token',
+        'xapp-token',
+        createTestOpts(),
+      );
+      expect(channel.ownsJid('12345@s.whatsapp.net')).toBe(false);
+    });
+
+    it('does not own Telegram JIDs', () => {
+      const channel = new SlackChannel(
+        'xoxb-token',
+        'xapp-token',
+        createTestOpts(),
+      );
+      expect(channel.ownsJid('tg:123456789')).toBe(false);
+    });
+
+    it('does not own unknown JID formats', () => {
+      const channel = new SlackChannel(
+        'xoxb-token',
+        'xapp-token',
+        createTestOpts(),
+      );
+      expect(channel.ownsJid('random-string')).toBe(false);
+    });
+  });
+
+  // --- setTyping ---
+
+  describe('setTyping', () => {
+    it('is a no-op (Slack does not support bot typing)', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+      await channel.connect();
+
+      // Should not throw and should not call any API
+      await expect(
+        channel.setTyping('slack:C_TEST_123', true),
+      ).resolves.toBeUndefined();
+    });
+
+    it('does not throw when app is not initialized', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+
+      // Don't connect
+      await expect(
+        channel.setTyping('slack:C_TEST_123', true),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  // --- Channel properties ---
+
+  describe('channel properties', () => {
+    it('has name "slack"', () => {
+      const channel = new SlackChannel(
+        'xoxb-token',
+        'xapp-token',
+        createTestOpts(),
+      );
+      expect(channel.name).toBe('slack');
+    });
+  });
+
+  // --- Channel type detection ---
+
+  describe('channel type detection', () => {
+    it('marks DM channels as non-group', async () => {
+      const opts = createTestOpts({
+        registeredGroups: vi.fn(() => ({
+          'slack:D_DM_123': {
+            name: 'DM',
+            folder: 'dm',
+            trigger: '@Andy',
+            added_at: '2024-01-01T00:00:00.000Z',
+          },
+        })),
+      });
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+      await channel.connect();
+
+      currentApp().client.conversations.info.mockResolvedValueOnce({
+        channel: { name: 'dm', is_im: true, is_mpim: false },
+      });
+
+      const event = createMessageEvent({
+        channel: 'D_DM_123',
+        text: 'Hello',
+      });
+      await triggerEvent('message', event);
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        'slack:D_DM_123',
+        expect.any(String),
+        'dm',
+        'slack',
+        false, // isGroup = false for DMs
+      );
+    });
+
+    it('marks MPIM channels as non-group', async () => {
+      const opts = createTestOpts({
+        registeredGroups: vi.fn(() => ({
+          'slack:G_MPIM_123': {
+            name: 'Group DM',
+            folder: 'mpim',
+            trigger: '@Andy',
+            added_at: '2024-01-01T00:00:00.000Z',
+          },
+        })),
+      });
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+      await channel.connect();
+
+      currentApp().client.conversations.info.mockResolvedValueOnce({
+        channel: { name: 'mpdm-user1--user2--user3', is_im: false, is_mpim: true },
+      });
+
+      const event = createMessageEvent({
+        channel: 'G_MPIM_123',
+        text: 'Hello',
+      });
+      await triggerEvent('message', event);
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        'slack:G_MPIM_123',
+        expect.any(String),
+        'mpdm-user1--user2--user3',
+        'slack',
+        false, // isGroup = false for MPIMs
+      );
+    });
+
+    it('marks regular channels as groups', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel('xoxb-token', 'xapp-token', opts);
+      await channel.connect();
+
+      const event = createMessageEvent({ text: 'Hello' });
+      await triggerEvent('message', event);
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        'slack:C_TEST_123',
+        expect.any(String),
+        'test-channel',
+        'slack',
+        true, // isGroup = true for channels
+      );
+    });
+  });
+});

--- a/.claude/skills/add-slack/add/src/channels/slack.ts
+++ b/.claude/skills/add-slack/add/src/channels/slack.ts
@@ -1,0 +1,329 @@
+import { App, LogLevel } from '@slack/bolt';
+
+import { ASSISTANT_NAME, TRIGGER_PATTERN } from '../config.js';
+import { logger } from '../logger.js';
+import {
+  Channel,
+  OnChatMetadata,
+  OnInboundMessage,
+  RegisteredGroup,
+} from '../types.js';
+
+export interface SlackChannelOpts {
+  onMessage: OnInboundMessage;
+  onChatMetadata: OnChatMetadata;
+  registeredGroups: () => Record<string, RegisteredGroup>;
+}
+
+export class SlackChannel implements Channel {
+  name = 'slack';
+
+  private app: App | null = null;
+  private opts: SlackChannelOpts;
+  private botToken: string;
+  private appToken: string;
+  private botUserId: string | null = null;
+
+  constructor(botToken: string, appToken: string, opts: SlackChannelOpts) {
+    this.botToken = botToken;
+    this.appToken = appToken;
+    this.opts = opts;
+  }
+
+  async connect(): Promise<void> {
+    this.app = new App({
+      token: this.botToken,
+      appToken: this.appToken,
+      socketMode: true,
+      logLevel: LogLevel.WARN,
+    });
+
+    // Get bot user ID for mention detection
+    const authResult = await this.app.client.auth.test();
+    this.botUserId = authResult.user_id as string;
+
+    // Handle all message events
+    this.app.event('message', async ({ event, client }) => {
+      // Type guard for message events with text
+      if (!('text' in event) || !event.text) return;
+      // Skip bot messages
+      if ('bot_id' in event && event.bot_id) return;
+      // Skip message subtypes (edits, deletes, etc.)
+      if ('subtype' in event && event.subtype) return;
+
+      const channelId = event.channel;
+      const chatJid = `slack:${channelId}`;
+      let content = event.text;
+      const timestamp = new Date(parseFloat(event.ts) * 1000).toISOString();
+      const sender = event.user || '';
+      const msgId = event.ts;
+
+      // Get sender display name
+      let senderName = sender;
+      try {
+        const userInfo = await client.users.info({ user: sender });
+        senderName =
+          userInfo.user?.profile?.display_name ||
+          userInfo.user?.profile?.real_name ||
+          userInfo.user?.name ||
+          sender;
+      } catch {
+        // Fall back to user ID
+      }
+
+      // Determine channel name and type
+      let chatName = chatJid;
+      let isGroup = true;
+      try {
+        const channelInfo = await client.conversations.info({
+          channel: channelId,
+        });
+        chatName = channelInfo.channel?.name || chatJid;
+        // DMs and MPIMs are "is_im" or "is_mpim"
+        isGroup = !(
+          channelInfo.channel?.is_im || channelInfo.channel?.is_mpim
+        );
+      } catch {
+        // Fall back to JID as name
+      }
+
+      // Translate <@botUserId> mentions into TRIGGER_PATTERN format.
+      // Slack @mentions (e.g., <@U123ABC>) won't match TRIGGER_PATTERN
+      // (e.g., ^@Andy\b), so we prepend the trigger when the bot is @mentioned.
+      if (this.botUserId) {
+        const botMentionPattern = new RegExp(`<@${this.botUserId}>`, 'g');
+        if (botMentionPattern.test(content) && !TRIGGER_PATTERN.test(content)) {
+          content = `@${ASSISTANT_NAME} ${content}`;
+        }
+      }
+
+      // Store chat metadata for discovery
+      this.opts.onChatMetadata(chatJid, timestamp, chatName, 'slack', isGroup);
+
+      // Only deliver full message for registered groups
+      const group = this.opts.registeredGroups()[chatJid];
+      if (!group) {
+        logger.debug({ chatJid, chatName }, 'Message from unregistered Slack channel');
+        return;
+      }
+
+      // Deliver message — startMessageLoop() will pick it up
+      this.opts.onMessage(chatJid, {
+        id: msgId,
+        chat_jid: chatJid,
+        sender,
+        sender_name: senderName,
+        content,
+        timestamp,
+        is_from_me: false,
+      });
+
+      logger.info(
+        { chatJid, chatName, sender: senderName },
+        'Slack message stored',
+      );
+    });
+
+    // Handle app_mention events (when bot is @mentioned)
+    this.app.event('app_mention', async ({ event, client }) => {
+      const channelId = event.channel;
+      const chatJid = `slack:${channelId}`;
+      let content = event.text;
+      const timestamp = new Date(parseFloat(event.ts) * 1000).toISOString();
+      const sender = event.user || '';
+      const msgId = event.ts;
+
+      // Get sender display name
+      let senderName = sender;
+      try {
+        const userInfo = await client.users.info({ user: sender });
+        senderName =
+          userInfo.user?.profile?.display_name ||
+          userInfo.user?.profile?.real_name ||
+          userInfo.user?.name ||
+          sender;
+      } catch {
+        // Fall back to user ID
+      }
+
+      // Determine channel name
+      let chatName = chatJid;
+      let isGroup = true;
+      try {
+        const channelInfo = await client.conversations.info({
+          channel: channelId,
+        });
+        chatName = channelInfo.channel?.name || chatJid;
+        isGroup = !(
+          channelInfo.channel?.is_im || channelInfo.channel?.is_mpim
+        );
+      } catch {
+        // Fall back to JID as name
+      }
+
+      // Translate mention to trigger format
+      if (this.botUserId && !TRIGGER_PATTERN.test(content)) {
+        content = `@${ASSISTANT_NAME} ${content}`;
+      }
+
+      // Store chat metadata
+      this.opts.onChatMetadata(chatJid, timestamp, chatName, 'slack', isGroup);
+
+      // Only deliver for registered groups
+      const group = this.opts.registeredGroups()[chatJid];
+      if (!group) {
+        logger.debug({ chatJid }, 'app_mention from unregistered Slack channel');
+        return;
+      }
+
+      this.opts.onMessage(chatJid, {
+        id: msgId,
+        chat_jid: chatJid,
+        sender,
+        sender_name: senderName,
+        content,
+        timestamp,
+        is_from_me: false,
+      });
+
+      logger.info({ chatJid, sender: senderName }, 'Slack app_mention stored');
+    });
+
+    // Handle file shared events
+    this.app.event('file_shared', async ({ event, client }) => {
+      const channelId = event.channel_id;
+      const chatJid = `slack:${channelId}`;
+
+      const group = this.opts.registeredGroups()[chatJid];
+      if (!group) return;
+
+      try {
+        const fileInfo = await client.files.info({ file: event.file_id });
+        const file = fileInfo.file;
+        if (!file) return;
+
+        const timestamp = new Date(
+          parseFloat(event.event_ts) * 1000,
+        ).toISOString();
+        const sender = file.user || '';
+        const msgId = event.event_ts;
+
+        // Get sender name
+        let senderName = sender;
+        try {
+          const userInfo = await client.users.info({ user: sender });
+          senderName =
+            userInfo.user?.profile?.display_name ||
+            userInfo.user?.profile?.real_name ||
+            userInfo.user?.name ||
+            sender;
+        } catch {
+          // Fall back to user ID
+        }
+
+        // Determine file type placeholder
+        let placeholder: string;
+        const mimetype = file.mimetype || '';
+        const filename = file.name || 'file';
+
+        if (mimetype.startsWith('image/')) {
+          placeholder = `[Image: ${filename}]`;
+        } else if (mimetype.startsWith('video/')) {
+          placeholder = `[Video: ${filename}]`;
+        } else if (mimetype.startsWith('audio/')) {
+          placeholder = `[Audio: ${filename}]`;
+        } else {
+          placeholder = `[File: ${filename}]`;
+        }
+
+        // Include initial comment if present
+        const comment = file.initial_comment?.comment
+          ? ` ${file.initial_comment.comment}`
+          : '';
+
+        this.opts.onChatMetadata(
+          chatJid,
+          timestamp,
+          undefined,
+          'slack',
+          true,
+        );
+        this.opts.onMessage(chatJid, {
+          id: msgId,
+          chat_jid: chatJid,
+          sender,
+          sender_name: senderName,
+          content: `${placeholder}${comment}`,
+          timestamp,
+          is_from_me: false,
+        });
+      } catch (err) {
+        logger.debug({ chatJid, err }, 'Failed to process file_shared event');
+      }
+    });
+
+    // Start Socket Mode connection
+    await this.app.start();
+
+    logger.info(
+      { botUserId: this.botUserId },
+      'Slack bot connected via Socket Mode',
+    );
+    console.log(`\n  Slack bot connected (Socket Mode)`);
+    console.log(`  Bot user ID: ${this.botUserId}`);
+    console.log(
+      `  Get channel ID from Slack channel settings (right-click channel > View channel details)\n`,
+    );
+  }
+
+  async sendMessage(jid: string, text: string): Promise<void> {
+    if (!this.app) {
+      logger.warn('Slack app not initialized');
+      return;
+    }
+
+    try {
+      const channelId = jid.replace(/^slack:/, '');
+
+      // Slack has a 4000 character limit per message — split if needed
+      const MAX_LENGTH = 4000;
+      if (text.length <= MAX_LENGTH) {
+        await this.app.client.chat.postMessage({
+          channel: channelId,
+          text,
+        });
+      } else {
+        for (let i = 0; i < text.length; i += MAX_LENGTH) {
+          await this.app.client.chat.postMessage({
+            channel: channelId,
+            text: text.slice(i, i + MAX_LENGTH),
+          });
+        }
+      }
+      logger.info({ jid, length: text.length }, 'Slack message sent');
+    } catch (err) {
+      logger.error({ jid, err }, 'Failed to send Slack message');
+    }
+  }
+
+  isConnected(): boolean {
+    return this.app !== null;
+  }
+
+  ownsJid(jid: string): boolean {
+    return jid.startsWith('slack:');
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.app) {
+      await this.app.stop();
+      this.app = null;
+      this.botUserId = null;
+      logger.info('Slack bot stopped');
+    }
+  }
+
+  async setTyping(_jid: string, _isTyping: boolean): Promise<void> {
+    // Slack doesn't support bot typing indicators — no-op
+  }
+}

--- a/.claude/skills/add-slack/manifest.yaml
+++ b/.claude/skills/add-slack/manifest.yaml
@@ -1,0 +1,21 @@
+skill: slack
+version: 1.0.0
+description: "Slack Bot integration via @slack/bolt (Socket Mode)"
+core_version: 0.1.0
+adds:
+  - src/channels/slack.ts
+  - src/channels/slack.test.ts
+modifies:
+  - src/index.ts
+  - src/config.ts
+  - src/routing.test.ts
+structured:
+  npm_dependencies:
+    "@slack/bolt": "^4.1.0"
+  env_additions:
+    - SLACK_BOT_TOKEN
+    - SLACK_APP_TOKEN
+    - SLACK_ONLY
+conflicts: []
+depends: []
+test: "npx vitest run src/channels/slack.test.ts"

--- a/.claude/skills/add-slack/modify/src/config.ts
+++ b/.claude/skills/add-slack/modify/src/config.ts
@@ -1,0 +1,88 @@
+import os from 'os';
+import path from 'path';
+
+import { readEnvFile } from './env.js';
+
+// Read config values from .env (falls back to process.env).
+// Secrets are NOT read here — they stay on disk and are loaded only
+// where needed (container-runner.ts) to avoid leaking to child processes.
+const envConfig = readEnvFile([
+  'ASSISTANT_NAME',
+  'ASSISTANT_HAS_OWN_NUMBER',
+  'TELEGRAM_BOT_TOKEN',
+  'TELEGRAM_ONLY',
+  'SLACK_BOT_TOKEN',
+  'SLACK_APP_TOKEN',
+  'SLACK_ONLY',
+]);
+
+export const ASSISTANT_NAME =
+  process.env.ASSISTANT_NAME || envConfig.ASSISTANT_NAME || 'Andy';
+export const ASSISTANT_HAS_OWN_NUMBER =
+  (process.env.ASSISTANT_HAS_OWN_NUMBER || envConfig.ASSISTANT_HAS_OWN_NUMBER) === 'true';
+export const POLL_INTERVAL = 2000;
+export const SCHEDULER_POLL_INTERVAL = 60000;
+
+// Absolute paths needed for container mounts
+const PROJECT_ROOT = process.cwd();
+const HOME_DIR = process.env.HOME || os.homedir();
+
+// Mount security: allowlist stored OUTSIDE project root, never mounted into containers
+export const MOUNT_ALLOWLIST_PATH = path.join(
+  HOME_DIR,
+  '.config',
+  'nanoclaw',
+  'mount-allowlist.json',
+);
+export const STORE_DIR = path.resolve(PROJECT_ROOT, 'store');
+export const GROUPS_DIR = path.resolve(PROJECT_ROOT, 'groups');
+export const DATA_DIR = path.resolve(PROJECT_ROOT, 'data');
+export const MAIN_GROUP_FOLDER = 'main';
+
+export const CONTAINER_IMAGE =
+  process.env.CONTAINER_IMAGE || 'nanoclaw-agent:latest';
+export const CONTAINER_TIMEOUT = parseInt(
+  process.env.CONTAINER_TIMEOUT || '1800000',
+  10,
+);
+export const CONTAINER_MAX_OUTPUT_SIZE = parseInt(
+  process.env.CONTAINER_MAX_OUTPUT_SIZE || '10485760',
+  10,
+); // 10MB default
+export const IPC_POLL_INTERVAL = 1000;
+export const IDLE_TIMEOUT = parseInt(
+  process.env.IDLE_TIMEOUT || '1800000',
+  10,
+); // 30min default — how long to keep container alive after last result
+export const MAX_CONCURRENT_CONTAINERS = Math.max(
+  1,
+  parseInt(process.env.MAX_CONCURRENT_CONTAINERS || '5', 10) || 5,
+);
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export const TRIGGER_PATTERN = new RegExp(
+  `^@${escapeRegex(ASSISTANT_NAME)}\\b`,
+  'i',
+);
+
+// Timezone for scheduled tasks (cron expressions, etc.)
+// Uses system timezone by default
+export const TIMEZONE =
+  process.env.TZ || Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+// Telegram configuration
+export const TELEGRAM_BOT_TOKEN =
+  process.env.TELEGRAM_BOT_TOKEN || envConfig.TELEGRAM_BOT_TOKEN || '';
+export const TELEGRAM_ONLY =
+  (process.env.TELEGRAM_ONLY || envConfig.TELEGRAM_ONLY) === 'true';
+
+// Slack configuration
+export const SLACK_BOT_TOKEN =
+  process.env.SLACK_BOT_TOKEN || envConfig.SLACK_BOT_TOKEN || '';
+export const SLACK_APP_TOKEN =
+  process.env.SLACK_APP_TOKEN || envConfig.SLACK_APP_TOKEN || '';
+export const SLACK_ONLY =
+  (process.env.SLACK_ONLY || envConfig.SLACK_ONLY) === 'true';

--- a/.claude/skills/add-slack/modify/src/config.ts.intent.md
+++ b/.claude/skills/add-slack/modify/src/config.ts.intent.md
@@ -1,0 +1,22 @@
+# Intent: src/config.ts modifications
+
+## What changed
+Added three new configuration exports for Slack channel support.
+
+## Key sections
+- **readEnvFile call**: Must include `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, and `SLACK_ONLY` in the keys array. NanoClaw does NOT load `.env` into `process.env` — all `.env` values must be explicitly requested via `readEnvFile()`.
+- **SLACK_BOT_TOKEN**: Read from `process.env` first, then `envConfig` fallback, defaults to empty string (channel disabled when empty). This is the `xoxb-` token for API calls.
+- **SLACK_APP_TOKEN**: Read from `process.env` first, then `envConfig` fallback, defaults to empty string. This is the `xapp-` token for Socket Mode WebSocket connection. Both tokens are required for Slack to work.
+- **SLACK_ONLY**: Boolean flag from `process.env` or `envConfig`, when `true` disables WhatsApp channel creation (similar to TELEGRAM_ONLY)
+
+## Invariants
+- All existing config exports remain unchanged
+- New Slack keys are added to the `readEnvFile` call alongside existing keys
+- New exports are appended at the end of the file
+- No existing behavior is modified — Slack config is additive only
+- Both `process.env` and `envConfig` are checked (same pattern as `ASSISTANT_NAME`)
+
+## Must-keep
+- All existing exports (`ASSISTANT_NAME`, `POLL_INTERVAL`, `TRIGGER_PATTERN`, `TELEGRAM_BOT_TOKEN`, etc.)
+- The `readEnvFile` pattern — ALL config read from `.env` must go through this function
+- The `escapeRegex` helper and `TRIGGER_PATTERN` construction

--- a/.claude/skills/add-slack/modify/src/index.ts
+++ b/.claude/skills/add-slack/modify/src/index.ts
@@ -1,0 +1,519 @@
+import fs from 'fs';
+import path from 'path';
+
+import {
+  ASSISTANT_NAME,
+  IDLE_TIMEOUT,
+  MAIN_GROUP_FOLDER,
+  POLL_INTERVAL,
+  SLACK_APP_TOKEN,
+  SLACK_BOT_TOKEN,
+  SLACK_ONLY,
+  TELEGRAM_BOT_TOKEN,
+  TELEGRAM_ONLY,
+  TRIGGER_PATTERN,
+} from './config.js';
+import { SlackChannel } from './channels/slack.js';
+import { TelegramChannel } from './channels/telegram.js';
+import { WhatsAppChannel } from './channels/whatsapp.js';
+import {
+  ContainerOutput,
+  runContainerAgent,
+  writeGroupsSnapshot,
+  writeTasksSnapshot,
+} from './container-runner.js';
+import { cleanupOrphans, ensureContainerRuntimeRunning } from './container-runtime.js';
+import {
+  getAllChats,
+  getAllRegisteredGroups,
+  getAllSessions,
+  getAllTasks,
+  getMessagesSince,
+  getNewMessages,
+  getRouterState,
+  initDatabase,
+  setRegisteredGroup,
+  setRouterState,
+  setSession,
+  storeChatMetadata,
+  storeMessage,
+} from './db.js';
+import { GroupQueue } from './group-queue.js';
+import { resolveGroupFolderPath } from './group-folder.js';
+import { startIpcWatcher } from './ipc.js';
+import { findChannel, formatMessages, formatOutbound } from './router.js';
+import { startSchedulerLoop } from './task-scheduler.js';
+import { Channel, NewMessage, RegisteredGroup } from './types.js';
+import { logger } from './logger.js';
+
+// Re-export for backwards compatibility during refactor
+export { escapeXml, formatMessages } from './router.js';
+
+let lastTimestamp = '';
+let sessions: Record<string, string> = {};
+let registeredGroups: Record<string, RegisteredGroup> = {};
+let lastAgentTimestamp: Record<string, string> = {};
+let messageLoopRunning = false;
+
+let whatsapp: WhatsAppChannel;
+const channels: Channel[] = [];
+const queue = new GroupQueue();
+
+function loadState(): void {
+  lastTimestamp = getRouterState('last_timestamp') || '';
+  const agentTs = getRouterState('last_agent_timestamp');
+  try {
+    lastAgentTimestamp = agentTs ? JSON.parse(agentTs) : {};
+  } catch {
+    logger.warn('Corrupted last_agent_timestamp in DB, resetting');
+    lastAgentTimestamp = {};
+  }
+  sessions = getAllSessions();
+  registeredGroups = getAllRegisteredGroups();
+  logger.info(
+    { groupCount: Object.keys(registeredGroups).length },
+    'State loaded',
+  );
+}
+
+function saveState(): void {
+  setRouterState('last_timestamp', lastTimestamp);
+  setRouterState(
+    'last_agent_timestamp',
+    JSON.stringify(lastAgentTimestamp),
+  );
+}
+
+function registerGroup(jid: string, group: RegisteredGroup): void {
+  let groupDir: string;
+  try {
+    groupDir = resolveGroupFolderPath(group.folder);
+  } catch (err) {
+    logger.warn(
+      { jid, folder: group.folder, err },
+      'Rejecting group registration with invalid folder',
+    );
+    return;
+  }
+
+  registeredGroups[jid] = group;
+  setRegisteredGroup(jid, group);
+
+  // Create group folder
+  fs.mkdirSync(path.join(groupDir, 'logs'), { recursive: true });
+
+  logger.info(
+    { jid, name: group.name, folder: group.folder },
+    'Group registered',
+  );
+}
+
+/**
+ * Get available groups list for the agent.
+ * Returns groups ordered by most recent activity.
+ */
+export function getAvailableGroups(): import('./container-runner.js').AvailableGroup[] {
+  const chats = getAllChats();
+  const registeredJids = new Set(Object.keys(registeredGroups));
+
+  return chats
+    .filter((c) => c.jid !== '__group_sync__' && c.is_group)
+    .map((c) => ({
+      jid: c.jid,
+      name: c.name,
+      lastActivity: c.last_message_time,
+      isRegistered: registeredJids.has(c.jid),
+    }));
+}
+
+/** @internal - exported for testing */
+export function _setRegisteredGroups(groups: Record<string, RegisteredGroup>): void {
+  registeredGroups = groups;
+}
+
+/**
+ * Process all pending messages for a group.
+ * Called by the GroupQueue when it's this group's turn.
+ */
+async function processGroupMessages(chatJid: string): Promise<boolean> {
+  const group = registeredGroups[chatJid];
+  if (!group) return true;
+
+  const channel = findChannel(channels, chatJid);
+  if (!channel) {
+    console.log(`Warning: no channel owns JID ${chatJid}, skipping messages`);
+    return true;
+  }
+
+  const isMainGroup = group.folder === MAIN_GROUP_FOLDER;
+
+  const sinceTimestamp = lastAgentTimestamp[chatJid] || '';
+  const missedMessages = getMessagesSince(chatJid, sinceTimestamp, ASSISTANT_NAME);
+
+  if (missedMessages.length === 0) return true;
+
+  // For non-main groups, check if trigger is required and present
+  if (!isMainGroup && group.requiresTrigger !== false) {
+    const hasTrigger = missedMessages.some((m) =>
+      TRIGGER_PATTERN.test(m.content.trim()),
+    );
+    if (!hasTrigger) return true;
+  }
+
+  const prompt = formatMessages(missedMessages);
+
+  // Advance cursor so the piping path in startMessageLoop won't re-fetch
+  // these messages. Save the old cursor so we can roll back on error.
+  const previousCursor = lastAgentTimestamp[chatJid] || '';
+  lastAgentTimestamp[chatJid] =
+    missedMessages[missedMessages.length - 1].timestamp;
+  saveState();
+
+  logger.info(
+    { group: group.name, messageCount: missedMessages.length },
+    'Processing messages',
+  );
+
+  // Track idle timer for closing stdin when agent is idle
+  let idleTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const resetIdleTimer = () => {
+    if (idleTimer) clearTimeout(idleTimer);
+    idleTimer = setTimeout(() => {
+      logger.debug({ group: group.name }, 'Idle timeout, closing container stdin');
+      queue.closeStdin(chatJid);
+    }, IDLE_TIMEOUT);
+  };
+
+  await channel.setTyping?.(chatJid, true);
+  let hadError = false;
+  let outputSentToUser = false;
+
+  const output = await runAgent(group, prompt, chatJid, async (result) => {
+    // Streaming output callback — called for each agent result
+    if (result.result) {
+      const raw = typeof result.result === 'string' ? result.result : JSON.stringify(result.result);
+      // Strip <internal>...</internal> blocks — agent uses these for internal reasoning
+      const text = raw.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
+      logger.info({ group: group.name }, `Agent output: ${raw.slice(0, 200)}`);
+      if (text) {
+        await channel.sendMessage(chatJid, text);
+        outputSentToUser = true;
+      }
+      // Only reset idle timer on actual results, not session-update markers (result: null)
+      resetIdleTimer();
+    }
+
+    if (result.status === 'success') {
+      queue.notifyIdle(chatJid);
+    }
+
+    if (result.status === 'error') {
+      hadError = true;
+    }
+  });
+
+  await channel.setTyping?.(chatJid, false);
+  if (idleTimer) clearTimeout(idleTimer);
+
+  if (output === 'error' || hadError) {
+    // If we already sent output to the user, don't roll back the cursor —
+    // the user got their response and re-processing would send duplicates.
+    if (outputSentToUser) {
+      logger.warn({ group: group.name }, 'Agent error after output was sent, skipping cursor rollback to prevent duplicates');
+      return true;
+    }
+    // Roll back cursor so retries can re-process these messages
+    lastAgentTimestamp[chatJid] = previousCursor;
+    saveState();
+    logger.warn({ group: group.name }, 'Agent error, rolled back message cursor for retry');
+    return false;
+  }
+
+  return true;
+}
+
+async function runAgent(
+  group: RegisteredGroup,
+  prompt: string,
+  chatJid: string,
+  onOutput?: (output: ContainerOutput) => Promise<void>,
+): Promise<'success' | 'error'> {
+  const isMain = group.folder === MAIN_GROUP_FOLDER;
+  const sessionId = sessions[group.folder];
+
+  // Update tasks snapshot for container to read (filtered by group)
+  const tasks = getAllTasks();
+  writeTasksSnapshot(
+    group.folder,
+    isMain,
+    tasks.map((t) => ({
+      id: t.id,
+      groupFolder: t.group_folder,
+      prompt: t.prompt,
+      schedule_type: t.schedule_type,
+      schedule_value: t.schedule_value,
+      status: t.status,
+      next_run: t.next_run,
+    })),
+  );
+
+  // Update available groups snapshot (main group only can see all groups)
+  const availableGroups = getAvailableGroups();
+  writeGroupsSnapshot(
+    group.folder,
+    isMain,
+    availableGroups,
+    new Set(Object.keys(registeredGroups)),
+  );
+
+  // Wrap onOutput to track session ID from streamed results
+  const wrappedOnOutput = onOutput
+    ? async (output: ContainerOutput) => {
+        if (output.newSessionId) {
+          sessions[group.folder] = output.newSessionId;
+          setSession(group.folder, output.newSessionId);
+        }
+        await onOutput(output);
+      }
+    : undefined;
+
+  try {
+    const output = await runContainerAgent(
+      group,
+      {
+        prompt,
+        sessionId,
+        groupFolder: group.folder,
+        chatJid,
+        isMain,
+        assistantName: ASSISTANT_NAME,
+      },
+      (proc, containerName) => queue.registerProcess(chatJid, proc, containerName, group.folder),
+      wrappedOnOutput,
+    );
+
+    if (output.newSessionId) {
+      sessions[group.folder] = output.newSessionId;
+      setSession(group.folder, output.newSessionId);
+    }
+
+    if (output.status === 'error') {
+      logger.error(
+        { group: group.name, error: output.error },
+        'Container agent error',
+      );
+      return 'error';
+    }
+
+    return 'success';
+  } catch (err) {
+    logger.error({ group: group.name, err }, 'Agent error');
+    return 'error';
+  }
+}
+
+async function startMessageLoop(): Promise<void> {
+  if (messageLoopRunning) {
+    logger.debug('Message loop already running, skipping duplicate start');
+    return;
+  }
+  messageLoopRunning = true;
+
+  logger.info(`NanoClaw running (trigger: @${ASSISTANT_NAME})`);
+
+  while (true) {
+    try {
+      const jids = Object.keys(registeredGroups);
+      const { messages, newTimestamp } = getNewMessages(jids, lastTimestamp, ASSISTANT_NAME);
+
+      if (messages.length > 0) {
+        logger.info({ count: messages.length }, 'New messages');
+
+        // Advance the "seen" cursor for all messages immediately
+        lastTimestamp = newTimestamp;
+        saveState();
+
+        // Deduplicate by group
+        const messagesByGroup = new Map<string, NewMessage[]>();
+        for (const msg of messages) {
+          const existing = messagesByGroup.get(msg.chat_jid);
+          if (existing) {
+            existing.push(msg);
+          } else {
+            messagesByGroup.set(msg.chat_jid, [msg]);
+          }
+        }
+
+        for (const [chatJid, groupMessages] of messagesByGroup) {
+          const group = registeredGroups[chatJid];
+          if (!group) continue;
+
+          const channel = findChannel(channels, chatJid);
+          if (!channel) {
+            console.log(`Warning: no channel owns JID ${chatJid}, skipping messages`);
+            continue;
+          }
+
+          const isMainGroup = group.folder === MAIN_GROUP_FOLDER;
+          const needsTrigger = !isMainGroup && group.requiresTrigger !== false;
+
+          // For non-main groups, only act on trigger messages.
+          // Non-trigger messages accumulate in DB and get pulled as
+          // context when a trigger eventually arrives.
+          if (needsTrigger) {
+            const hasTrigger = groupMessages.some((m) =>
+              TRIGGER_PATTERN.test(m.content.trim()),
+            );
+            if (!hasTrigger) continue;
+          }
+
+          // Pull all messages since lastAgentTimestamp so non-trigger
+          // context that accumulated between triggers is included.
+          const allPending = getMessagesSince(
+            chatJid,
+            lastAgentTimestamp[chatJid] || '',
+            ASSISTANT_NAME,
+          );
+          const messagesToSend =
+            allPending.length > 0 ? allPending : groupMessages;
+          const formatted = formatMessages(messagesToSend);
+
+          if (queue.sendMessage(chatJid, formatted)) {
+            logger.debug(
+              { chatJid, count: messagesToSend.length },
+              'Piped messages to active container',
+            );
+            lastAgentTimestamp[chatJid] =
+              messagesToSend[messagesToSend.length - 1].timestamp;
+            saveState();
+            // Show typing indicator while the container processes the piped message
+            channel.setTyping?.(chatJid, true)?.catch((err) =>
+              logger.warn({ chatJid, err }, 'Failed to set typing indicator'),
+            );
+          } else {
+            // No active container — enqueue for a new one
+            queue.enqueueMessageCheck(chatJid);
+          }
+        }
+      }
+    } catch (err) {
+      logger.error({ err }, 'Error in message loop');
+    }
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL));
+  }
+}
+
+/**
+ * Startup recovery: check for unprocessed messages in registered groups.
+ * Handles crash between advancing lastTimestamp and processing messages.
+ */
+function recoverPendingMessages(): void {
+  for (const [chatJid, group] of Object.entries(registeredGroups)) {
+    const sinceTimestamp = lastAgentTimestamp[chatJid] || '';
+    const pending = getMessagesSince(chatJid, sinceTimestamp, ASSISTANT_NAME);
+    if (pending.length > 0) {
+      logger.info(
+        { group: group.name, pendingCount: pending.length },
+        'Recovery: found unprocessed messages',
+      );
+      queue.enqueueMessageCheck(chatJid);
+    }
+  }
+}
+
+function ensureContainerSystemRunning(): void {
+  ensureContainerRuntimeRunning();
+  cleanupOrphans();
+}
+
+async function main(): Promise<void> {
+  ensureContainerSystemRunning();
+  initDatabase();
+  logger.info('Database initialized');
+  loadState();
+
+  // Graceful shutdown handlers
+  const shutdown = async (signal: string) => {
+    logger.info({ signal }, 'Shutdown signal received');
+    await queue.shutdown(10000);
+    for (const ch of channels) await ch.disconnect();
+    process.exit(0);
+  };
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+  process.on('SIGINT', () => shutdown('SIGINT'));
+
+  // Channel callbacks (shared by all channels)
+  const channelOpts = {
+    onMessage: (_chatJid: string, msg: NewMessage) => storeMessage(msg),
+    onChatMetadata: (chatJid: string, timestamp: string, name?: string, channel?: string, isGroup?: boolean) =>
+      storeChatMetadata(chatJid, timestamp, name, channel, isGroup),
+    registeredGroups: () => registeredGroups,
+  };
+
+  // Create and connect channels
+  if (SLACK_BOT_TOKEN && SLACK_APP_TOKEN) {
+    const slack = new SlackChannel(SLACK_BOT_TOKEN, SLACK_APP_TOKEN, channelOpts);
+    channels.push(slack);
+    await slack.connect();
+  }
+
+  if (TELEGRAM_BOT_TOKEN) {
+    const telegram = new TelegramChannel(TELEGRAM_BOT_TOKEN, channelOpts);
+    channels.push(telegram);
+    await telegram.connect();
+  }
+
+  if (!TELEGRAM_ONLY && !SLACK_ONLY) {
+    whatsapp = new WhatsAppChannel(channelOpts);
+    channels.push(whatsapp);
+    await whatsapp.connect();
+  }
+
+  // Start subsystems (independently of connection handler)
+  startSchedulerLoop({
+    registeredGroups: () => registeredGroups,
+    getSessions: () => sessions,
+    queue,
+    onProcess: (groupJid, proc, containerName, groupFolder) => queue.registerProcess(groupJid, proc, containerName, groupFolder),
+    sendMessage: async (jid, rawText) => {
+      const channel = findChannel(channels, jid);
+      if (!channel) {
+        console.log(`Warning: no channel owns JID ${jid}, cannot send message`);
+        return;
+      }
+      const text = formatOutbound(rawText);
+      if (text) await channel.sendMessage(jid, text);
+    },
+  });
+  startIpcWatcher({
+    sendMessage: (jid, text) => {
+      const channel = findChannel(channels, jid);
+      if (!channel) throw new Error(`No channel for JID: ${jid}`);
+      return channel.sendMessage(jid, text);
+    },
+    registeredGroups: () => registeredGroups,
+    registerGroup,
+    syncGroupMetadata: (force) => whatsapp?.syncGroupMetadata(force) ?? Promise.resolve(),
+    getAvailableGroups,
+    writeGroupsSnapshot: (gf, im, ag, rj) => writeGroupsSnapshot(gf, im, ag, rj),
+  });
+  queue.setProcessMessagesFn(processGroupMessages);
+  recoverPendingMessages();
+  startMessageLoop().catch((err) => {
+    logger.fatal({ err }, 'Message loop crashed unexpectedly');
+    process.exit(1);
+  });
+}
+
+// Guard: only run when executed directly, not when imported by tests
+const isDirectRun =
+  process.argv[1] &&
+  new URL(import.meta.url).pathname === new URL(`file://${process.argv[1]}`).pathname;
+
+if (isDirectRun) {
+  main().catch((err) => {
+    logger.error({ err }, 'Failed to start NanoClaw');
+    process.exit(1);
+  });
+}

--- a/.claude/skills/add-slack/modify/src/index.ts.intent.md
+++ b/.claude/skills/add-slack/modify/src/index.ts.intent.md
@@ -1,0 +1,41 @@
+# Intent: src/index.ts modifications
+
+## What changed
+Added Slack channel support to the multi-channel architecture.
+
+## Key sections
+
+### Imports (top of file)
+- Added: `SlackChannel` from `./channels/slack.js`
+- Added: `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, `SLACK_ONLY` from `./config.js`
+
+### main() - Channel creation
+- Added: Slack channel creation block before Telegram:
+  ```typescript
+  if (SLACK_BOT_TOKEN && SLACK_APP_TOKEN) {
+    const slack = new SlackChannel(SLACK_BOT_TOKEN, SLACK_APP_TOKEN, channelOpts);
+    channels.push(slack);
+    await slack.connect();
+  }
+  ```
+- Note: Both `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN` are required for Slack (Socket Mode needs both)
+
+### main() - WhatsApp conditional
+- Changed: `if (!TELEGRAM_ONLY)` → `if (!TELEGRAM_ONLY && !SLACK_ONLY)`
+- This allows SLACK_ONLY=true to disable WhatsApp just like TELEGRAM_ONLY does
+
+## Invariants
+- All existing message processing logic is preserved
+- Channel ordering: Slack first, then Telegram, then WhatsApp (order matters for initialization logs)
+- The `runAgent` function is unchanged
+- State management (loadState/saveState) is unchanged
+- Recovery logic is unchanged
+- findChannel() routing uses ownsJid() which each channel implements
+
+## Must-keep
+- The `escapeXml` and `formatMessages` re-exports
+- The `_setRegisteredGroups` test helper
+- The `isDirectRun` guard at bottom
+- All error handling and cursor rollback logic in processGroupMessages
+- The shared `channelOpts` pattern for all channels
+- Graceful shutdown that disconnects all channels

--- a/.claude/skills/add-slack/modify/src/routing.test.ts
+++ b/.claude/skills/add-slack/modify/src/routing.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { _initTestDatabase, getAllChats, storeChatMetadata } from './db.js';
+import { getAvailableGroups, _setRegisteredGroups } from './index.js';
+
+beforeEach(() => {
+  _initTestDatabase();
+  _setRegisteredGroups({});
+});
+
+// --- JID ownership patterns ---
+
+describe('JID ownership patterns', () => {
+  // These test the patterns that will become ownsJid() on the Channel interface
+
+  it('WhatsApp group JID: ends with @g.us', () => {
+    const jid = '12345678@g.us';
+    expect(jid.endsWith('@g.us')).toBe(true);
+  });
+
+  it('WhatsApp DM JID: ends with @s.whatsapp.net', () => {
+    const jid = '12345678@s.whatsapp.net';
+    expect(jid.endsWith('@s.whatsapp.net')).toBe(true);
+  });
+
+  it('Telegram JID: starts with tg:', () => {
+    const jid = 'tg:123456789';
+    expect(jid.startsWith('tg:')).toBe(true);
+  });
+
+  it('Telegram group JID: starts with tg: and has negative ID', () => {
+    const jid = 'tg:-1001234567890';
+    expect(jid.startsWith('tg:')).toBe(true);
+  });
+
+  it('Slack JID: starts with slack:', () => {
+    const jid = 'slack:C1234567890';
+    expect(jid.startsWith('slack:')).toBe(true);
+  });
+
+  it('Slack DM JID: starts with slack:D', () => {
+    const jid = 'slack:D_DM_123';
+    expect(jid.startsWith('slack:')).toBe(true);
+  });
+});
+
+// --- getAvailableGroups ---
+
+describe('getAvailableGroups', () => {
+  it('returns only groups, excludes DMs', () => {
+    storeChatMetadata('group1@g.us', '2024-01-01T00:00:01.000Z', 'Group 1', 'whatsapp', true);
+    storeChatMetadata('user@s.whatsapp.net', '2024-01-01T00:00:02.000Z', 'User DM', 'whatsapp', false);
+    storeChatMetadata('group2@g.us', '2024-01-01T00:00:03.000Z', 'Group 2', 'whatsapp', true);
+
+    const groups = getAvailableGroups();
+    expect(groups).toHaveLength(2);
+    expect(groups.map((g) => g.jid)).toContain('group1@g.us');
+    expect(groups.map((g) => g.jid)).toContain('group2@g.us');
+    expect(groups.map((g) => g.jid)).not.toContain('user@s.whatsapp.net');
+  });
+
+  it('excludes __group_sync__ sentinel', () => {
+    storeChatMetadata('__group_sync__', '2024-01-01T00:00:00.000Z');
+    storeChatMetadata('group@g.us', '2024-01-01T00:00:01.000Z', 'Group', 'whatsapp', true);
+
+    const groups = getAvailableGroups();
+    expect(groups).toHaveLength(1);
+    expect(groups[0].jid).toBe('group@g.us');
+  });
+
+  it('marks registered groups correctly', () => {
+    storeChatMetadata('reg@g.us', '2024-01-01T00:00:01.000Z', 'Registered', 'whatsapp', true);
+    storeChatMetadata('unreg@g.us', '2024-01-01T00:00:02.000Z', 'Unregistered', 'whatsapp', true);
+
+    _setRegisteredGroups({
+      'reg@g.us': {
+        name: 'Registered',
+        folder: 'registered',
+        trigger: '@Andy',
+        added_at: '2024-01-01T00:00:00.000Z',
+      },
+    });
+
+    const groups = getAvailableGroups();
+    const reg = groups.find((g) => g.jid === 'reg@g.us');
+    const unreg = groups.find((g) => g.jid === 'unreg@g.us');
+
+    expect(reg?.isRegistered).toBe(true);
+    expect(unreg?.isRegistered).toBe(false);
+  });
+
+  it('returns groups ordered by most recent activity', () => {
+    storeChatMetadata('old@g.us', '2024-01-01T00:00:01.000Z', 'Old', 'whatsapp', true);
+    storeChatMetadata('new@g.us', '2024-01-01T00:00:05.000Z', 'New', 'whatsapp', true);
+    storeChatMetadata('mid@g.us', '2024-01-01T00:00:03.000Z', 'Mid', 'whatsapp', true);
+
+    const groups = getAvailableGroups();
+    expect(groups[0].jid).toBe('new@g.us');
+    expect(groups[1].jid).toBe('mid@g.us');
+    expect(groups[2].jid).toBe('old@g.us');
+  });
+
+  it('excludes non-group chats regardless of JID format', () => {
+    // Unknown JID format stored without is_group should not appear
+    storeChatMetadata('unknown-format-123', '2024-01-01T00:00:01.000Z', 'Unknown');
+    // Explicitly non-group with unusual JID
+    storeChatMetadata('custom:abc', '2024-01-01T00:00:02.000Z', 'Custom DM', 'custom', false);
+    // A real group for contrast
+    storeChatMetadata('group@g.us', '2024-01-01T00:00:03.000Z', 'Group', 'whatsapp', true);
+
+    const groups = getAvailableGroups();
+    expect(groups).toHaveLength(1);
+    expect(groups[0].jid).toBe('group@g.us');
+  });
+
+  it('returns empty array when no chats exist', () => {
+    const groups = getAvailableGroups();
+    expect(groups).toHaveLength(0);
+  });
+
+  it('includes Telegram chat JIDs', () => {
+    storeChatMetadata('tg:100200300', '2024-01-01T00:00:01.000Z', 'Telegram Chat', 'telegram', true);
+    storeChatMetadata('user@s.whatsapp.net', '2024-01-01T00:00:02.000Z', 'User DM', 'whatsapp', false);
+
+    const groups = getAvailableGroups();
+    expect(groups).toHaveLength(1);
+    expect(groups[0].jid).toBe('tg:100200300');
+  });
+
+  it('returns Telegram group JIDs with negative IDs', () => {
+    storeChatMetadata('tg:-1001234567890', '2024-01-01T00:00:01.000Z', 'TG Group', 'telegram', true);
+
+    const groups = getAvailableGroups();
+    expect(groups).toHaveLength(1);
+    expect(groups[0].jid).toBe('tg:-1001234567890');
+    expect(groups[0].name).toBe('TG Group');
+  });
+
+  it('marks registered Telegram chats correctly', () => {
+    storeChatMetadata('tg:100200300', '2024-01-01T00:00:01.000Z', 'TG Registered', 'telegram', true);
+    storeChatMetadata('tg:999999', '2024-01-01T00:00:02.000Z', 'TG Unregistered', 'telegram', true);
+
+    _setRegisteredGroups({
+      'tg:100200300': {
+        name: 'TG Registered',
+        folder: 'tg-registered',
+        trigger: '@Andy',
+        added_at: '2024-01-01T00:00:00.000Z',
+      },
+    });
+
+    const groups = getAvailableGroups();
+    const tgReg = groups.find((g) => g.jid === 'tg:100200300');
+    const tgUnreg = groups.find((g) => g.jid === 'tg:999999');
+
+    expect(tgReg?.isRegistered).toBe(true);
+    expect(tgUnreg?.isRegistered).toBe(false);
+  });
+
+  it('mixes WhatsApp and Telegram chats ordered by activity', () => {
+    storeChatMetadata('wa@g.us', '2024-01-01T00:00:01.000Z', 'WhatsApp', 'whatsapp', true);
+    storeChatMetadata('tg:100', '2024-01-01T00:00:03.000Z', 'Telegram', 'telegram', true);
+    storeChatMetadata('wa2@g.us', '2024-01-01T00:00:02.000Z', 'WhatsApp 2', 'whatsapp', true);
+
+    const groups = getAvailableGroups();
+    expect(groups).toHaveLength(3);
+    expect(groups[0].jid).toBe('tg:100');
+    expect(groups[1].jid).toBe('wa2@g.us');
+    expect(groups[2].jid).toBe('wa@g.us');
+  });
+
+  it('includes Slack channel JIDs', () => {
+    storeChatMetadata('slack:C_TEST_123', '2024-01-01T00:00:01.000Z', 'Slack Channel', 'slack', true);
+    storeChatMetadata('user@s.whatsapp.net', '2024-01-01T00:00:02.000Z', 'User DM', 'whatsapp', false);
+
+    const groups = getAvailableGroups();
+    expect(groups).toHaveLength(1);
+    expect(groups[0].jid).toBe('slack:C_TEST_123');
+  });
+
+  it('marks registered Slack channels correctly', () => {
+    storeChatMetadata('slack:C_REG', '2024-01-01T00:00:01.000Z', 'Slack Registered', 'slack', true);
+    storeChatMetadata('slack:C_UNREG', '2024-01-01T00:00:02.000Z', 'Slack Unregistered', 'slack', true);
+
+    _setRegisteredGroups({
+      'slack:C_REG': {
+        name: 'Slack Registered',
+        folder: 'slack-registered',
+        trigger: '@Andy',
+        added_at: '2024-01-01T00:00:00.000Z',
+      },
+    });
+
+    const groups = getAvailableGroups();
+    const slackReg = groups.find((g) => g.jid === 'slack:C_REG');
+    const slackUnreg = groups.find((g) => g.jid === 'slack:C_UNREG');
+
+    expect(slackReg?.isRegistered).toBe(true);
+    expect(slackUnreg?.isRegistered).toBe(false);
+  });
+
+  it('mixes WhatsApp, Telegram, and Slack chats ordered by activity', () => {
+    storeChatMetadata('wa@g.us', '2024-01-01T00:00:01.000Z', 'WhatsApp', 'whatsapp', true);
+    storeChatMetadata('slack:C_SLACK', '2024-01-01T00:00:04.000Z', 'Slack', 'slack', true);
+    storeChatMetadata('tg:100', '2024-01-01T00:00:03.000Z', 'Telegram', 'telegram', true);
+    storeChatMetadata('wa2@g.us', '2024-01-01T00:00:02.000Z', 'WhatsApp 2', 'whatsapp', true);
+
+    const groups = getAvailableGroups();
+    expect(groups).toHaveLength(4);
+    expect(groups[0].jid).toBe('slack:C_SLACK');
+    expect(groups[1].jid).toBe('tg:100');
+    expect(groups[2].jid).toBe('wa2@g.us');
+    expect(groups[3].jid).toBe('wa@g.us');
+  });
+
+  it('excludes Slack DMs (is_group=false)', () => {
+    storeChatMetadata('slack:D_DM_123', '2024-01-01T00:00:01.000Z', 'Slack DM', 'slack', false);
+    storeChatMetadata('slack:C_CHANNEL', '2024-01-01T00:00:02.000Z', 'Slack Channel', 'slack', true);
+
+    const groups = getAvailableGroups();
+    expect(groups).toHaveLength(1);
+    expect(groups[0].jid).toBe('slack:C_CHANNEL');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `/add-slack` skill for Slack channel integration via @slack/bolt (Socket Mode)
- JID format: `slack:<channel-id>`
- Includes 42 unit tests
- No public URL required (uses WebSocket connection)

## Features
- Socket Mode connection with app-level token
- Mention translation (`<@botUserId>` → trigger format)
- Message splitting for 4000 char limit
- File/image handling with placeholders

## Usage
```bash
npx tsx scripts/apply-skill.ts .claude/skills/add-slack
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)