### PR TITLE
fix: improve WhatsApp setup reliability

### DIFF
--- a/setup/groups.ts
+++ b/setup/groups.ts
@@ -90,7 +90,7 @@ async function syncGroups(projectRoot: string): Promise<void> {
   let syncOk = false;
   try {
     const syncScript = `
-import makeWASocket, { useMultiFileAuthState, makeCacheableSignalKeyStore, Browsers } from '@whiskeysockets/baileys';
+import makeWASocket, { useMultiFileAuthState, makeCacheableSignalKeyStore, Browsers, fetchLatestWaWebVersion } from '@whiskeysockets/baileys';
 import pino from 'pino';
 import path from 'path';
 import fs from 'fs';
@@ -113,60 +113,76 @@ const upsert = db.prepare(
   'INSERT INTO chats (jid, name, last_message_time) VALUES (?, ?, ?) ON CONFLICT(jid) DO UPDATE SET name = excluded.name'
 );
 
-const { state, saveCreds } = await useMultiFileAuthState(authDir);
+let retries = 0;
+const MAX_RETRIES = 3;
 
-const sock = makeWASocket({
-  auth: { creds: state.creds, keys: makeCacheableSignalKeyStore(state.keys, logger) },
-  printQRInTerminal: false,
-  logger,
-  browser: Browsers.macOS('Chrome'),
-});
+async function connect() {
+  const { state, saveCreds } = await useMultiFileAuthState(authDir);
+  const { version } = await fetchLatestWaWebVersion({}).catch(() => ({ version: undefined }));
 
-const timeout = setTimeout(() => {
-  console.error('TIMEOUT');
-  process.exit(1);
-}, 30000);
+  const sock = makeWASocket({
+    version,
+    auth: { creds: state.creds, keys: makeCacheableSignalKeyStore(state.keys, logger) },
+    printQRInTerminal: false,
+    logger,
+    browser: Browsers.macOS('Chrome'),
+  });
 
-sock.ev.on('creds.update', saveCreds);
-
-sock.ev.on('connection.update', async (update) => {
-  if (update.connection === 'open') {
-    try {
-      const groups = await sock.groupFetchAllParticipating();
-      const now = new Date().toISOString();
-      let count = 0;
-      for (const [jid, metadata] of Object.entries(groups)) {
-        if (metadata.subject) {
-          upsert.run(jid, metadata.subject, now);
-          count++;
-        }
-      }
-      console.log('SYNCED:' + count);
-    } catch (err) {
-      console.error('FETCH_ERROR:' + err.message);
-    } finally {
-      clearTimeout(timeout);
-      sock.end(undefined);
-      db.close();
-      process.exit(0);
-    }
-  } else if (update.connection === 'close') {
-    clearTimeout(timeout);
-    console.error('CONNECTION_CLOSED');
+  const timeout = setTimeout(() => {
+    console.error('TIMEOUT');
+    db.close();
     process.exit(1);
-  }
-});
+  }, 30000);
+
+  sock.ev.on('creds.update', saveCreds);
+
+  sock.ev.on('connection.update', async (update) => {
+    if (update.connection === 'open') {
+      try {
+        const groups = await sock.groupFetchAllParticipating();
+        const now = new Date().toISOString();
+        let count = 0;
+        for (const [jid, metadata] of Object.entries(groups)) {
+          if (metadata.subject) {
+            upsert.run(jid, metadata.subject, now);
+            count++;
+          }
+        }
+        console.log('SYNCED:' + count);
+      } catch (err) {
+        console.error('FETCH_ERROR:' + err.message);
+      } finally {
+        clearTimeout(timeout);
+        sock.end(undefined);
+        db.close();
+        process.exit(0);
+      }
+    } else if (update.connection === 'close') {
+      clearTimeout(timeout);
+      const statusCode = update.lastDisconnect?.error?.output?.statusCode;
+      if ((statusCode === 515 || statusCode === 408) && retries < MAX_RETRIES) {
+        retries++;
+        console.error('RECONNECTING:' + statusCode);
+        setTimeout(() => connect(), 2000);
+      } else {
+        console.error('CONNECTION_CLOSED:' + (statusCode || 'unknown'));
+        db.close();
+        process.exit(1);
+      }
+    }
+  });
+}
+
+connect();
 `;
 
-    const output = execSync(
-      `node --input-type=module -e ${JSON.stringify(syncScript)}`,
-      {
-        cwd: projectRoot,
-        encoding: 'utf-8',
-        timeout: 45000,
-        stdio: ['ignore', 'pipe', 'pipe'],
-      },
-    );
+    const output = execSync(`node --input-type=module`, {
+      cwd: projectRoot,
+      encoding: 'utf-8',
+      input: syncScript,
+      timeout: 45000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
     syncOk = output.includes('SYNCED:');
     logger.info({ output: output.trim() }, 'Sync output');
   } catch (err) {


### PR DESCRIPTION
## Summary

- **setup/groups.ts**: Pass inline sync script via stdin instead of `-e` flag to fix escaped newline syntax errors. Add `fetchLatestWaWebVersion` and reconnection logic for 515/408 stream errors.
- **src/whatsapp-auth.ts**: Wait for `registered=true` in creds before exiting after QR/pairing auth, preventing 405 "Method Not Allowed" failures on subsequent connections.

## Context

During fresh setup on macOS, two issues prevent successful WhatsApp authentication and group sync:

1. The groups sync script passed via `node -e` with `JSON.stringify()` produces literal `\n` escapes that cause `SyntaxError: Invalid or unexpected token`. Using stdin (`input:` option with `execSync`) fixes this.

2. After QR scan or pairing code auth, the auth script exits after 1 second (`setTimeout(() => process.exit(0), 1000)`) before the registration handshake completes. Subsequent connections then fail with HTTP 405 because the server rejects the unregistered session. The fix polls `creds.json` for up to 30 seconds waiting for `registered: true`.

## Test plan

- [ ] Run `/setup` on a fresh install — WhatsApp auth should complete with `registered: true`
- [ ] Run group sync step — should successfully fetch and store groups
- [ ] Verify reconnection on 515 stream error during group sync


🤖 Generated with [Claude Code](https://claude.com/claude-code)