### PR TITLE
feat: download and process images from WhatsApp messages

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -6,6 +6,7 @@ import makeWASocket, {
   Browsers,
   DisconnectReason,
   WASocket,
+  downloadMediaMessage,
   fetchLatestWaWebVersion,
   makeCacheableSignalKeyStore,
   useMultiFileAuthState,
@@ -14,6 +15,7 @@ import makeWASocket, {
 import {
   ASSISTANT_HAS_OWN_NUMBER,
   ASSISTANT_NAME,
+  GROUPS_DIR,
   STORE_DIR,
 } from '../config.js';
 import { getLastGroupSync, setLastGroupSync, updateChatName } from '../db.js';
@@ -195,14 +197,54 @@ export class WhatsAppChannel implements Channel {
         // Only deliver full message for registered groups
         const groups = this.opts.registeredGroups();
         if (groups[chatJid]) {
-          const content =
+          // Download image if present and save to group's images directory
+          let imagePath = '';
+          if (msg.message?.imageMessage) {
+            try {
+              const buffer = await downloadMediaMessage(
+                msg,
+                'buffer',
+                {},
+                {
+                  logger,
+                  reuploadRequest: this.sock.updateMediaMessage,
+                },
+              );
+              const ext =
+                (msg.message.imageMessage.mimetype || 'image/jpeg')
+                  .split('/')[1] || 'jpg';
+              const filename = `${msg.key.id || Date.now()}.${ext}`;
+              const group = groups[chatJid];
+              const imagesDir = path.join(
+                GROUPS_DIR,
+                group.folder,
+                'images',
+              );
+              fs.mkdirSync(imagesDir, { recursive: true });
+              fs.writeFileSync(path.join(imagesDir, filename), buffer);
+              imagePath = `/workspace/group/images/${filename}`;
+              logger.info(
+                { chatJid, filename },
+                'Downloaded image from WhatsApp message',
+              );
+            } catch (err) {
+              logger.error({ err, chatJid }, 'Failed to download image');
+            }
+          }
+
+          const textContent =
             msg.message?.conversation ||
             msg.message?.extendedTextMessage?.text ||
             msg.message?.imageMessage?.caption ||
             msg.message?.videoMessage?.caption ||
             '';
 
-          // Skip protocol messages with no text content (encryption keys, read receipts, etc.)
+          // Build final content: text + image path (if present)
+          const content = imagePath
+            ? `${textContent}\n[Image: ${imagePath}]`.trim()
+            : textContent;
+
+          // Skip protocol messages with no usable content
           if (!content) continue;
 
           const sender = msg.key.participant || msg.key.remoteJid || '';


### PR DESCRIPTION
## Problem

When users send images via WhatsApp, NanoClaw extracts only the caption text and **silently drops the image**. The agent never sees the actual image — it receives an empty message (or just the caption). This makes image-based interactions impossible: no screenshots, no documents, no charts, no receipts.

**Current behavior:** Image arrives → only caption extracted → image data discarded
**New behavior:** Image arrives → downloaded via Baileys → saved to group workspace → path passed to agent

## Solution

Uses Baileys' existing `downloadMediaMessage()` to download the image buffer, saves it to the group's `images/` directory, and appends the file path to the message content as `[Image: /workspace/group/images/filename.jpg]`.

The Claude agent can then read and analyze the image using its multimodal capabilities via the `Read` tool — no additional infrastructure needed.

### Changes

- **`src/channels/whatsapp.ts`**: Import `downloadMediaMessage` from Baileys. When an `imageMessage` is detected, download the media buffer, determine file extension from MIME type, save to `{GROUPS_DIR}/{folder}/images/`, and append `[Image: path]` to content. Images without captions are no longer silently dropped.
- **`src/channels/whatsapp.test.ts`**: Add `downloadMediaMessage` mock, add `writeFileSync` to fs mock, add `GROUPS_DIR` to config mock. Two new tests: image with caption (verifies download + path in content) and image without caption (verifies it's not skipped as empty).

### What this unlocks

- Screenshot analysis
- Document/receipt scanning  
- Chart and graph interpretation
- Any image-based question

## Test plan

- [x] All 42 existing tests pass
- [x] New test: image with caption → downloads image, content includes both caption and `[Image: path]`
- [x] New test: image without caption → still delivered (not dropped as empty content)
- [x] Graceful error handling — download failure logs error, message still delivered with caption only

Closes #463