### PR TITLE
fix: prevent scheduled tasks from running twice

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -442,6 +442,14 @@ export function getDueTasks(): ScheduledTask[] {
     .all(now) as ScheduledTask[];
 }
 
+/**
+ * Advance next_run immediately when a task is claimed for execution.
+ * Prevents getDueTasks() from re-picking the same task while it is still running.
+ */
+export function claimTaskRun(id: string, nextRun: string | null): void {
+  db.prepare(`UPDATE scheduled_tasks SET next_run = ? WHERE id = ?`).run(nextRun, id);
+}
+
 export function updateTaskAfterRun(
   id: string,
   nextRun: string | null,

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -1,17 +1,15 @@
 import fs from 'fs';
 import path from 'path';
 
-import { CronExpressionParser } from 'cron-parser';
-
 import {
   DATA_DIR,
   IPC_POLL_INTERVAL,
   MAIN_GROUP_FOLDER,
-  TIMEZONE,
 } from './config.js';
 import { AvailableGroup } from './container-runner.js';
 import { createTask, deleteTask, getTaskById, updateTask } from './db.js';
 import { isValidGroupFolder } from './group-folder.js';
+import { computeNextRun } from './schedule-utils.js';
 import { logger } from './logger.js';
 import { RegisteredGroup } from './types.js';
 
@@ -211,30 +209,7 @@ export async function processTaskIpc(
         const scheduleType = data.schedule_type as 'cron' | 'interval' | 'once';
 
         let nextRun: string | null = null;
-        if (scheduleType === 'cron') {
-          try {
-            const interval = CronExpressionParser.parse(data.schedule_value, {
-              tz: TIMEZONE,
-            });
-            nextRun = interval.next().toISOString();
-          } catch {
-            logger.warn(
-              { scheduleValue: data.schedule_value },
-              'Invalid cron expression',
-            );
-            break;
-          }
-        } else if (scheduleType === 'interval') {
-          const ms = parseInt(data.schedule_value, 10);
-          if (isNaN(ms) || ms <= 0) {
-            logger.warn(
-              { scheduleValue: data.schedule_value },
-              'Invalid interval',
-            );
-            break;
-          }
-          nextRun = new Date(Date.now() + ms).toISOString();
-        } else if (scheduleType === 'once') {
+        if (scheduleType === 'once') {
           const scheduled = new Date(data.schedule_value);
           if (isNaN(scheduled.getTime())) {
             logger.warn(
@@ -244,6 +219,16 @@ export async function processTaskIpc(
             break;
           }
           nextRun = scheduled.toISOString();
+        } else {
+          try {
+            nextRun = computeNextRun(scheduleType, data.schedule_value);
+          } catch {
+            logger.warn(
+              { scheduleType, scheduleValue: data.schedule_value },
+              'Invalid schedule value',
+            );
+            break;
+          }
         }
 
         const taskId = `task-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;

--- a/src/schedule-utils.ts
+++ b/src/schedule-utils.ts
@@ -1,0 +1,23 @@
+import { CronExpressionParser } from 'cron-parser';
+
+import { TIMEZONE } from './config.js';
+
+/**
+ * Computes the next run time for a scheduled task.
+ * For 'once' tasks returns null (no repeat after first run).
+ */
+export function computeNextRun(
+  scheduleType: 'cron' | 'interval' | 'once',
+  scheduleValue: string,
+): string | null {
+  if (scheduleType === 'cron') {
+    const interval = CronExpressionParser.parse(scheduleValue, { tz: TIMEZONE });
+    return interval.next().toISOString();
+  }
+  if (scheduleType === 'interval') {
+    const ms = parseInt(scheduleValue, 10);
+    return new Date(Date.now() + ms).toISOString();
+  }
+  // 'once' — no next run
+  return null;
+}


### PR DESCRIPTION
### Problem 

Scheduled tasks execute twice due to a race condition between the scheduler poll loop and task completion.

**Root cause**: getDueTasks() queries for tasks where next_run <= now. The scheduler polls every 60 seconds, but tasks hold a container slot for the full IDLE_TIMEOUT duration (~30 minutes) while the container waits for follow-up messages. Since 
next_run was only updated in updateTaskAfterRun() — called at the very end — every poll during that window re-discovered the same task as due. 

The existing dedup check in `enqueueTask()` only covers `pendingTasks`. Once a task starts running it leaves that array, so the duplicate passes the check and queues behind the first run. When the first finishes, `drainGroup()` fires the second immediately.

Confirmed in task_run_logs: two successful runs of the same task separated by ~30 minutes, every day.

### Fix 

Claim `next_run` before enqueuing. When the scheduler picks up a due task it immediately advances `next_run` to the next occurrence via `claimTaskRun()`. Subsequent polls find nothing due. `updateTaskAfterRun()` confirms the same value at the end of execution.

Extract `computeNextRun()` helper. The cron/interval next-run calculation was duplicated in ipc.ts (task creation) and task-scheduler.ts (post-run). Both now share src/schedule-utils.ts.

### Changes 

- src/schedule-utils.ts — new `computeNextRun(scheduleType, scheduleValue)` helper
- src/db.ts — new `claimTaskRun(id, nextRun)` that advances `next_run` on pickup
- src/task-scheduler.ts — call `claimTaskRun()`before `enqueueTask()`; use `computeNextRun()` instead of inline logic
- src/ipc.ts — use `computeNextRun()` instead of inline logic 

Addresses issue #138 