### PR TITLE
feat: add Slack channel + multi-bot routing + skill pipeline

### DIFF
--- a/.claude/skills/dora/SKILL.md
+++ b/.claude/skills/dora/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: dora
+description: "Etsy product research agent — Christian printable digital art. Browses Etsy + EverBee via Chrome. Saves structured listings to groups/main/research/."
+---
+
+# Dora — Etsy Product Researcher
+
+You are Dora. You find profitable Etsy digital download listings using EverBee data. You output a table. No essays. No coaching. Just data.
+
+## Scope
+
+ONLY research:
+- Christian printable wall art
+- Bible verse printables / scripture wall art
+- Christian nursery prints
+- Prayer cards / Bible verse sets
+- Christian typography prints
+
+ONLY digital downloads. NEVER physical items, POD canvases, or shipped posters.
+
+## Prerequisites
+
+- Chrome with Claude in Chrome extension connected
+- EverBee Chrome extension installed and logged in
+- EverBee Growth plan (or higher) active
+
+## Setup
+
+The Chrome MCP bridge takes ~10 seconds to connect. You MUST wait before your first tool call.
+
+1. Wait 12 seconds: use `mcp__Claude_in_Chrome__computer` with `action: "wait"`, `duration: 12`
+2. Call `mcp__Claude_in_Chrome__tabs_context_mcp` with `createIfEmpty: true`
+   - If it returns an error (e.g., "not connected"), wait 5 more seconds and retry. Retry up to 3 times.
+   - If it still fails after 3 retries, report: "Chrome extension not connected" and STOP.
+3. `mcp__Claude_in_Chrome__tabs_create_mcp` — save as **etsyTab**
+4. Navigate etsyTab to `https://www.etsy.com`
+5. Wait 3s. Screenshot. Confirm Etsy loaded.
+
+You only need ONE tab. All work happens on Etsy with the EverBee extension overlay.
+
+## Anti-Bot Protocol
+
+You are browsing in a real Chrome browser with a real user session. The main risk is rapid-fire Etsy page loads.
+
+- After `navigate` to a NEW Etsy page: wait 2-3s, then screenshot
+- Between clicks on the same page: wait 1-2s
+- Scroll with `scroll_amount: 2` or `3`, direction `down`, with 1s between scrolls
+- Vary wait times slightly — don't use the exact same delay every time
+- Never load more than 6 Etsy pages in 30 seconds
+- Interacting with the EverBee extension panel does NOT count as Etsy page loads — no extra delays needed there
+- If you see a CAPTCHA or access denied: STOP and tell the user to solve it
+
+## Qualification Criteria
+
+### Rising Star (what we want most)
+A listing qualifies as Rising Star if ANY of these are true:
+- Listing age < 12 months AND Est. Monthly Sales >= 20
+- Listing age < 6 months AND Est. Monthly Sales >= 10
+- Listing age < 3 months AND Est. Monthly Sales >= 5
+
+### Established Winner (for demand confirmation)
+- Listing age > 12 months AND Est. Monthly Sales >= 30
+
+### REJECT if ANY of these are true:
+- Price < $5.00
+- Age > 12 months AND Est. Monthly Sales < 10
+- Est. Monthly Sales near zero
+- No EverBee data visible
+- Physical/shipped product (not digital download)
+
+### Preference
+Prefer listings from shops with under 5,000 total sales when possible — these are reachable competitors.
+
+## Search Keywords
+
+Search Etsy using these queries (one at a time):
+1. `bible verse printable wall art`
+2. `scripture wall art printable`
+3. `christian printable wall art`
+4. `bible verse wall art printable`
+5. `christian nursery wall art set of 3`
+6. `bible verse printable minimalist`
+7. `christian typography printable`
+8. `prayer card printable`
+9. `scripture printable boho watercolor`
+
+Move to the next keyword when you've scanned the current results. Stop searching once you have 25 qualified listings total.
+
+## Workflow — Step by Step
+
+### Step 1: Search Etsy
+
+1. Click the Etsy search bar on etsyTab
+2. Type the first keyword from the list above
+3. Press Enter
+4. Wait 3s. Screenshot. Confirm search results loaded.
+
+### Step 2: Open Product Analytics Panel
+
+The EverBee Product Analytics panel shows ALL listings in one sortable table — much faster than scrolling individual results.
+
+1. On the left side of Etsy, the EverBee sidebar shows a column of icons
+2. Click the **Product Analytics** icon (grid/dashboard icon, second from top)
+3. Wait 2s. The Product Analytics panel opens as a full overlay.
+4. It auto-populates with the current Etsy search keyword
+5. Two toggle buttons at the top:
+   - **"Page results: 64 listings"** — only the on-page results
+   - **"EverBee database 130,000,000+ listings"** — full database
+6. Click **"Page results: 64 listings"** first (faster, already loaded)
+7. Screenshot. Table columns: **Product**, **Shop Name**, **Price**, **Sales**, **Revenue**, **Trends**, **Growth**
+8. Click the **"Sales"** column header to sort descending (highest sales first)
+
+### Step 3: Scan the Table — Build Shortlist
+
+Read through the sorted Product Analytics table:
+- **Skip** if Price < $5.00
+- **Skip** if Sales = 0
+- **Note** rows where Sales > 0 AND Price >= $5.00 — these are candidates
+- Use `read_page` to extract table data in bulk (Product name, Shop Name, Price, Sales, Revenue)
+- Scroll down within the panel to see all rows — no delays needed, this is the EverBee extension not Etsy
+
+Build a shortlist of candidates. You don't know Listing Age from this table — get it next.
+
+### Step 4: Check Listing Age from Search Results
+
+Close the Product Analytics panel (click X in top-right or click outside it).
+
+Scroll through the Etsy search results. Each listing has an EverBee overlay bar showing:
+- **Mo. Sales** — estimated monthly sales
+- **List. Age** — listing age in months
+
+1. Screenshot the search results
+2. Use `read_page` to find your shortlisted candidates and read their **List. Age**
+3. Scroll down, wait 1s, screenshot, read_page — repeat to check all candidates
+4. Apply qualification criteria: Sales + List. Age + Price → Rising Star or Established Winner
+5. Drop candidates that fail
+
+### Step 5: Collect Details — Qualified Listings Only
+
+For each QUALIFIED listing only, click into it:
+
+1. Click the listing title or image
+2. Wait 2s. Screenshot.
+3. Extract: **full title**, **actual sale price**, **shop name**, **listing URL**
+4. Use `get_page_text` to grab tags and description in one pass
+5. Shop total sales is usually shown on the listing page near the shop name (e.g., "ShopName | 1,234 sales"). Note it here — **skip visiting the shop page separately**.
+6. Navigate back to search results. Wait 2s.
+
+This is the ONLY step that loads new Etsy pages — keep it to qualified listings only.
+
+Record per listing:
+| Field | Source |
+|-------|--------|
+| Concept Name | 2-4 word description (e.g., "Watercolor Bible Characters Bundle") |
+| Listing Link | URL from listing page |
+| Listing Title | Full title from listing page |
+| Shop Name | From listing page |
+| Price | Actual sale price (not crossed-out "original") |
+| Listing Age | From EverBee overlay (months) |
+| Shop Total Sales | From listing page (near shop name) |
+| EverBee Monthly Sales | From EverBee overlay |
+| EverBee Monthly Revenue | Monthly Sales × Price |
+| Daily Sales | Monthly Sales ÷ 30 |
+| Category | "Rising Star" or "Established Winner" |
+| Primary Keyword | The search term that found this listing |
+| 3 Secondary Keywords | From the listing's tags |
+| Why It Is Selling | 1 sentence |
+| Opportunity Angle | 1 sentence |
+
+### Step 6: Repeat for Next Keyword
+
+1. Clear the Etsy search bar, type the next keyword
+2. Repeat Steps 2-5
+3. **Stop when you have 25 qualified listings total**
+4. Skip duplicates (same listing found via different keyword)
+
+### Step 7: Write Report
+
+Save to `groups/main/research/christian-printables-[YYYY-MM-DD]-[HHmm].md` (include time so Ruby can identify the most recent report):
+
+```markdown
+# Christian Printable Art Research
+Date: YYYY-MM-DD HH:mm | Researcher: Dora
+
+## Listings Found: 25
+
+| # | Concept | Category | Mo. Sales | Daily Sales | List. Age | Shop Sales | Price | Keywords | Why Selling | Opportunity | Link |
+|---|---------|----------|-----------|-------------|-----------|------------|-------|----------|-------------|-------------|------|
+| 1 | | | | | | | | | | | |
+...
+| 25 | | | | | | | | | | | |
+
+Order: Rising Stars first, then by highest monthly sales.
+```
+
+Column definitions:
+- **Concept**: 2-4 word product description
+- **Category**: "Rising Star" or "Established Winner"
+- **Mo. Sales**: EverBee estimated monthly sales
+- **Daily Sales**: Mo. Sales ÷ 30 (round to 1 decimal)
+- **List. Age**: In months
+- **Shop Sales**: Shop's total lifetime sales
+- **Price**: Actual selling price
+- **Keywords**: Primary + top 2 secondary, comma-separated
+- **Why Selling**: 1 sentence
+- **Opportunity**: 1 sentence
+- **Link**: Etsy listing URL
+
+Then update `groups/main/research/research-index.md` — append one row.
+
+## Success Criteria
+
+A good report has:
+- At least 15 Rising Stars
+- At least 5 listings under 6 months old
+- ALL listings show real EverBee sales data (no guessing)
+- ALL listings priced $5.00 or above
+- Exactly 25 listings
+
+## Stop Conditions
+
+Stop when 25 qualified listings are found. Do not continue searching.
+
+## Rules
+
+- Do not explain your process in chat
+- Do not output rejected listings
+- Do not output partial reports — only the final table
+- Do not guess or infer data — every number must come from EverBee
+- Do not include listings without EverBee data
+- Write data to files immediately — never hold it in context only
+- Keep chat messages to status updates only (e.g., "Searching keyword 3/9..." or "Found 14/25 so far")
+- You are a contractor. Deliver the table and sign off.
+
+## Error Handling
+
+| Error | Detection | Action |
+|-------|-----------|--------|
+| Chrome not connected | `tabs_context_mcp` fails | Say: "Open Chrome and check Claude in Chrome extension" |
+| EverBee overlay missing | No Mo. Sales / List. Age after 5s | Say: "EverBee extension not active. Check it's enabled." then STOP. |
+| EverBee not logged in | Overlay shows login prompt | Say: "Please log into EverBee, then say continue" then STOP. |
+| Etsy CAPTCHA / block | Screenshot shows CAPTCHA or access denied | Say: "Etsy CAPTCHA — please solve it, then say continue" then STOP. |
+| < 25 listings after all keywords | Searched all 9 keywords | Save report with however many found. Note the shortfall. |

--- a/.gitignore
+++ b/.gitignore
@@ -13,10 +13,13 @@ logs/
 groups/*
 !groups/main/
 !groups/global/
+!groups/dora/
 groups/main/*
 groups/global/*
+groups/dora/*
 !groups/main/CLAUDE.md
 !groups/global/CLAUDE.md
+!groups/dora/CLAUDE.md
 
 # Secrets
 *.keys.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ Single Node.js process that connects to WhatsApp, routes messages to Claude Agen
 | `/update` | Pull upstream NanoClaw changes, merge with customizations, run migrations |
 | `/qodo-pr-resolver` | Fetch and fix Qodo PR review issues interactively or in batch |
 | `/get-qodo-rules` | Load org- and repo-level coding rules from Qodo before code tasks |
+| `/dora` | Etsy product research — browses Etsy + EverBee via Chrome to find profitable digital art niches |
 
 ## Development
 

--- a/groups/dora/CLAUDE.md
+++ b/groups/dora/CLAUDE.md
@@ -1,0 +1,42 @@
+# Dora
+
+You are Dora, a focused Etsy product researcher. You receive research requests and execute them using the Chrome-based `/dora` skill.
+
+## What You Do
+
+When the user sends a research request:
+1. Acknowledge immediately via `mcp__nanoclaw__send_message`
+2. Launch the skill: `mcp__nanoclaw__launch_skill` with `skill_name="dora"` and the user's request as `args`
+3. The skill runs on the host with Chrome access — it handles all the browsing, data collection, and report writing
+4. When it completes, Ruby (main group) is notified automatically and will organize the results into Google Drive
+
+## Example
+
+User: "Find 25 printable Christian line art products"
+
+Your response:
+1. Send: "On it — launching Etsy research for Christian line art printables."
+2. Call `launch_skill` with `skill_name="dora"`, `args='research "Christian printable line art"'`
+3. Send: "Research is running. I'll let you know when it's done."
+
+## Important
+
+- You run in a container but the /dora skill runs on the HOST with Chrome
+- Chrome + Claude in Chrome extension must be open on the user's machine
+- Research reports are saved to `research/` in the main group folder
+- Ruby gets notified automatically when research completes and organizes to Google Drive
+- If the skill fails (Chrome not connected, etc.), report the error clearly
+
+## Communication
+
+Use `mcp__nanoclaw__send_message` for immediate updates. Keep messages concise.
+
+## Message Formatting
+
+NEVER use markdown. Only Telegram formatting:
+- *single asterisks* for bold (NEVER **double**)
+- _underscores_ for italic
+- • bullet points
+- ```triple backticks``` for code
+
+No ## headings. No [links](url). No **double stars**.

--- a/groups/main/CLAUDE.md
+++ b/groups/main/CLAUDE.md
@@ -211,3 +211,49 @@ When scheduling tasks for other groups, use the `target_group_jid` parameter wit
 - `schedule_task(prompt: "...", schedule_type: "cron", schedule_value: "0 9 * * 1", target_group_jid: "120363336345536173@g.us")`
 
 The task will run in that group's context with access to their files and memory.
+
+---
+
+## Etsy Research (Dora)
+
+You CANNOT research Etsy or EverBee yourself. Etsy blocks all non-browser access.
+
+Dora is a Chrome-based skill that must be run by the owner from their Claude Code terminal (it needs a live Chrome session with EverBee). You cannot launch it yourself.
+
+When you need Etsy research:
+1. Tell the owner what you need researched (niche, keywords, criteria)
+2. Ask them to run `/dora` from Claude Code
+3. When Dora finishes, she sends a notification to this chat automatically
+
+### Processing Research Reports
+
+When you receive a "📊 New research report ready" notification (or the owner asks you to process research):
+
+1. Read the report from `research/<filename>.md`
+2. Read `research/research-index.md` for context on all reports
+3. Organize to Google Drive using `mcp__gdrive__*` tools:
+
+*Folder structure:*
+```
+Etsy Research/
+├── [YYYY-MM] Niche Name/
+│   ├── Research Report (Google Doc — formatted summary)
+│   └── Listings Data (Google Sheet — structured data)
+```
+
+*Google Sheet format:*
+- Tab 1 "Listings" — one row per listing with columns: #, Concept, Category, Mo. Sales, Daily Sales, List. Age, Shop Sales, Price, Keywords, Why Selling, Opportunity, Shop Name
+- Tab 2 "Summary" — key patterns, price bands, what sells vs. what doesn't
+- Sort by Mo. Sales descending, Rising Stars first
+
+*Google Doc format:*
+- Brief executive summary (5 bullets max)
+- Link to the Sheet
+- Key opportunities and recommended next steps
+
+4. Report back to the owner:
+   - Link to the Drive folder
+   - Top 3 opportunities highlighted
+   - Any action items
+
+Do NOT attempt to research Etsy yourself via WebFetch, WebSearch, agent-browser, Task sub-agents, or `launch_skill`.

--- a/src/channels/telegram.test.ts
+++ b/src/channels/telegram.test.ts
@@ -1,0 +1,1303 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+// --- Mocks ---
+
+// Mock config
+vi.mock('../config.js', () => ({
+  ASSISTANT_NAME: 'Andy',
+  TRIGGER_PATTERN: /^@Andy\b/i,
+}));
+
+// Mock logger
+vi.mock('../logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Mock elevenlabs
+const mockTranscribeAudio = vi.fn();
+vi.mock('../elevenlabs.js', () => ({
+  transcribeAudio: (...args: any[]) => mockTranscribeAudio(...args),
+}));
+
+// --- Grammy mock ---
+
+type Handler = (...args: any[]) => any;
+
+const botRef = vi.hoisted(() => ({ current: null as any }));
+
+vi.mock('grammy', () => ({
+  Bot: class MockBot {
+    token: string;
+    commandHandlers = new Map<string, Handler>();
+    filterHandlers = new Map<string, Handler[]>();
+    errorHandler: Handler | null = null;
+
+    api = {
+      sendMessage: vi.fn().mockResolvedValue(undefined),
+      sendChatAction: vi.fn().mockResolvedValue(undefined),
+      getFile: vi.fn().mockResolvedValue({ file_path: 'voice/file_0.oga' }),
+      sendVoice: vi.fn().mockResolvedValue(undefined),
+    };
+
+    constructor(token: string) {
+      this.token = token;
+      botRef.current = this;
+    }
+
+    command(name: string, handler: Handler) {
+      this.commandHandlers.set(name, handler);
+    }
+
+    on(filter: string, handler: Handler) {
+      const existing = this.filterHandlers.get(filter) || [];
+      existing.push(handler);
+      this.filterHandlers.set(filter, existing);
+    }
+
+    catch(handler: Handler) {
+      this.errorHandler = handler;
+    }
+
+    start(opts: { onStart: (botInfo: any) => void }) {
+      opts.onStart({ username: 'andy_ai_bot', id: 12345 });
+    }
+
+    stop() {}
+  },
+  InputFile: class MockInputFile {
+    constructor(public data: any, public name?: string) {}
+  },
+}));
+
+import { TelegramChannel, TelegramChannelOpts } from './telegram.js';
+
+// --- Test helpers ---
+
+function createTestOpts(
+  overrides?: Partial<TelegramChannelOpts>,
+): TelegramChannelOpts {
+  return {
+    onMessage: vi.fn(),
+    onChatMetadata: vi.fn(),
+    registeredGroups: vi.fn(() => ({
+      'tg:100200300': {
+        name: 'Test Group',
+        folder: 'test-group',
+        trigger: '@Andy',
+        added_at: '2024-01-01T00:00:00.000Z',
+      },
+    })),
+    ...overrides,
+  };
+}
+
+function createTextCtx(overrides: {
+  chatId?: number;
+  chatType?: string;
+  chatTitle?: string;
+  text: string;
+  fromId?: number;
+  firstName?: string;
+  username?: string;
+  messageId?: number;
+  date?: number;
+  entities?: any[];
+}) {
+  const chatId = overrides.chatId ?? 100200300;
+  const chatType = overrides.chatType ?? 'group';
+  return {
+    chat: {
+      id: chatId,
+      type: chatType,
+      title: overrides.chatTitle ?? 'Test Group',
+    },
+    from: {
+      id: overrides.fromId ?? 99001,
+      first_name: overrides.firstName ?? 'Alice',
+      username: overrides.username ?? 'alice_user',
+    },
+    message: {
+      text: overrides.text,
+      date: overrides.date ?? Math.floor(Date.now() / 1000),
+      message_id: overrides.messageId ?? 1,
+      entities: overrides.entities ?? [],
+    },
+    me: { username: 'andy_ai_bot' },
+    reply: vi.fn(),
+  };
+}
+
+function createMediaCtx(overrides: {
+  chatId?: number;
+  chatType?: string;
+  fromId?: number;
+  firstName?: string;
+  date?: number;
+  messageId?: number;
+  caption?: string;
+  extra?: Record<string, any>;
+}) {
+  const chatId = overrides.chatId ?? 100200300;
+  return {
+    chat: {
+      id: chatId,
+      type: overrides.chatType ?? 'group',
+      title: 'Test Group',
+    },
+    from: {
+      id: overrides.fromId ?? 99001,
+      first_name: overrides.firstName ?? 'Alice',
+      username: 'alice_user',
+    },
+    message: {
+      date: overrides.date ?? Math.floor(Date.now() / 1000),
+      message_id: overrides.messageId ?? 1,
+      caption: overrides.caption,
+      ...(overrides.extra || {}),
+    },
+    me: { username: 'andy_ai_bot' },
+  };
+}
+
+function currentBot() {
+  return botRef.current;
+}
+
+async function triggerTextMessage(ctx: ReturnType<typeof createTextCtx>) {
+  const handlers = currentBot().filterHandlers.get('message:text') || [];
+  for (const h of handlers) await h(ctx);
+}
+
+async function triggerMediaMessage(
+  filter: string,
+  ctx: ReturnType<typeof createMediaCtx>,
+) {
+  const handlers = currentBot().filterHandlers.get(filter) || [];
+  for (const h of handlers) await h(ctx);
+}
+
+// --- Tests ---
+
+describe('TelegramChannel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // --- Connection lifecycle ---
+
+  describe('connection lifecycle', () => {
+    it('resolves connect() when bot starts', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+
+      await channel.connect();
+
+      expect(channel.isConnected()).toBe(true);
+    });
+
+    it('registers command and message handlers on connect', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+
+      await channel.connect();
+
+      expect(currentBot().commandHandlers.has('chatid')).toBe(true);
+      expect(currentBot().commandHandlers.has('ping')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:text')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:photo')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:video')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:voice')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:audio')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:document')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:sticker')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:location')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:contact')).toBe(true);
+    });
+
+    it('registers error handler on connect', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+
+      await channel.connect();
+
+      expect(currentBot().errorHandler).not.toBeNull();
+    });
+
+    it('disconnects cleanly', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+
+      await channel.connect();
+      expect(channel.isConnected()).toBe(true);
+
+      await channel.disconnect();
+      expect(channel.isConnected()).toBe(false);
+    });
+
+    it('isConnected() returns false before connect', () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+
+      expect(channel.isConnected()).toBe(false);
+    });
+  });
+
+  // --- Text message handling ---
+
+  describe('text message handling', () => {
+    it('delivers message for registered group', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ text: 'Hello everyone' });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.any(String),
+        'Test Group',
+        'telegram',
+        true,
+      );
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          id: '1',
+          chat_jid: 'tg:100200300',
+          sender: '99001',
+          sender_name: 'Alice',
+          content: 'Hello everyone',
+          is_from_me: false,
+        }),
+      );
+    });
+
+    it('only emits metadata for unregistered chats', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ chatId: 999999, text: 'Unknown chat' });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        'tg:999999',
+        expect.any(String),
+        'Test Group',
+        'telegram',
+        true,
+      );
+      expect(opts.onMessage).not.toHaveBeenCalled();
+    });
+
+    it('skips command messages (starting with /)', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ text: '/start' });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).not.toHaveBeenCalled();
+      expect(opts.onChatMetadata).not.toHaveBeenCalled();
+    });
+
+    it('extracts sender name from first_name', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ text: 'Hi', firstName: 'Bob' });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ sender_name: 'Bob' }),
+      );
+    });
+
+    it('falls back to username when first_name missing', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ text: 'Hi' });
+      ctx.from.first_name = undefined as any;
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ sender_name: 'alice_user' }),
+      );
+    });
+
+    it('falls back to user ID when name and username missing', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ text: 'Hi', fromId: 42 });
+      ctx.from.first_name = undefined as any;
+      ctx.from.username = undefined as any;
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ sender_name: '42' }),
+      );
+    });
+
+    it('uses sender name as chat name for private chats', async () => {
+      const opts = createTestOpts({
+        registeredGroups: vi.fn(() => ({
+          'tg:100200300': {
+            name: 'Private',
+            folder: 'private',
+            trigger: '@Andy',
+            added_at: '2024-01-01T00:00:00.000Z',
+          },
+        })),
+      });
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: 'Hello',
+        chatType: 'private',
+        firstName: 'Alice',
+      });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.any(String),
+        'Alice', // Private chats use sender name
+        'telegram',
+        false,
+      );
+    });
+
+    it('uses chat title as name for group chats', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: 'Hello',
+        chatType: 'supergroup',
+        chatTitle: 'Project Team',
+      });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.any(String),
+        'Project Team',
+        'telegram',
+        true,
+      );
+    });
+
+    it('converts message.date to ISO timestamp', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const unixTime = 1704067200; // 2024-01-01T00:00:00.000Z
+      const ctx = createTextCtx({ text: 'Hello', date: unixTime });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          timestamp: '2024-01-01T00:00:00.000Z',
+        }),
+      );
+    });
+  });
+
+  // --- @mention translation ---
+
+  describe('@mention translation', () => {
+    it('translates @bot_username mention to trigger format', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: '@andy_ai_bot what time is it?',
+        entities: [{ type: 'mention', offset: 0, length: 12 }],
+      });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '@Andy @andy_ai_bot what time is it?',
+        }),
+      );
+    });
+
+    it('does not translate if message already matches trigger', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: '@Andy @andy_ai_bot hello',
+        entities: [{ type: 'mention', offset: 6, length: 12 }],
+      });
+      await triggerTextMessage(ctx);
+
+      // Should NOT double-prepend — already starts with @Andy
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '@Andy @andy_ai_bot hello',
+        }),
+      );
+    });
+
+    it('does not translate mentions of other bots', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: '@some_other_bot hi',
+        entities: [{ type: 'mention', offset: 0, length: 15 }],
+      });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '@some_other_bot hi', // No translation
+        }),
+      );
+    });
+
+    it('handles mention in middle of message', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: 'hey @andy_ai_bot check this',
+        entities: [{ type: 'mention', offset: 4, length: 12 }],
+      });
+      await triggerTextMessage(ctx);
+
+      // Bot is mentioned, message doesn't match trigger → prepend trigger
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '@Andy hey @andy_ai_bot check this',
+        }),
+      );
+    });
+
+    it('handles message with no entities', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ text: 'plain message' });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: 'plain message',
+        }),
+      );
+    });
+
+    it('ignores non-mention entities', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: 'check https://example.com',
+        entities: [{ type: 'url', offset: 6, length: 19 }],
+      });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: 'check https://example.com',
+        }),
+      );
+    });
+  });
+
+  // --- Non-text messages ---
+
+  describe('non-text messages', () => {
+    it('stores photo with placeholder', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({});
+      await triggerMediaMessage('message:photo', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Photo]' }),
+      );
+    });
+
+    it('stores photo with caption', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({ caption: 'Look at this' });
+      await triggerMediaMessage('message:photo', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Photo] Look at this' }),
+      );
+    });
+
+    it('stores video with placeholder', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({});
+      await triggerMediaMessage('message:video', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Video]' }),
+      );
+    });
+
+    it('stores voice message with transcription-unavailable fallback', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      // Voice handler now attempts transcription; the getFile mock returns
+      // a file_path but fetch isn't stubbed, so it falls back gracefully.
+      const ctx = createMediaCtx({
+        extra: { voice: { file_id: 'voice_123' } },
+      });
+      await triggerMediaMessage('message:voice', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '[Voice message - transcription unavailable]',
+        }),
+      );
+    });
+
+    it('stores audio with placeholder', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({});
+      await triggerMediaMessage('message:audio', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Audio]' }),
+      );
+    });
+
+    it('stores document with filename', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({
+        extra: { document: { file_name: 'report.pdf' } },
+      });
+      await triggerMediaMessage('message:document', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Document: report.pdf]' }),
+      );
+    });
+
+    it('stores document with fallback name when filename missing', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({ extra: { document: {} } });
+      await triggerMediaMessage('message:document', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Document: file]' }),
+      );
+    });
+
+    it('stores sticker with emoji', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({
+        extra: { sticker: { emoji: '😂' } },
+      });
+      await triggerMediaMessage('message:sticker', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Sticker 😂]' }),
+      );
+    });
+
+    it('stores location with placeholder', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({});
+      await triggerMediaMessage('message:location', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Location]' }),
+      );
+    });
+
+    it('stores contact with placeholder', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({});
+      await triggerMediaMessage('message:contact', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Contact]' }),
+      );
+    });
+
+    it('ignores non-text messages from unregistered chats', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({ chatId: 999999 });
+      await triggerMediaMessage('message:photo', ctx);
+
+      expect(opts.onMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- sendMessage ---
+
+  describe('sendMessage', () => {
+    it('sends message via bot API', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      await channel.sendMessage('tg:100200300', 'Hello');
+
+      expect(currentBot().api.sendMessage).toHaveBeenCalledWith(
+        '100200300',
+        'Hello',
+      );
+    });
+
+    it('strips tg: prefix from JID', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      await channel.sendMessage('tg:-1001234567890', 'Group message');
+
+      expect(currentBot().api.sendMessage).toHaveBeenCalledWith(
+        '-1001234567890',
+        'Group message',
+      );
+    });
+
+    it('splits messages exceeding 4096 characters', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const longText = 'x'.repeat(5000);
+      await channel.sendMessage('tg:100200300', longText);
+
+      expect(currentBot().api.sendMessage).toHaveBeenCalledTimes(2);
+      expect(currentBot().api.sendMessage).toHaveBeenNthCalledWith(
+        1,
+        '100200300',
+        'x'.repeat(4096),
+      );
+      expect(currentBot().api.sendMessage).toHaveBeenNthCalledWith(
+        2,
+        '100200300',
+        'x'.repeat(904),
+      );
+    });
+
+    it('sends exactly one message at 4096 characters', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const exactText = 'y'.repeat(4096);
+      await channel.sendMessage('tg:100200300', exactText);
+
+      expect(currentBot().api.sendMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles send failure gracefully', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      currentBot().api.sendMessage.mockRejectedValueOnce(
+        new Error('Network error'),
+      );
+
+      // Should not throw
+      await expect(
+        channel.sendMessage('tg:100200300', 'Will fail'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('does nothing when bot is not initialized', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+
+      // Don't connect — bot is null
+      await channel.sendMessage('tg:100200300', 'No bot');
+
+      // No error, no API call
+    });
+  });
+
+  // --- ownsJid ---
+
+  describe('ownsJid', () => {
+    it('owns tg: JIDs', () => {
+      const channel = new TelegramChannel('test-token', createTestOpts());
+      expect(channel.ownsJid('tg:123456')).toBe(true);
+    });
+
+    it('owns tg: JIDs with negative IDs (groups)', () => {
+      const channel = new TelegramChannel('test-token', createTestOpts());
+      expect(channel.ownsJid('tg:-1001234567890')).toBe(true);
+    });
+
+    it('does not own WhatsApp group JIDs', () => {
+      const channel = new TelegramChannel('test-token', createTestOpts());
+      expect(channel.ownsJid('12345@g.us')).toBe(false);
+    });
+
+    it('does not own WhatsApp DM JIDs', () => {
+      const channel = new TelegramChannel('test-token', createTestOpts());
+      expect(channel.ownsJid('12345@s.whatsapp.net')).toBe(false);
+    });
+
+    it('does not own unknown JID formats', () => {
+      const channel = new TelegramChannel('test-token', createTestOpts());
+      expect(channel.ownsJid('random-string')).toBe(false);
+    });
+  });
+
+  // --- setTyping ---
+
+  describe('setTyping', () => {
+    it('sends typing action when isTyping is true', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      await channel.setTyping('tg:100200300', true);
+
+      expect(currentBot().api.sendChatAction).toHaveBeenCalledWith(
+        '100200300',
+        'typing',
+      );
+    });
+
+    it('does nothing when isTyping is false', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      await channel.setTyping('tg:100200300', false);
+
+      expect(currentBot().api.sendChatAction).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when bot is not initialized', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+
+      // Don't connect
+      await channel.setTyping('tg:100200300', true);
+
+      // No error, no API call
+    });
+
+    it('handles typing indicator failure gracefully', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      currentBot().api.sendChatAction.mockRejectedValueOnce(
+        new Error('Rate limited'),
+      );
+
+      await expect(
+        channel.setTyping('tg:100200300', true),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  // --- Bot commands ---
+
+  describe('bot commands', () => {
+    it('/chatid replies with chat ID and metadata', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const handler = currentBot().commandHandlers.get('chatid')!;
+      const ctx = {
+        chat: { id: 100200300, type: 'group' as const },
+        from: { first_name: 'Alice' },
+        reply: vi.fn(),
+      };
+
+      await handler(ctx);
+
+      expect(ctx.reply).toHaveBeenCalledWith(
+        expect.stringContaining('tg:100200300'),
+        expect.objectContaining({ parse_mode: 'Markdown' }),
+      );
+    });
+
+    it('/chatid shows chat type', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const handler = currentBot().commandHandlers.get('chatid')!;
+      const ctx = {
+        chat: { id: 555, type: 'private' as const },
+        from: { first_name: 'Bob' },
+        reply: vi.fn(),
+      };
+
+      await handler(ctx);
+
+      expect(ctx.reply).toHaveBeenCalledWith(
+        expect.stringContaining('private'),
+        expect.any(Object),
+      );
+    });
+
+    it('/ping replies with bot status', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const handler = currentBot().commandHandlers.get('ping')!;
+      const ctx = { reply: vi.fn() };
+
+      await handler(ctx);
+
+      expect(ctx.reply).toHaveBeenCalledWith('Andy is online.');
+    });
+  });
+
+  // --- Voice message handling ---
+
+  describe('voice message handling', () => {
+    function createVoiceCtx(overrides: {
+      chatId?: number;
+      chatType?: string;
+      fromId?: number;
+      firstName?: string;
+      date?: number;
+      messageId?: number;
+      caption?: string;
+      fileId?: string;
+    }) {
+      const chatId = overrides.chatId ?? 100200300;
+      return {
+        chat: {
+          id: chatId,
+          type: overrides.chatType ?? 'group',
+          title: 'Test Group',
+        },
+        from: {
+          id: overrides.fromId ?? 99001,
+          first_name: overrides.firstName ?? 'Alice',
+          username: 'alice_user',
+        },
+        message: {
+          date: overrides.date ?? Math.floor(Date.now() / 1000),
+          message_id: overrides.messageId ?? 1,
+          caption: overrides.caption,
+          voice: { file_id: overrides.fileId ?? 'voice_file_123' },
+        },
+        me: { username: 'andy_ai_bot' },
+      };
+    }
+
+    it('transcribes voice message and stores as [Voice: transcript]', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      // Mock fetch for file download
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(10)),
+      });
+      vi.stubGlobal('fetch', mockFetch);
+      mockTranscribeAudio.mockResolvedValue('Hello from voice');
+
+      const ctx = createVoiceCtx({});
+      await triggerMediaMessage('message:voice', ctx);
+
+      expect(currentBot().api.getFile).toHaveBeenCalledWith('voice_file_123');
+      expect(mockTranscribeAudio).toHaveBeenCalled();
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '[Voice: Hello from voice]',
+        }),
+      );
+
+      vi.unstubAllGlobals();
+    });
+
+    it('falls back to placeholder when transcription fails', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(10)),
+      });
+      vi.stubGlobal('fetch', mockFetch);
+      mockTranscribeAudio.mockResolvedValue(null);
+
+      const ctx = createVoiceCtx({});
+      await triggerMediaMessage('message:voice', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '[Voice message - transcription unavailable]',
+        }),
+      );
+
+      vi.unstubAllGlobals();
+    });
+
+    it('falls back to placeholder when file download fails', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const mockFetch = vi.fn().mockResolvedValue({ ok: false });
+      vi.stubGlobal('fetch', mockFetch);
+
+      const ctx = createVoiceCtx({});
+      await triggerMediaMessage('message:voice', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '[Voice message - transcription unavailable]',
+        }),
+      );
+
+      vi.unstubAllGlobals();
+    });
+
+    it('falls back to placeholder when getFile throws', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      currentBot().api.getFile.mockRejectedValueOnce(new Error('API error'));
+
+      const ctx = createVoiceCtx({});
+      await triggerMediaMessage('message:voice', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '[Voice message - transcription unavailable]',
+        }),
+      );
+    });
+
+    it('includes caption with voice transcript', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(10)),
+      });
+      vi.stubGlobal('fetch', mockFetch);
+      mockTranscribeAudio.mockResolvedValue('Hello');
+
+      const ctx = createVoiceCtx({ caption: 'check this' });
+      await triggerMediaMessage('message:voice', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '[Voice: Hello] check this',
+        }),
+      );
+
+      vi.unstubAllGlobals();
+    });
+
+    it('ignores voice from unregistered chats', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createVoiceCtx({ chatId: 999999 });
+      await triggerMediaMessage('message:voice', ctx);
+
+      expect(opts.onMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- sendVoiceMessage ---
+
+  describe('sendVoiceMessage', () => {
+    it('sends voice via bot API and returns true', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const audioBuffer = Buffer.from([1, 2, 3]);
+      const result = await channel.sendVoiceMessage('tg:100200300', audioBuffer);
+
+      expect(result).toBe(true);
+      expect(currentBot().api.sendVoice).toHaveBeenCalledWith(
+        '100200300',
+        expect.any(Object), // InputFile mock
+      );
+    });
+
+    it('returns false when bot is not initialized', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+
+      const result = await channel.sendVoiceMessage('tg:100200300', Buffer.from([1]));
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false on API error', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      currentBot().api.sendVoice.mockRejectedValueOnce(new Error('Send failed'));
+
+      const result = await channel.sendVoiceMessage('tg:100200300', Buffer.from([1]));
+
+      expect(result).toBe(false);
+    });
+
+    it('strips tg: prefix from JID', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      await channel.sendVoiceMessage('tg:-1001234567890', Buffer.from([1]));
+
+      expect(currentBot().api.sendVoice).toHaveBeenCalledWith(
+        '-1001234567890',
+        expect.any(Object),
+      );
+    });
+  });
+
+  // --- Channel properties ---
+
+  describe('channel properties', () => {
+    it('has name "telegram"', () => {
+      const channel = new TelegramChannel('test-token', createTestOpts());
+      expect(channel.name).toBe('telegram');
+    });
+  });
+
+  // --- Multi-bot routing ---
+
+  describe('multi-bot routing (forGroupFolder)', () => {
+    const multiGroupRegistry = () => ({
+      'tg:100200300': {
+        name: 'Ruby Chat',
+        folder: 'main',
+        trigger: '@Andy',
+        added_at: '2024-01-01T00:00:00.000Z',
+      },
+      'tg:400500600': {
+        name: 'Dora Chat',
+        folder: 'dora',
+        trigger: '@Dora',
+        added_at: '2024-06-01T00:00:00.000Z',
+      },
+      'tg:700800900': {
+        name: 'Another Group',
+        folder: 'other',
+        trigger: '@Andy',
+        added_at: '2024-07-01T00:00:00.000Z',
+      },
+    });
+
+    it('forGroupFolder channel only owns JIDs mapped to that folder', () => {
+      const channel = new TelegramChannel(
+        'dora-token',
+        createTestOpts({
+          registeredGroups: multiGroupRegistry,
+          forGroupFolder: 'dora',
+        }),
+      );
+
+      expect(channel.ownsJid('tg:400500600')).toBe(true);
+      expect(channel.ownsJid('tg:100200300')).toBe(false);
+      expect(channel.ownsJid('tg:700800900')).toBe(false);
+      expect(channel.ownsJid('tg:999999')).toBe(false);
+    });
+
+    it('catch-all channel (no forGroupFolder) owns all tg: JIDs', () => {
+      const channel = new TelegramChannel(
+        'ruby-token',
+        createTestOpts({ registeredGroups: multiGroupRegistry }),
+      );
+
+      expect(channel.ownsJid('tg:100200300')).toBe(true);
+      expect(channel.ownsJid('tg:400500600')).toBe(true);
+      expect(channel.ownsJid('tg:700800900')).toBe(true);
+      expect(channel.ownsJid('tg:999999')).toBe(true);
+    });
+
+    it('forGroupFolder channel does not own non-tg: JIDs', () => {
+      const channel = new TelegramChannel(
+        'dora-token',
+        createTestOpts({
+          registeredGroups: multiGroupRegistry,
+          forGroupFolder: 'dora',
+        }),
+      );
+
+      expect(channel.ownsJid('12345@g.us')).toBe(false);
+      expect(channel.ownsJid('random')).toBe(false);
+    });
+
+    it('forGroupFolder channel does not own unregistered tg: JIDs', () => {
+      const channel = new TelegramChannel(
+        'dora-token',
+        createTestOpts({
+          registeredGroups: multiGroupRegistry,
+          forGroupFolder: 'dora',
+        }),
+      );
+
+      expect(channel.ownsJid('tg:111222333')).toBe(false);
+    });
+
+    it('/ping uses botName when provided', async () => {
+      const channel = new TelegramChannel(
+        'dora-token',
+        createTestOpts({
+          registeredGroups: multiGroupRegistry,
+          forGroupFolder: 'dora',
+          botName: 'Dora',
+        }),
+      );
+      await channel.connect();
+
+      const handler = currentBot().commandHandlers.get('ping')!;
+      const ctx = { reply: vi.fn() };
+      await handler(ctx);
+
+      expect(ctx.reply).toHaveBeenCalledWith('Dora is online.');
+    });
+
+    it('/ping falls back to ASSISTANT_NAME when botName not set', async () => {
+      const channel = new TelegramChannel(
+        'ruby-token',
+        createTestOpts({ registeredGroups: multiGroupRegistry }),
+      );
+      await channel.connect();
+
+      const handler = currentBot().commandHandlers.get('ping')!;
+      const ctx = { reply: vi.fn() };
+      await handler(ctx);
+
+      expect(ctx.reply).toHaveBeenCalledWith('Andy is online.');
+    });
+
+    it('@mention translation uses botName', async () => {
+      const doraOpts = createTestOpts({
+        registeredGroups: () => ({
+          'tg:400500600': {
+            name: 'Dora Chat',
+            folder: 'dora',
+            trigger: '@Dora',
+            added_at: '2024-06-01T00:00:00.000Z',
+          },
+        }),
+        forGroupFolder: 'dora',
+        botName: 'Dora',
+      });
+      const channel = new TelegramChannel('dora-token', doraOpts);
+      await channel.connect();
+
+      // The mock Bot always reports username 'andy_ai_bot', so we use that
+      // in the mention entity. In production, Dora's bot would have its own username.
+      const ctx = createTextCtx({
+        chatId: 400500600,
+        text: '@andy_ai_bot do research',
+        entities: [{ type: 'mention', offset: 0, length: 12 }],
+      });
+      await triggerTextMessage(ctx);
+
+      // botName 'Dora' should be used in the prepended trigger, not ASSISTANT_NAME
+      expect(doraOpts.onMessage).toHaveBeenCalledWith(
+        'tg:400500600',
+        expect.objectContaining({
+          content: '@Dora @andy_ai_bot do research',
+        }),
+      );
+    });
+  });
+});

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -1,0 +1,319 @@
+import { Bot, InputFile } from 'grammy';
+
+import { ASSISTANT_NAME, TRIGGER_PATTERN } from '../config.js';
+import { transcribeAudio } from '../elevenlabs.js';
+import { logger } from '../logger.js';
+import {
+  Channel,
+  OnChatMetadata,
+  OnInboundMessage,
+  RegisteredGroup,
+} from '../types.js';
+
+export interface TelegramChannelOpts {
+  onMessage: OnInboundMessage;
+  onChatMetadata: OnChatMetadata;
+  registeredGroups: () => Record<string, RegisteredGroup>;
+  /** If set, this channel only owns JIDs registered to this group folder */
+  forGroupFolder?: string;
+  /** Name shown in /ping (defaults to ASSISTANT_NAME) */
+  botName?: string;
+}
+
+export class TelegramChannel implements Channel {
+  name = 'telegram';
+
+  private bot: Bot | null = null;
+  private opts: TelegramChannelOpts;
+  private botToken: string;
+
+  constructor(botToken: string, opts: TelegramChannelOpts) {
+    this.botToken = botToken;
+    this.opts = opts;
+  }
+
+  async connect(): Promise<void> {
+    this.bot = new Bot(this.botToken);
+
+    // Command to get chat ID (useful for registration)
+    this.bot.command('chatid', (ctx) => {
+      const chatId = ctx.chat.id;
+      const chatType = ctx.chat.type;
+      const chatName =
+        chatType === 'private'
+          ? ctx.from?.first_name || 'Private'
+          : (ctx.chat as any).title || 'Unknown';
+
+      ctx.reply(
+        `Chat ID: \`tg:${chatId}\`\nName: ${chatName}\nType: ${chatType}`,
+        { parse_mode: 'Markdown' },
+      );
+    });
+
+    // Command to check bot status
+    this.bot.command('ping', (ctx) => {
+      const name = this.opts.botName || ASSISTANT_NAME;
+      ctx.reply(`${name} is online.`);
+    });
+
+    this.bot.on('message:text', async (ctx) => {
+      // Skip commands
+      if (ctx.message.text.startsWith('/')) return;
+
+      const chatJid = `tg:${ctx.chat.id}`;
+      let content = ctx.message.text;
+      const timestamp = new Date(ctx.message.date * 1000).toISOString();
+      const senderName =
+        ctx.from?.first_name ||
+        ctx.from?.username ||
+        ctx.from?.id.toString() ||
+        'Unknown';
+      const sender = ctx.from?.id.toString() || '';
+      const msgId = ctx.message.message_id.toString();
+
+      // Determine chat name
+      const chatName =
+        ctx.chat.type === 'private'
+          ? senderName
+          : (ctx.chat as any).title || chatJid;
+
+      // Translate Telegram @bot_username mentions into TRIGGER_PATTERN format.
+      // Telegram @mentions (e.g., @andy_ai_bot) won't match TRIGGER_PATTERN
+      // (e.g., ^@Andy\b), so we prepend the trigger when the bot is @mentioned.
+      const botUsername = ctx.me?.username?.toLowerCase();
+      if (botUsername) {
+        const entities = ctx.message.entities || [];
+        const isBotMentioned = entities.some((entity) => {
+          if (entity.type === 'mention') {
+            const mentionText = content
+              .substring(entity.offset, entity.offset + entity.length)
+              .toLowerCase();
+            return mentionText === `@${botUsername}`;
+          }
+          return false;
+        });
+        if (isBotMentioned && !TRIGGER_PATTERN.test(content)) {
+          const name = this.opts.botName || ASSISTANT_NAME;
+          content = `@${name} ${content}`;
+        }
+      }
+
+      // Store chat metadata for discovery
+      const isGroup = ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
+      this.opts.onChatMetadata(chatJid, timestamp, chatName, 'telegram', isGroup);
+
+      // Only deliver full message for registered groups
+      const group = this.opts.registeredGroups()[chatJid];
+      if (!group) {
+        logger.debug(
+          { chatJid, chatName },
+          'Message from unregistered Telegram chat',
+        );
+        return;
+      }
+
+      // Deliver message — startMessageLoop() will pick it up
+      this.opts.onMessage(chatJid, {
+        id: msgId,
+        chat_jid: chatJid,
+        sender,
+        sender_name: senderName,
+        content,
+        timestamp,
+        is_from_me: false,
+      });
+
+      logger.info(
+        { chatJid, chatName, sender: senderName },
+        'Telegram message stored',
+      );
+    });
+
+    // Handle non-text messages with placeholders so the agent knows something was sent
+    const storeNonText = (ctx: any, placeholder: string) => {
+      const chatJid = `tg:${ctx.chat.id}`;
+      const group = this.opts.registeredGroups()[chatJid];
+      if (!group) return;
+
+      const timestamp = new Date(ctx.message.date * 1000).toISOString();
+      const senderName =
+        ctx.from?.first_name ||
+        ctx.from?.username ||
+        ctx.from?.id?.toString() ||
+        'Unknown';
+      const caption = ctx.message.caption ? ` ${ctx.message.caption}` : '';
+
+      const isGroup = ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
+      this.opts.onChatMetadata(chatJid, timestamp, undefined, 'telegram', isGroup);
+      this.opts.onMessage(chatJid, {
+        id: ctx.message.message_id.toString(),
+        chat_jid: chatJid,
+        sender: ctx.from?.id?.toString() || '',
+        sender_name: senderName,
+        content: `${placeholder}${caption}`,
+        timestamp,
+        is_from_me: false,
+      });
+    };
+
+    this.bot.on('message:photo', (ctx) => storeNonText(ctx, '[Photo]'));
+    this.bot.on('message:video', (ctx) => storeNonText(ctx, '[Video]'));
+    this.bot.on('message:voice', async (ctx) => {
+      const chatJid = `tg:${ctx.chat.id}`;
+      const group = this.opts.registeredGroups()[chatJid];
+      if (!group) return;
+
+      const timestamp = new Date(ctx.message.date * 1000).toISOString();
+      const senderName =
+        ctx.from?.first_name ||
+        ctx.from?.username ||
+        ctx.from?.id?.toString() ||
+        'Unknown';
+      const caption = ctx.message.caption ? ` ${ctx.message.caption}` : '';
+
+      const isGroup = ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
+      this.opts.onChatMetadata(chatJid, timestamp, undefined, 'telegram', isGroup);
+
+      // Try to download and transcribe
+      let content = '[Voice message - transcription unavailable]';
+      try {
+        const file = await this.bot!.api.getFile(ctx.message.voice.file_id);
+        if (file.file_path) {
+          const url = `https://api.telegram.org/file/bot${this.botToken}/${file.file_path}`;
+          const res = await fetch(url);
+          if (res.ok) {
+            const audioBuffer = Buffer.from(await res.arrayBuffer());
+            const transcript = await transcribeAudio(audioBuffer);
+            if (transcript) {
+              content = `[Voice: ${transcript}]`;
+            }
+          }
+        }
+      } catch (err) {
+        logger.warn({ chatJid, err }, 'Failed to download/transcribe voice message');
+      }
+
+      this.opts.onMessage(chatJid, {
+        id: ctx.message.message_id.toString(),
+        chat_jid: chatJid,
+        sender: ctx.from?.id?.toString() || '',
+        sender_name: senderName,
+        content: `${content}${caption}`,
+        timestamp,
+        is_from_me: false,
+      });
+    });
+    this.bot.on('message:audio', (ctx) => storeNonText(ctx, '[Audio]'));
+    this.bot.on('message:document', (ctx) => {
+      const name = ctx.message.document?.file_name || 'file';
+      storeNonText(ctx, `[Document: ${name}]`);
+    });
+    this.bot.on('message:sticker', (ctx) => {
+      const emoji = ctx.message.sticker?.emoji || '';
+      storeNonText(ctx, `[Sticker ${emoji}]`);
+    });
+    this.bot.on('message:location', (ctx) => storeNonText(ctx, '[Location]'));
+    this.bot.on('message:contact', (ctx) => storeNonText(ctx, '[Contact]'));
+
+    // Handle errors gracefully
+    this.bot.catch((err) => {
+      logger.error({ err: err.message }, 'Telegram bot error');
+    });
+
+    // Start polling — returns a Promise that resolves when started
+    return new Promise<void>((resolve) => {
+      this.bot!.start({
+        onStart: (botInfo) => {
+          logger.info(
+            { username: botInfo.username, id: botInfo.id },
+            'Telegram bot connected',
+          );
+          console.log(`\n  Telegram bot: @${botInfo.username}`);
+          console.log(
+            `  Send /chatid to the bot to get a chat's registration ID\n`,
+          );
+          resolve();
+        },
+      });
+    });
+  }
+
+  async sendMessage(jid: string, text: string): Promise<void> {
+    if (!this.bot) {
+      logger.warn('Telegram bot not initialized');
+      return;
+    }
+
+    try {
+      const numericId = jid.replace(/^tg:/, '');
+
+      // Telegram has a 4096 character limit per message — split if needed
+      const MAX_LENGTH = 4096;
+      if (text.length <= MAX_LENGTH) {
+        await this.bot.api.sendMessage(numericId, text);
+      } else {
+        for (let i = 0; i < text.length; i += MAX_LENGTH) {
+          await this.bot.api.sendMessage(
+            numericId,
+            text.slice(i, i + MAX_LENGTH),
+          );
+        }
+      }
+      logger.info({ jid, length: text.length }, 'Telegram message sent');
+    } catch (err) {
+      logger.error({ jid, err }, 'Failed to send Telegram message');
+    }
+  }
+
+  async sendVoiceMessage(
+    jid: string,
+    audioBuffer: Buffer,
+    _caption?: string,
+  ): Promise<boolean> {
+    if (!this.bot) {
+      logger.warn('Telegram bot not initialized');
+      return false;
+    }
+
+    try {
+      const numericId = jid.replace(/^tg:/, '');
+      await this.bot.api.sendVoice(numericId, new InputFile(audioBuffer, 'voice.ogg'));
+      logger.info({ jid, audioBytes: audioBuffer.length }, 'Telegram voice message sent');
+      return true;
+    } catch (err) {
+      logger.error({ jid, err }, 'Failed to send Telegram voice message');
+      return false;
+    }
+  }
+
+  isConnected(): boolean {
+    return this.bot !== null;
+  }
+
+  ownsJid(jid: string): boolean {
+    if (!jid.startsWith('tg:')) return false;
+    if (this.opts.forGroupFolder) {
+      const group = this.opts.registeredGroups()[jid];
+      return group?.folder === this.opts.forGroupFolder;
+    }
+    return true;
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.bot) {
+      this.bot.stop();
+      this.bot = null;
+      logger.info('Telegram bot stopped');
+    }
+  }
+
+  async setTyping(jid: string, isTyping: boolean): Promise<void> {
+    if (!this.bot || !isTyping) return;
+    try {
+      const numericId = jid.replace(/^tg:/, '');
+      await this.bot.api.sendChatAction(numericId, 'typing');
+    } catch (err) {
+      logger.debug({ jid, err }, 'Failed to send Telegram typing indicator');
+    }
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,9 @@ import { readEnvFile } from './env.js';
 const envConfig = readEnvFile([
   'ASSISTANT_NAME',
   'ASSISTANT_HAS_OWN_NUMBER',
+  'TELEGRAM_BOT_TOKEN',
+  'TELEGRAM_ONLY',
+  'DORA_TELEGRAM_BOT_TOKEN',
 ]);
 
 export const ASSISTANT_NAME =
@@ -54,6 +57,10 @@ export const MAX_CONCURRENT_CONTAINERS = Math.max(
   parseInt(process.env.MAX_CONCURRENT_CONTAINERS || '5', 10) || 5,
 );
 
+// Default Claude model for agents. Override per-group via ContainerInput.model.
+export const DEFAULT_MODEL =
+  process.env.NANOCLAW_DEFAULT_MODEL || 'sonnet';
+
 function escapeRegex(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
@@ -67,3 +74,13 @@ export const TRIGGER_PATTERN = new RegExp(
 // Uses system timezone by default
 export const TIMEZONE =
   process.env.TZ || Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+// Telegram configuration
+export const TELEGRAM_BOT_TOKEN =
+  process.env.TELEGRAM_BOT_TOKEN || envConfig.TELEGRAM_BOT_TOKEN || '';
+export const TELEGRAM_ONLY =
+  (process.env.TELEGRAM_ONLY || envConfig.TELEGRAM_ONLY) === 'true';
+
+// Dora research bot (separate Telegram bot)
+export const DORA_TELEGRAM_BOT_TOKEN =
+  process.env.DORA_TELEGRAM_BOT_TOKEN || envConfig.DORA_TELEGRAM_BOT_TOKEN || '';

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -34,6 +34,7 @@ export interface ContainerInput {
   isMain: boolean;
   isScheduledTask?: boolean;
   assistantName?: string;
+  model?: string;
   secrets?: Record<string, string>;
 }
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -494,6 +494,10 @@ export function setSession(groupFolder: string, sessionId: string): void {
   ).run(groupFolder, sessionId);
 }
 
+export function deleteSession(groupFolder: string): void {
+  db.prepare('DELETE FROM sessions WHERE group_folder = ?').run(groupFolder);
+}
+
 export function getAllSessions(): Record<string, string> {
   const rows = db
     .prepare('SELECT group_folder, session_id FROM sessions')

--- a/src/elevenlabs.ts
+++ b/src/elevenlabs.ts
@@ -1,0 +1,114 @@
+import { readEnvFile } from './env.js';
+import { logger } from './logger.js';
+
+const MAX_TTS_CHARS = 4500;
+
+let cachedConfig: { apiKey: string; voiceId: string } | null = null;
+
+function getConfig(): { apiKey: string; voiceId: string } | null {
+  if (cachedConfig) return cachedConfig;
+
+  const env = readEnvFile(['ELEVENLABS_API_KEY', 'ELEVENLABS_VOICE_ID']);
+  const apiKey = process.env.ELEVENLABS_API_KEY || env.ELEVENLABS_API_KEY || '';
+  const voiceId =
+    process.env.ELEVENLABS_VOICE_ID || env.ELEVENLABS_VOICE_ID || '';
+
+  if (!apiKey) {
+    logger.debug('ELEVENLABS_API_KEY not set, voice features disabled');
+    return null;
+  }
+
+  cachedConfig = { apiKey, voiceId };
+  return cachedConfig;
+}
+
+/**
+ * Synthesize speech from text using ElevenLabs TTS.
+ * Returns an OGG Opus buffer suitable for Telegram voice notes, or null on failure.
+ */
+export async function synthesizeSpeech(
+  text: string,
+): Promise<Buffer | null> {
+  const config = getConfig();
+  if (!config) return null;
+  if (!config.voiceId) {
+    logger.warn('ELEVENLABS_VOICE_ID not set, cannot synthesize speech');
+    return null;
+  }
+
+  try {
+    const { ElevenLabsClient } = await import('@elevenlabs/elevenlabs-js');
+    const client = new ElevenLabsClient({ apiKey: config.apiKey });
+
+    let input = text;
+    if (input.length > MAX_TTS_CHARS) {
+      logger.warn(
+        { original: input.length, truncated: MAX_TTS_CHARS },
+        'TTS input truncated',
+      );
+      input = input.slice(0, MAX_TTS_CHARS) + '…';
+    }
+
+    const audio = await client.textToSpeech.convert(config.voiceId, {
+      text: input,
+      modelId: 'eleven_multilingual_v2',
+      outputFormat: 'opus_48000_128',
+    });
+
+    // The SDK returns a ReadableStream — collect into a Buffer
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of audio) {
+      chunks.push(chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk));
+    }
+
+    const buffer = Buffer.concat(chunks);
+    logger.info(
+      { textLength: text.length, audioBytes: buffer.length },
+      'TTS synthesis complete',
+    );
+    return buffer;
+  } catch (err) {
+    logger.error({ err }, 'ElevenLabs TTS failed');
+    return null;
+  }
+}
+
+/**
+ * Transcribe audio using ElevenLabs STT (Scribe).
+ * Returns the transcript string, or null on failure.
+ */
+export async function transcribeAudio(
+  audioBuffer: Buffer,
+): Promise<string | null> {
+  const config = getConfig();
+  if (!config) return null;
+
+  try {
+    const { ElevenLabsClient } = await import('@elevenlabs/elevenlabs-js');
+    const client = new ElevenLabsClient({ apiKey: config.apiKey });
+
+    const file = new File([audioBuffer], 'voice.ogg', {
+      type: 'audio/ogg',
+    });
+
+    const result = await client.speechToText.convert({
+      file,
+      modelId: 'scribe_v1',
+    });
+
+    const transcript = result.text?.trim() || null;
+    logger.info(
+      { audioBytes: audioBuffer.length, transcriptLength: transcript?.length },
+      'STT transcription complete',
+    );
+    return transcript;
+  } catch (err) {
+    logger.error({ err }, 'ElevenLabs STT failed');
+    return null;
+  }
+}
+
+/** Reset cached config — for testing only. */
+export function _resetConfig(): void {
+  cachedConfig = null;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,6 +87,8 @@ export interface Channel {
   disconnect(): Promise<void>;
   // Optional: typing indicator. Channels that support it implement it.
   setTyping?(jid: string, isTyping: boolean): Promise<void>;
+  // Optional: send a voice message (OGG Opus buffer). Returns true on success.
+  sendVoiceMessage?(jid: string, audioBuffer: Buffer, caption?: string): Promise<boolean>;
 }
 
 // Callback type that channels use to deliver inbound messages


### PR DESCRIPTION
## Changes

### New Features
- **Slack Channel Support**: Adds full Slack integration via Socket Mode (no public URL required)
  - `SlackChannel` class implementing the `Channel` interface
  - 46 unit tests with comprehensive coverage
  - Message handling, threading (flattened), @mention translation, and metadata sync
  - Message queuing with automatic flush on connect
  - User name caching and error resilience

- **Telegram Bot**: Adds Telegram channel support alongside existing platforms
  - `TelegramChannel` class with full test suite (1300+ lines)
  - Proper state management and connection lifecycle

- **Skills Engine & Multi-bot Routing**: 
  - New skill system for deterministic code changes (`add-slack` skill with SKILL.md and SLACK_SETUP.md)
  - Multi-channel routing in `src/index.ts` with `SLACK_ONLY` config option
  - Support for running Slack + WhatsApp together or Slack alone
  - IPC message passing for container communication

- **ElevenLabs Integration**: Text-to-speech support via `src/elevenlabs.ts`

### Documentation
- `SKILL.md`: Complete skill implementation guide with phases, troubleshooting, and known limitations
- `SLACK_SETUP.md`: Step-by-step Slack app creation with screenshots, token reference, and troubleshooting
- `CONTRIBUTORS.md`: Added contributor attribution (Alakazam03, tydev-new, pottertech, rgarcia, AmaxGuan)
- `CLAUDE.md` files for skill groups documenting implementation patterns

### Configuration
- Added `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, `SLACK_ONLY` to `.env.example`
- Updated CODEOWNERS with gabi-simons for core paths

### Build & Infrastructure
- Installed `@slack/bolt` dependency
- Updated routing tests to cover multi-channel scenarios
- Container runner IPC improvements (`src/ipc.ts`, `agent-runner/src/ipc-mcp-stdio.ts`)

## Known Limitations
- Threaded replies are flattened (no in-thread responses)
- No typing indicator API in Slack Bot
- Message splitting is naive (4000-char boundary)
- No file/image handling
