### PR TITLE
fix: prevent IPC message drops and WhatsApp reconnect loop

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -310,10 +310,10 @@ function drainIpcInput(): string[] {
       const filePath = path.join(IPC_INPUT_DIR, file);
       try {
         const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-        fs.unlinkSync(filePath);
         if (data.type === 'message' && data.text) {
           messages.push(data.text);
         }
+        try { fs.unlinkSync(filePath); } catch { /* file already gone, fine */ }
       } catch (err) {
         log(`Failed to process input file ${file}: ${err instanceof Error ? err.message : String(err)}`);
         try { fs.unlinkSync(filePath); } catch { /* ignore */ }

--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -51,6 +51,14 @@ export class WhatsAppChannel implements Channel {
   }
 
   private async connectInternal(onFirstOpen?: () => void): Promise<void> {
+    // Clean up old socket to prevent conflict loops on reconnect
+    if (this.sock) {
+      this.sock.ev.removeAllListeners('connection.update');
+      this.sock.ev.removeAllListeners('creds.update');
+      this.sock.ev.removeAllListeners('messages.upsert');
+      this.sock.end(undefined);
+    }
+
     const authDir = path.join(STORE_DIR, 'auth');
     fs.mkdirSync(authDir, { recursive: true });
 


### PR DESCRIPTION
## Summary

- **IPC message drop fix**: In `container/agent-runner/src/index.ts`, `drainIpcInput()` placed `messages.push()` after `fs.unlinkSync()`. When unlink threw ENOENT (common on Docker volume mounts, especially Windows), the catch block was entered and the successfully-read message was silently dropped. Fix: extract message content before attempting unlink, and wrap unlink in its own try-catch.

- **WhatsApp reconnect loop fix**: In `src/channels/whatsapp.ts`, `connectInternal()` created a new socket without cleaning up the old one's event listeners. When the old socket received a "conflict: replaced" disconnect, its handler called `connectInternal()` again, creating an infinite reconnect loop. Fix: remove all event listeners and end the old socket at the start of `connectInternal()`.

## Test plan

- [ ] Start NanoClaw, verify WhatsApp connects without "conflict: replaced" loop
- [ ] Send IPC messages to a running container, verify they are received (not dropped)
- [ ] Disconnect/reconnect WhatsApp, verify clean reconnect without duplicate sockets
- [ ] Run `npm run build` to verify clean compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)