### PR TITLE
fix: update WA protocol version to fix 405 connection errors

### DIFF
--- a/setup/whatsapp-auth.ts
+++ b/setup/whatsapp-auth.ts
@@ -210,8 +210,8 @@ async function handleQrBrowser(
   const qrData = fs.readFileSync(qrFile, 'utf-8');
   try {
     const svg = execSync(
-      `node -e "const QR=require('qrcode');const data=${JSON.stringify(qrData)};QR.toString(data,{type:'svg'},(e,s)=>{if(e)process.exit(1);process.stdout.write(s)})"`,
-      { cwd: projectRoot, encoding: 'utf-8' },
+      `node -e "const QR=require('qrcode');QR.toString(process.env.QR_DATA,{type:'svg'},(e,s)=>{if(e)process.exit(1);process.stdout.write(s)})"`,
+      { cwd: projectRoot, encoding: 'utf-8', env: { ...process.env, QR_DATA: qrData } },
     );
     const html = QR_AUTH_TEMPLATE.replace('{{QR_SVG}}', svg);
     const htmlPath = path.join(projectRoot, 'store', 'qr-auth.html');

--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -56,6 +56,7 @@ export class WhatsAppChannel implements Channel {
     const { state, saveCreds } = await useMultiFileAuthState(authDir);
 
     this.sock = makeWASocket({
+      version: [2, 3000, 1034074495],
       auth: {
         creds: state.creds,
         keys: makeCacheableSignalKeyStore(state.keys, logger),

--- a/src/whatsapp-auth.ts
+++ b/src/whatsapp-auth.ts
@@ -54,6 +54,7 @@ async function connectSocket(phoneNumber?: string, isReconnect = false): Promise
   }
 
   const sock = makeWASocket({
+    version: [2, 3000, 1034074495],
     auth: {
       creds: state.creds,
       keys: makeCacheableSignalKeyStore(state.keys, logger),


### PR DESCRIPTION
## Summary

- Override the WhatsApp Web protocol version from Baileys' hardcoded `1027934701` to `1034074495` (current stable). The old version causes WhatsApp to reject connections with HTTP 405, making fresh setups impossible.
- Fix QR browser auth shell quoting bug — QR data containing `@`, `+`, `/`, `=` characters broke the `node -e` command. Pass via environment variable instead.

## Context

Baileys `7.0.0-rc.9` hardcodes a stale WA protocol version in `lib/Defaults/index.js`. When WhatsApp stops accepting that version, all connections fail with 405 "Method Not Allowed". The error is especially confusing because:

1. The 405 triggers automatic reconnects
2. Rapid reconnects cause WhatsApp to rate-limit the IP
3. Rate limiting masks the root cause, making it look like a network issue

The fix overrides the version in `makeWASocket()` calls in both `src/channels/whatsapp.ts` and `src/whatsapp-auth.ts`.

## Test plan

- [ ] Fresh setup with `npm run setup` — should connect without 405
- [ ] QR browser auth — should render QR code correctly regardless of special characters in QR data

🤖 Generated with [Claude Code](https://claude.com/claude-code)