### PR TITLE
fix: prevent scheduled tasks from running twice when execution exceeds poll interval

### DIFF
--- a/src/task-scheduler.test.ts
+++ b/src/task-scheduler.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { _initTestDatabase, createTask, getTaskById } from './db.js';
 import {
   _resetSchedulerLoopForTests,
+  computeNextRun,
   startSchedulerLoop,
 } from './task-scheduler.js';
 
@@ -49,5 +50,117 @@ describe('task scheduler', () => {
 
     const task = getTaskById('task-invalid-folder');
     expect(task?.status).toBe('paused');
+  });
+
+  it('advances next_run before enqueuing to prevent double-execution', async () => {
+    const pastDate = new Date(Date.now() - 60_000).toISOString();
+
+    createTask({
+      id: 'task-cron',
+      group_folder: 'main',
+      chat_jid: 'test@g.us',
+      prompt: 'sweep',
+      schedule_type: 'cron',
+      schedule_value: '0 * * * *', // hourly
+      context_mode: 'isolated',
+      next_run: pastDate,
+      status: 'active',
+      created_at: '2026-02-22T00:00:00.000Z',
+    });
+
+    let nextRunAtEnqueueTime: string | null | undefined;
+
+    const enqueueTask = vi.fn(
+      (_groupJid: string, _taskId: string, _fn: () => Promise<void>) => {
+        // Capture next_run at the moment enqueueTask is called
+        const t = getTaskById('task-cron');
+        nextRunAtEnqueueTime = t?.next_run;
+      },
+    );
+
+    startSchedulerLoop({
+      registeredGroups: () => ({}),
+      getSessions: () => ({}),
+      queue: { enqueueTask } as any,
+      onProcess: () => {},
+      sendMessage: async () => {},
+    });
+
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(enqueueTask).toHaveBeenCalledOnce();
+    // next_run should have been advanced past "now" before the task was enqueued
+    expect(new Date(nextRunAtEnqueueTime!).getTime()).toBeGreaterThan(
+      Date.now(),
+    );
+  });
+
+  it('sets next_run to null for once tasks before enqueuing', async () => {
+    const pastDate = new Date(Date.now() - 60_000).toISOString();
+
+    createTask({
+      id: 'task-once',
+      group_folder: 'main',
+      chat_jid: 'test@g.us',
+      prompt: 'run once',
+      schedule_type: 'once',
+      schedule_value: pastDate,
+      context_mode: 'isolated',
+      next_run: pastDate,
+      status: 'active',
+      created_at: '2026-02-22T00:00:00.000Z',
+    });
+
+    let nextRunAtEnqueueTime: string | null | undefined;
+
+    const enqueueTask = vi.fn(
+      (_groupJid: string, _taskId: string, _fn: () => Promise<void>) => {
+        const t = getTaskById('task-once');
+        nextRunAtEnqueueTime = t?.next_run;
+      },
+    );
+
+    startSchedulerLoop({
+      registeredGroups: () => ({}),
+      getSessions: () => ({}),
+      queue: { enqueueTask } as any,
+      onProcess: () => {},
+      sendMessage: async () => {},
+    });
+
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(enqueueTask).toHaveBeenCalledOnce();
+    // once tasks should have next_run set to null so they aren't re-picked
+    expect(nextRunAtEnqueueTime).toBeNull();
+  });
+});
+
+describe('computeNextRun', () => {
+  it('returns next cron occurrence for cron tasks', () => {
+    const result = computeNextRun({
+      schedule_type: 'cron',
+      schedule_value: '0 * * * *',
+    });
+    expect(result).toBeTruthy();
+    expect(new Date(result!).getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it('returns fromTime + interval for interval tasks', () => {
+    const fromTime = new Date('2026-03-01T12:00:00Z').getTime();
+    const intervalMs = 3600000; // 1 hour
+    const result = computeNextRun(
+      { schedule_type: 'interval', schedule_value: String(intervalMs) },
+      fromTime,
+    );
+    expect(result).toBe(new Date(fromTime + intervalMs).toISOString());
+  });
+
+  it('returns null for once tasks', () => {
+    const result = computeNextRun({
+      schedule_type: 'once',
+      schedule_value: '2026-03-01T00:00:00Z',
+    });
+    expect(result).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Scheduled tasks that take longer than `SCHEDULER_POLL_INTERVAL` (60s) get picked up again by the next poll because `next_run` is only updated at the end of `runTask` via `updateTaskAfterRun`. The queue's duplicate check only looks at `pendingTasks`, not the currently running task, so the same task gets enqueued and runs a second time.
- Fix: advance `next_run` in the database **before** enqueuing the task, closing the race window entirely.
- Extract `computeNextRun` helper to eliminate duplicated cron/interval/once logic.
- At the end of `runTask`, re-derive `next_run` from completion time — prevents interval drift accumulation across long-running tasks.
- `once` tasks now also get `next_run` set to `null` pre-enqueue, fixing a secondary race where a long-running once task could be picked up again.
- Regression tests verify `next_run` is advanced before `enqueueTask` is called, plus unit tests for `computeNextRun`.

## Test plan

- [x] Existing tests pass (`vitest run src/task-scheduler.test.ts`)
- [x] New regression test covers the race condition (cron + once tasks)
- [x] `computeNextRun` unit tests cover all three schedule types
- [x] `tsc --noEmit` clean
- [x] Verified in production with an hourly cron task that takes ~66s — no longer double-executes