### PR TITLE
feat: add support for custom Anthropic API endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,10 @@
+# Anthropic API Key (required)
+# Get your API key from: https://console.anthropic.com/settings/keys
+ANTHROPIC_API_KEY=your_api_key_here
 
+# Optional: Custom API endpoint for proxies or alternative endpoints
+# Leave commented out to use the default Anthropic API endpoint
+# ANTHROPIC_BASE_URL=https://your-proxy-endpoint.com
+
+# Optional: Claude Code OAuth Token (alternative to API key for Claude Pro/Max subscribers)
+# CLAUDE_CODE_OAUTH_TOKEN=your_token_here

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -204,7 +204,11 @@ function buildVolumeMounts(
  * Secrets are never written to disk or mounted as files.
  */
 function readSecrets(): Record<string, string> {
-  return readEnvFile(['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_API_KEY']);
+  return readEnvFile([
+    'CLAUDE_CODE_OAUTH_TOKEN',
+    'ANTHROPIC_API_KEY',
+    'ANTHROPIC_BASE_URL',
+  ]);
 }
 
 function buildContainerArgs(


### PR DESCRIPTION
## Summary
Adds support for custom Anthropic API endpoint configuration via the `ANTHROPIC_BASE_URL` environment variable. This enables users to route API requests through corporate proxies or use alternative Anthropic-compatible endpoints.

## Changes
- **src/container-runner.ts**: Added `ANTHROPIC_BASE_URL` to the `readSecrets()` function so it gets passed securely to the container agent
- **.env.example**: Updated with comprehensive documentation for all authentication options including the new `ANTHROPIC_BASE_URL` setting

## Use Cases
- Corporate environments requiring API requests to go through internal proxies
- Development/testing with alternative Anthropic-compatible endpoints
- Regional endpoint configurations

## Usage
Users can now set the custom endpoint in their `.env` file:
```bash
ANTHROPIC_API_KEY=your_api_key_here
ANTHROPIC_BASE_URL=https://your-proxy-endpoint.com
```

The environment variable is securely passed to the container via stdin (never written to disk) and made available to the Claude Agent SDK.

## Testing
- ✅ Successfully tested with custom proxy endpoint
- ✅ Container builds and runs correctly
- ✅ WhatsApp authentication and message handling work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)