### PR TITLE
feat: add update_project IPC host command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ Single Node.js process that connects to WhatsApp, routes messages to Claude Agen
 | `src/config.ts` | Trigger pattern, paths, intervals |
 | `src/container-runner.ts` | Spawns agent containers with mounts |
 | `src/task-scheduler.ts` | Runs scheduled tasks |
+| `src/host-commands.ts` | IPC host command handlers (update_project) |
 | `src/db.ts` | SQLite operations |
 | `groups/{name}/CLAUDE.md` | Per-group memory (isolated) |
 | `container/skills/agent-browser.md` | Browser automation tool (available to all agents via Bash) |

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -210,11 +210,15 @@ function readSecrets(): Record<string, string> {
 function buildContainerArgs(
   mounts: VolumeMount[],
   containerName: string,
+  chatJid: string,
 ): string[] {
   const args: string[] = ['run', '-i', '--rm', '--name', containerName];
 
   // Pass host timezone so container's local time matches the user's
   args.push('-e', `TZ=${TIMEZONE}`);
+
+  // Pass chat JID so the agent knows which conversation it's serving
+  args.push('-e', `CHAT_JID=${chatJid}`);
 
   // Run as host user so bind-mounted files are accessible.
   // Skip when running as root (uid 0), as the container's node user (uid 1000),
@@ -253,7 +257,7 @@ export async function runContainerAgent(
   const mounts = buildVolumeMounts(group, input.isMain);
   const safeName = group.folder.replace(/[^a-zA-Z0-9-]/g, '-');
   const containerName = `nanoclaw-${safeName}-${Date.now()}`;
-  const containerArgs = buildContainerArgs(mounts, containerName);
+  const containerArgs = buildContainerArgs(mounts, containerName, input.chatJid);
 
   logger.debug(
     {

--- a/src/host-commands.test.ts
+++ b/src/host-commands.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { handleHostCommand } from './host-commands.js';
+
+let sendMessage: (jid: string, text: string) => Promise<void>;
+let sendMessageCalls: Array<{ jid: string; text: string }>;
+
+beforeEach(() => {
+  sendMessageCalls = [];
+  sendMessage = async (jid: string, text: string) => {
+    sendMessageCalls.push({ jid, text });
+  };
+});
+
+// --- type routing ---
+
+describe('handleHostCommand type routing', () => {
+  it('returns false for unknown type', async () => {
+    const result = await handleHostCommand(
+      { type: 'unknown_command' },
+      'main',
+      true,
+      sendMessage,
+    );
+    expect(result).toBe(false);
+    expect(sendMessageCalls).toHaveLength(0);
+  });
+
+  it('returns true for update_project', async () => {
+    const result = await handleHostCommand(
+      { type: 'update_project' },
+      'main',
+      true,
+      sendMessage,
+    );
+    expect(result).toBe(true);
+  });
+});
+
+// --- authorization ---
+
+describe('handleHostCommand authorization', () => {
+  it('blocks non-main group', async () => {
+    const result = await handleHostCommand(
+      { type: 'update_project', chatJid: 'other@g.us' },
+      'other-group',
+      false,
+      sendMessage,
+    );
+    expect(result).toBe(true);
+    expect(sendMessageCalls).toHaveLength(0);
+  });
+});
+
+// --- dedup window ---
+
+describe('handleHostCommand dedup', () => {
+  it('ignores duplicate requests within dedup window', async () => {
+    // First call should proceed
+    await handleHostCommand(
+      { type: 'update_project' },
+      'main',
+      true,
+      sendMessage,
+    );
+
+    // Second call within 30s should be deduped (no additional sendMessage calls)
+    const callsBefore = sendMessageCalls.length;
+    const result = await handleHostCommand(
+      { type: 'update_project' },
+      'main',
+      true,
+      sendMessage,
+    );
+    expect(result).toBe(true);
+    expect(sendMessageCalls).toHaveLength(callsBefore);
+  });
+});
+
+// --- chatJid validation ---
+
+describe('handleHostCommand chatJid validation', () => {
+  it('does not send messages when chatJid is invalid', async () => {
+    await handleHostCommand(
+      { type: 'update_project', chatJid: 'no-at-sign' },
+      'main',
+      true,
+      sendMessage,
+    );
+    expect(sendMessageCalls).toHaveLength(0);
+  });
+
+  it('does not send messages when chatJid is missing', async () => {
+    await handleHostCommand(
+      { type: 'update_project' },
+      'main',
+      true,
+      sendMessage,
+    );
+    expect(sendMessageCalls).toHaveLength(0);
+  });
+});

--- a/src/host-commands.ts
+++ b/src/host-commands.ts
@@ -1,0 +1,153 @@
+import { exec } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import { promisify } from 'util';
+
+import { logger } from './logger.js';
+
+const execAsync = promisify(exec);
+
+const DEDUP_WINDOW_MS = 30_000;
+const CMD_TIMEOUT_MS = 300_000; // 5 minutes for npm install / build
+let lastUpdateTime = 0;
+
+type ServiceManager = 'launchd' | 'systemd' | 'none';
+
+function detectServiceManager(): ServiceManager {
+  if (os.platform() === 'darwin') return 'launchd';
+  if (os.platform() === 'linux') {
+    try {
+      const init = fs.readFileSync('/proc/1/comm', 'utf-8').trim();
+      if (init === 'systemd') return 'systemd';
+    } catch {
+      // /proc not available
+    }
+  }
+  return 'none';
+}
+
+function restartService(): void {
+  const manager = detectServiceManager();
+  switch (manager) {
+    case 'launchd': {
+      const uid = process.getuid?.() ?? 501;
+      exec(`launchctl kickstart -k gui/${uid}/com.nanoclaw`);
+      break;
+    }
+    case 'systemd': {
+      const isRootUser = process.getuid?.() === 0;
+      const cmd = isRootUser
+        ? 'systemctl restart nanoclaw'
+        : 'systemctl --user restart nanoclaw';
+      exec(cmd);
+      break;
+    }
+    default:
+      logger.warn('No service manager detected, skipping restart');
+  }
+}
+
+export async function handleHostCommand(
+  data: { type: string; chatJid?: string },
+  sourceGroup: string,
+  isMain: boolean,
+  sendMessage: (jid: string, text: string) => Promise<void>,
+): Promise<boolean> {
+  if (data.type !== 'update_project') return false;
+
+  if (!isMain) {
+    logger.warn(
+      { sourceGroup },
+      'Unauthorized update_project attempt blocked',
+    );
+    return true;
+  }
+
+  const now = Date.now();
+  if (now - lastUpdateTime < DEDUP_WINDOW_MS) {
+    logger.info('Duplicate update_project request ignored (within dedup window)');
+    return true;
+  }
+  lastUpdateTime = now;
+
+  const chatJid =
+    data.chatJid && (data.chatJid.includes('@') || data.chatJid.startsWith('tg:'))
+      ? data.chatJid
+      : undefined;
+
+  const notify = async (text: string) => {
+    if (chatJid) {
+      try {
+        await sendMessage(chatJid, text);
+      } catch (err) {
+        logger.error({ err, chatJid }, 'Failed to send update notification');
+      }
+    }
+    logger.info(text);
+  };
+
+  try {
+    // 1. Fetch upstream
+    await notify('Checking for upstream changes...');
+    await execAsync('git fetch upstream main');
+
+    // 2. Check if upstream has new commits beyond HEAD
+    const { stdout: revCount } = await execAsync(
+      'git rev-list --count HEAD..upstream/main',
+    );
+    if (parseInt(revCount.trim(), 10) === 0) {
+      await notify('Already up to date.');
+      return true;
+    }
+
+    const { stdout: diffStat } = await execAsync(
+      'git diff --stat HEAD...upstream/main',
+    );
+    await notify(`Changes detected (${revCount.trim()} commits):\n${diffStat.trim()}`);
+
+    // 3. Merge
+    try {
+      const { stdout: mergeResult } = await execAsync('git merge upstream/main');
+      if (mergeResult.includes('Already up to date')) {
+        await notify('Already up to date.');
+        return true;
+      }
+    } catch (mergeErr) {
+      await execAsync('git merge --abort');
+      const errMsg =
+        mergeErr instanceof Error ? mergeErr.message : String(mergeErr);
+      await notify(`Merge conflict, rolled back:\n${errMsg}`);
+      return true;
+    }
+
+    // 4. npm install (if package.json changed)
+    const { stdout: pkgChanged } = await execAsync(
+      'git diff --name-only HEAD~1 HEAD -- package.json',
+    );
+    if (pkgChanged.trim()) {
+      await notify('Installing dependencies...');
+      await execAsync('npm install', { timeout: CMD_TIMEOUT_MS });
+    }
+
+    // 5. Build
+    try {
+      await execAsync('npm run build', { timeout: CMD_TIMEOUT_MS });
+    } catch (buildErr) {
+      await execAsync('git reset --hard HEAD~1');
+      const errMsg =
+        buildErr instanceof Error ? buildErr.message : String(buildErr);
+      await notify(`Build failed, rolled back to previous version:\n${errMsg}`);
+      return true;
+    }
+
+    await notify('Update complete! Restarting service...');
+
+    // 6. Restart
+    restartService();
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    await notify(`Update failed:\n${errMsg}`);
+  }
+
+  return true;
+}

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -12,6 +12,7 @@ import {
 import { AvailableGroup } from './container-runner.js';
 import { createTask, deleteTask, getTaskById, updateTask } from './db.js';
 import { isValidGroupFolder } from './group-folder.js';
+import { handleHostCommand } from './host-commands.js';
 import { logger } from './logger.js';
 import { RegisteredGroup } from './types.js';
 
@@ -381,7 +382,16 @@ export async function processTaskIpc(
       }
       break;
 
-    default:
-      logger.warn({ type: data.type }, 'Unknown IPC task type');
+    default: {
+      const handled = await handleHostCommand(
+        data,
+        sourceGroup,
+        isMain,
+        deps.sendMessage,
+      );
+      if (!handled) {
+        logger.warn({ type: data.type }, 'Unknown IPC task type');
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Container agents can request upstream updates via IPC (`update_project` host command)
- Host automatically fetches, merges, installs deps, builds, and restarts the service
- Cross-platform restart: launchd (macOS), systemd (Linux), graceful skip (unknown)
- Rollback on merge conflict or build failure with notification to chat
- Integrate `CHAT_JID` into `buildContainerArgs` (removes splice hack)
- 5-minute timeout on `npm install` / `npm run build`

## Files changed
- `src/host-commands.ts` — Host command handler with `update_project` implementation
- `src/host-commands.test.ts` — Unit tests (type routing, auth, dedup, chatJid validation)
- `src/ipc.ts` — Route unknown IPC task types through `handleHostCommand`
- `src/container-runner.ts` — Pass `CHAT_JID` env to container (replaces splice hack)
- `CLAUDE.md` — Add `host-commands.ts` to Key Files table

## Test plan
- [x] `npm run build` passes
- [x] Unit tests pass (`src/host-commands.test.ts`)
- [x] Manual IPC test: "Already up to date." response confirmed via Telegram
- [x] Service restart works correctly after update

🤖 Generated with [Claude Code](https://claude.com/claude-code)