### PR TITLE
fix(agent-runner): break for-await loop after result to unblock IPC handling

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -482,6 +482,14 @@ async function runQuery(
         result: textResult || null,
         newSessionId
       });
+
+      // Break out of the for-await loop after receiving a result.
+      // This allows control to return to the outer while(true) loop where
+      // waitForIpcMessage() can properly handle follow-up messages.
+      // Without this break, the for-await loop hangs waiting for more stream
+      // input that the SDK will never process after yielding a result.
+      // See: https://github.com/qwibitai/nanoclaw/issues/233
+      break;
     }
   }
 


### PR DESCRIPTION
 ## Type of Change

  - [ ] **Skill** - adds a new skill in `.claude/skills/`
  - [x] **Fix** - bug fix or security fix to source code
  - [ ] **Simplification** - reduces or simplifies source code

  ## Summary

  Fixes #233 - Follow-up messages sent via IPC to an active container were silently dropped.

  ## Problem

  When a follow-up message was sent via IPC after the agent produced a result but before the container timed out, the message
  was written to the IPC input directory but never processed. The container would sit idle until the 25-minute idle timeout
  killed it.

  ## Root Cause

  In `container/agent-runner/src/index.ts`, the `for await (const message of query(...))` loop processes SDK messages. After
  receiving a `result` message:

  1. The loop continued waiting for more stream input
  2. `pollIpcDuringQuery()` pushed IPC messages into the stream
  3. But the SDK had already finished processing and wouldn't read from the stream again
  4. The outer `while(true)` loop with `waitForIpcMessage()` could never execute

  ## Fix

  Break out of the `for-await` loop immediately after receiving a `result` message. This allows control to return to the outer
   `while(true)` loop where `waitForIpcMessage()` can properly handle follow-up messages.

  ## Test plan

  - [ ] Send a message that triggers a quick agent response
  - [ ] Wait 1+ minutes after the response
  - [ ] Send a follow-up message
  - [ ] Verify the follow-up message is processed (not dropped)
  - [ ] Verify no 25-minute idle timeout delay