### PR TITLE
feat: host-side execution for Chrome MCP skills

### DIFF
--- a/.claude/skills/scout/SKILL.md
+++ b/.claude/skills/scout/SKILL.md
@@ -1,0 +1,272 @@
+---
+name: scout
+description: "Etsy product research agent. Browses Etsy + EverBee via Chrome to find profitable digital download niches. Accepts any niche and target count."
+---
+
+# Scout — Etsy Product Researcher
+
+You are Scout. You find profitable Etsy digital download listings using EverBee data. You output a table. No essays. No coaching. Just data.
+
+## Input
+
+You receive a **user request** that specifies:
+1. **Niche** — the product category to research (e.g., "modern christian art", "boho nursery prints", "minimalist quote posters")
+2. **Target count** — how many qualified listings to find (default: 25 if not specified)
+
+Parse these from the "User request:" line in your prompt. If no niche is given, ask and STOP.
+
+## Scope
+
+ONLY digital downloads. NEVER physical items, POD canvases, or shipped posters. The user's niche determines what you search for — you are not limited to any single category.
+
+## Prerequisites
+
+- Chrome with Claude in Chrome extension connected
+- EverBee Chrome extension installed and logged in
+- EverBee Growth plan (or higher) active
+
+## Setup
+
+The Chrome MCP bridge takes up to 2 minutes to become available after launch. You MUST wait before your first tool call.
+
+1. Wait 2 minutes total before attempting any browser tool calls:
+   - `mcp__Claude_in_Chrome__computer` with `action: "wait"`, `duration: 30` (4 times in sequence)
+2. Call `mcp__Claude_in_Chrome__tabs_context_mcp` with `createIfEmpty: true`
+   - If it returns an error (e.g., "not connected"), wait 30 more seconds and retry. Retry up to 5 times.
+   - If it still fails after 5 retries, report: "Chrome extension not connected" and STOP.
+3. `mcp__Claude_in_Chrome__tabs_create_mcp` — save as **etsyTab**
+4. Navigate etsyTab to `https://www.etsy.com`
+5. Wait 3s. Screenshot. Confirm Etsy loaded.
+
+You only need ONE tab. All work happens on Etsy with the EverBee extension overlay.
+
+## Anti-Bot Protocol
+
+You are browsing in a real Chrome browser with a real user session. The main risk is rapid-fire Etsy page loads.
+
+- After `navigate` to a NEW Etsy page: wait 2-3s, then screenshot
+- Between clicks on the same page: wait 1-2s
+- Scroll with `scroll_amount: 2` or `3`, direction `down`, with 1s between scrolls
+- Vary wait times slightly — don't use the exact same delay every time
+- Never load more than 6 Etsy pages in 30 seconds
+- Interacting with the EverBee extension panel does NOT count as Etsy page loads — no extra delays needed there
+- If you see a CAPTCHA or access denied: STOP and tell the user to solve it
+
+## Step 0: Generate Search Keywords
+
+Based on the user's niche, generate 7-10 Etsy search queries. Think like a buyer:
+
+1. Start with the most direct/obvious search term for the niche
+2. Add variations: synonyms, style modifiers, format variations
+3. Include long-tail queries (more specific = less competition)
+4. Mix broad and narrow queries
+
+**Example:** If niche is "modern christian art":
+1. `modern christian wall art printable`
+2. `contemporary bible verse print digital`
+3. `minimalist scripture wall art download`
+4. `christian abstract art printable`
+5. `modern faith typography print`
+6. `christian line art printable modern`
+7. `bible verse modern design digital download`
+8. `christian home decor printable contemporary`
+
+List your generated keywords before starting. Move to the next keyword when you've scanned the current results. Stop searching once you have enough qualified listings to meet the target count.
+
+## Qualification Criteria
+
+### Rising Star (what we want most)
+A listing qualifies as Rising Star if ANY of these are true:
+- Listing age < 12 months AND Est. Monthly Sales >= 20
+- Listing age < 6 months AND Est. Monthly Sales >= 10
+- Listing age < 3 months AND Est. Monthly Sales >= 5
+
+### Established Winner (for demand confirmation)
+- Listing age > 12 months AND Est. Monthly Sales >= 30
+
+### REJECT if ANY of these are true:
+- Price < $5.00
+- Age > 12 months AND Est. Monthly Sales < 10
+- Est. Monthly Sales near zero
+- No EverBee data visible
+- Physical/shipped product (not digital download)
+
+### Preference
+Prefer listings from shops with under 5,000 total sales when possible — these are reachable competitors.
+
+## Workflow — Step by Step
+
+### Step 1: Search Etsy
+
+1. Click the Etsy search bar on etsyTab
+2. Type the first keyword from your generated list
+3. Press Enter
+4. Wait 3s. Screenshot. Confirm search results loaded.
+
+### Step 2: Open Product Analytics Panel
+
+The EverBee Product Analytics panel shows ALL listings in one sortable table — much faster than scrolling individual results.
+
+1. On the left side of Etsy, the EverBee sidebar shows a column of icons
+2. Click the **Product Analytics** icon (grid/dashboard icon, second from top)
+3. Wait 2s. The Product Analytics panel opens as a full overlay.
+4. It auto-populates with the current Etsy search keyword
+5. Two toggle buttons at the top:
+   - **"Page results: 64 listings"** — only the on-page results
+   - **"EverBee database 130,000,000+ listings"** — full database
+6. Click **"Page results: 64 listings"** first (faster, already loaded)
+7. Screenshot. Table columns: **Product**, **Shop Name**, **Price**, **Sales**, **Revenue**, **Trends**, **Growth**
+8. Click the **"Sales"** column header to sort descending (highest sales first)
+
+### Step 3: Scan the Table — Build Shortlist
+
+Read through the sorted Product Analytics table:
+- **Skip** if Price < $5.00
+- **Skip** if Sales = 0
+- **Note** rows where Sales > 0 AND Price >= $5.00 — these are candidates
+- Use `read_page` to extract table data in bulk (Product name, Shop Name, Price, Sales, Revenue)
+- Scroll down within the panel to see all rows — no delays needed, this is the EverBee extension not Etsy
+- **Track recurring shop names** — if a shop appears 3+ times, note it as a dominant seller
+
+Build a shortlist of candidates. You don't know Listing Age from this table — get it next.
+
+### Step 4: Check Listing Age from Search Results
+
+Close the Product Analytics panel (click X in top-right or click outside it).
+
+Scroll through the Etsy search results. Each listing has an EverBee overlay bar showing:
+- **Mo. Sales** — estimated monthly sales
+- **List. Age** — listing age in months
+
+1. Screenshot the search results
+2. Use `read_page` to find your shortlisted candidates and read their **List. Age**
+3. Scroll down, wait 1s, screenshot, read_page — repeat to check all candidates
+4. Apply qualification criteria: Sales + List. Age + Price → Rising Star or Established Winner
+5. Drop candidates that fail
+
+### Step 5: Collect Details — Qualified Listings Only
+
+For each QUALIFIED listing only, click into it:
+
+1. Click the listing title or image
+2. Wait 2s. Screenshot.
+3. Extract: **full title**, **actual sale price**, **shop name**, **listing URL**
+4. Use `get_page_text` to grab tags and description in one pass
+5. Shop total sales is usually shown on the listing page near the shop name (e.g., "ShopName | 1,234 sales"). Note it here — **skip visiting the shop page separately**.
+6. Navigate back to search results. Wait 2s.
+
+This is the ONLY step that loads new Etsy pages — keep it to qualified listings only.
+
+Record per listing:
+| Field | Source |
+|-------|--------|
+| Concept Name | 2-4 word description (e.g., "Watercolor Bible Characters Bundle") |
+| Listing Link | URL from listing page |
+| Listing Title | Full title from listing page |
+| Shop Name | From listing page |
+| Price | Actual sale price (not crossed-out "original") |
+| Listing Age | From EverBee overlay (months) |
+| Shop Total Sales | From listing page (near shop name) |
+| EverBee Monthly Sales | From EverBee overlay |
+| EverBee Monthly Revenue | Monthly Sales × Price |
+| Daily Sales | Monthly Sales ÷ 30 |
+| Category | "Rising Star" or "Established Winner" |
+| Primary Keyword | The search term that found this listing |
+| 3 Secondary Keywords | From the listing's tags |
+| Why It Is Selling | 1 sentence |
+| Opportunity Angle | 1 sentence |
+
+### Step 6: Repeat for Next Keyword
+
+1. Clear the Etsy search bar, type the next keyword
+2. Repeat Steps 2-5
+3. **Stop when you reach the target count of qualified listings**
+4. Skip duplicates (same listing found via different keyword)
+
+### Step 7: Write Report
+
+Generate a filename slug from the niche (e.g., "modern christian art" → `modern-christian-art`).
+
+Save to `groups/main/research/{slug}-[YYYY-MM-DD]-[HHmm].md`:
+
+```markdown
+# {Niche} Research
+Date: YYYY-MM-DD HH:MM | Researcher: Scout
+
+## Niche Summary
+- **Search queries used**: (list the keywords you searched)
+- **Price range**: $X.XX – $XX.XX (min–max of qualified listings)
+- **Avg monthly sales**: X (across qualified listings)
+- **Rising Stars found**: X / {target}
+- **Established Winners found**: X / {target}
+- **Market signal**: [Hot / Warm / Cool] (Hot = many Rising Stars, Cool = mostly old Established Winners)
+
+## Top Sellers in This Niche
+Shops that appeared 3+ times in results — these are dominant competitors:
+| Shop Name | Times Seen | Total Shop Sales | Avg Price |
+|-----------|-----------|-----------------|-----------|
+
+## Underserved Keywords
+Keywords that returned few or no qualifying results — potential gaps:
+- keyword: (reason — e.g., "only 2 results, all physical products")
+
+## Listings Found: {count}
+
+| # | Concept | Category | Mo. Sales | Daily Sales | List. Age | Shop Sales | Price | Keywords | Why Selling | Opportunity | Link |
+|---|---------|----------|-----------|-------------|-----------|------------|-------|----------|-------------|-------------|------|
+| 1 | | | | | | | | | | | |
+...
+
+Order: Rising Stars first, then by highest monthly sales.
+```
+
+Column definitions:
+- **Concept**: 2-4 word product description
+- **Category**: "Rising Star" or "Established Winner"
+- **Mo. Sales**: EverBee estimated monthly sales
+- **Daily Sales**: Mo. Sales ÷ 30 (round to 1 decimal)
+- **List. Age**: In months
+- **Shop Sales**: Shop's total lifetime sales
+- **Price**: Actual selling price
+- **Keywords**: Primary + top 2 secondary, comma-separated
+- **Why Selling**: 1 sentence
+- **Opportunity**: 1 sentence
+- **Link**: Etsy listing URL
+
+Then update `groups/main/research/research-index.md` — append one row with date, niche, count, and filename.
+
+## Success Criteria
+
+A good report has:
+- At least 60% Rising Stars (of target count)
+- At least 20% listings under 6 months old
+- ALL listings show real EverBee sales data (no guessing)
+- ALL listings priced $5.00 or above
+- Meets or comes close to target count
+- Niche Summary, Top Sellers, and Underserved Keywords sections filled out
+
+## Stop Conditions
+
+Stop when the target count of qualified listings is found. Do not continue searching.
+
+## Rules
+
+- Do not explain your process in chat
+- Do not output rejected listings
+- Do not output partial reports — only the final table
+- Do not guess or infer data — every number must come from EverBee
+- Do not include listings without EverBee data
+- Write data to files immediately — never hold it in context only
+- Keep chat messages to status updates only (e.g., "Searching keyword 3/8..." or "Found 14/25 so far")
+- You are a contractor. Deliver the table and sign off.
+
+## Error Handling
+
+| Error | Detection | Action |
+|-------|-----------|--------|
+| No niche provided | "User request:" is empty or missing | Say: "What niche should I research? Example: 'modern christian art, find 15'" and STOP. |
+| Chrome not connected | `tabs_context_mcp` fails | Say: "Open Chrome and check Claude in Chrome extension" |
+| EverBee overlay missing | No Mo. Sales / List. Age after 5s | Say: "EverBee extension not active. Check it's enabled." then STOP. |
+| EverBee not logged in | Overlay shows login prompt | Say: "Please log into EverBee, then say continue" then STOP. |
+| Etsy CAPTCHA / block | Screenshot shows CAPTCHA or access denied | Say: "Etsy CAPTCHA — please solve it, then say continue" then STOP. |
+| < target after all keywords | Searched all generated keywords | Save report with however many found. Note the shortfall. |

--- a/src/host-runner.ts
+++ b/src/host-runner.ts
@@ -1,0 +1,239 @@
+/**
+ * Host Runner for NanoClaw
+ * Spawns claude CLI directly on the host (not in a container) for skills
+ * that need Chrome MCP access (e.g., scout with EverBee).
+ *
+ * Intermediate messages: The agent writes IPC JSON files via Bash.
+ * The existing IPC watcher picks them up and routes to the channel.
+ */
+import { ChildProcess, spawn } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+import { CONTAINER_TIMEOUT } from './config.js';
+import { ContainerOutput } from './container-runner.js';
+import { readEnvFile } from './env.js';
+import { resolveGroupFolderPath, resolveGroupIpcPath } from './group-folder.js';
+import { logger } from './logger.js';
+import { RegisteredGroup } from './types.js';
+
+export interface HostRunnerInput {
+  prompt: string;
+  groupFolder: string;
+  chatJid: string;
+  assistantName?: string;
+}
+
+/**
+ * Read and prepare a skill's SKILL.md content.
+ * Strips YAML frontmatter and appends IPC instructions.
+ */
+function buildSkillPrompt(
+  skillName: string,
+  chatJid: string,
+  ipcMessagesDir: string,
+  groupDir: string,
+): string {
+  const projectRoot = process.cwd();
+  const skillPath = path.join(
+    projectRoot,
+    '.claude',
+    'skills',
+    skillName,
+    'SKILL.md',
+  );
+
+  if (!fs.existsSync(skillPath)) {
+    throw new Error(`Skill "${skillName}" not found at ${skillPath}`);
+  }
+
+  let content = fs.readFileSync(skillPath, 'utf-8');
+  // Strip YAML frontmatter
+  content = content.replace(/^---[\s\S]*?---\n*/, '');
+
+  // Append IPC instructions so the agent can send status updates
+  const ipcInstructions = `
+
+## Sending Messages to User
+
+To send a message to the user while you're still working, use Bash:
+
+\`\`\`bash
+echo '{"type":"message","chatJid":"${chatJid}","text":"YOUR MESSAGE HERE"}' > ${ipcMessagesDir}/msg_$(date +%s%N).json
+\`\`\`
+
+Use this for progress updates like "Searching keyword 3/8..." or "Found 14/25 so far".
+
+## Output Directory
+
+Save research reports to: ${groupDir}/research/
+`;
+
+  return content + ipcInstructions;
+}
+
+export async function runHostSkillAgent(
+  group: RegisteredGroup,
+  input: HostRunnerInput,
+  onProcess: (proc: ChildProcess) => void,
+  onOutput?: (output: ContainerOutput) => Promise<void>,
+): Promise<ContainerOutput> {
+  const startTime = Date.now();
+  const hostSkill = group.hostSkill!;
+
+  const groupDir = resolveGroupFolderPath(group.folder);
+  const ipcDir = resolveGroupIpcPath(group.folder);
+  const ipcMessagesDir = path.join(ipcDir, 'messages');
+  fs.mkdirSync(ipcMessagesDir, { recursive: true });
+  fs.mkdirSync(path.join(groupDir, 'research'), { recursive: true });
+  fs.mkdirSync(path.join(groupDir, 'logs'), { recursive: true });
+
+  let skillPrompt: string;
+  try {
+    skillPrompt = buildSkillPrompt(
+      hostSkill,
+      input.chatJid,
+      ipcMessagesDir,
+      groupDir,
+    );
+  } catch (err) {
+    const msg =
+      err instanceof Error ? err.message : `Failed to load skill: ${err}`;
+    logger.error({ hostSkill, err }, 'Failed to load skill');
+    return { status: 'error', result: null, error: msg };
+  }
+
+  // Read secrets — same pattern as container-runner.ts
+  const secrets = readEnvFile(['ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN']);
+
+  const configTimeout = group.containerConfig?.timeout || CONTAINER_TIMEOUT;
+
+  logger.info(
+    { group: group.name, hostSkill, groupDir },
+    'Spawning host skill agent',
+  );
+
+  const args = [
+    '-p',
+    '--chrome',
+    '--model',
+    'sonnet',
+    '--dangerously-skip-permissions',
+    '--append-system-prompt',
+    skillPrompt,
+    input.prompt,
+  ];
+
+  const child = spawn('claude', args, {
+    cwd: groupDir,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, ...secrets },
+  });
+
+  onProcess(child);
+
+  return new Promise((resolve) => {
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      logger.error(
+        { group: group.name, hostSkill },
+        'Host skill timeout, killing process',
+      );
+      child.kill('SIGTERM');
+      setTimeout(() => {
+        if (!child.killed) child.kill('SIGKILL');
+      }, 10000);
+    }, configTimeout);
+
+    child.stdout!.on('data', (chunk: Buffer) => {
+      const text = chunk.toString();
+      if (stdout.length < 1_000_000) stdout += text;
+    });
+
+    child.stderr!.on('data', (chunk: Buffer) => {
+      const text = chunk.toString();
+      if (stderr.length < 100_000) stderr += text;
+      // Log stderr lines for debugging
+      for (const line of text.trim().split('\n')) {
+        if (line) logger.debug({ hostSkill }, line);
+      }
+    });
+
+    child.on('close', async (code) => {
+      clearTimeout(timeout);
+      const duration = Date.now() - startTime;
+
+      // Write log file
+      const ts = new Date().toISOString().replace(/[:.]/g, '-');
+      const logFile = path.join(groupDir, 'logs', `host-skill-${ts}.log`);
+      fs.writeFileSync(
+        logFile,
+        [
+          `=== Host Skill Run Log ===`,
+          `Skill: ${hostSkill}`,
+          `Group: ${group.name}`,
+          `Duration: ${duration}ms`,
+          `Exit Code: ${code}`,
+          `Timed Out: ${timedOut}`,
+          ``,
+          `=== Stderr ===`,
+          stderr.slice(0, 5000),
+          ``,
+          `=== Stdout (last 2000 chars) ===`,
+          stdout.slice(-2000),
+        ].join('\n'),
+      );
+
+      if (timedOut) {
+        logger.error(
+          { group: group.name, hostSkill, duration },
+          'Host skill timed out',
+        );
+        resolve({
+          status: 'error',
+          result: null,
+          error: `Host skill timed out after ${configTimeout}ms`,
+        });
+        return;
+      }
+
+      if (code !== 0) {
+        logger.error(
+          { group: group.name, hostSkill, code, duration },
+          'Host skill failed',
+        );
+        resolve({
+          status: 'error',
+          result: null,
+          error: `claude exited with code ${code}: ${stderr.slice(-500)}`,
+        });
+        return;
+      }
+
+      logger.info(
+        { group: group.name, hostSkill, duration },
+        'Host skill completed',
+      );
+
+      const result = stdout.trim() || null;
+      if (onOutput && result) {
+        await onOutput({ status: 'success', result });
+      }
+      resolve({ status: 'success', result });
+    });
+
+    child.on('error', (err) => {
+      clearTimeout(timeout);
+      logger.error({ group: group.name, hostSkill, err }, 'Host skill spawn error');
+      resolve({
+        status: 'error',
+        result: null,
+        error: `Failed to spawn claude: ${err.message}`,
+      });
+    });
+  });
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,7 @@ export interface RegisteredGroup {
   added_at: string;
   containerConfig?: ContainerConfig;
   requiresTrigger?: boolean; // Default: true for groups, false for solo chats
+  hostSkill?: string; // Skill name from .claude/skills/{name}/SKILL.md — runs on host with Chrome MCP (not in container)
 }
 
 export interface NewMessage {


### PR DESCRIPTION
## Summary
- Adds a host-side execution path for skills that require Chrome MCP (e.g., Scout with EverBee)
- When a registered group has `hostSkill` set, `runAgent()` spawns `claude` CLI directly on the host instead of in a Docker container, giving it access to Chrome MCP bridge sockets
- Intermediate status updates flow through IPC files (same mechanism containers use), picked up by the existing IPC watcher

## Changes
- `src/types.ts` — Add `hostSkill` field to `RegisteredGroup`
- `src/host-runner.ts` — New file: spawns `claude -p --chrome` on host with skill SKILL.md as system prompt
- `src/index.ts` — Dispatch to host runner when `hostSkill` is set
- `src/db.ts` — Add `host_skill` column migration + update getters/setters
- `.claude/skills/scout/SKILL.md` — Scout skill definition

## Test plan
- [ ] `npm run build` compiles cleanly
- [ ] `npm test` passes (no regressions)
- [ ] Register scout group with `hostSkill: 'scout'` and verify `claude` spawns on host
- [ ] Verify IPC messages route to Telegram
- [ ] Verify Chrome MCP tools accessible to the spawned process

🤖 Generated with [Claude Code](https://claude.com/claude-code)