### PR TITLE
fix: make CLAUDE_MODEL env var work end-to-end

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -417,6 +417,7 @@ async function runQuery(
   for await (const message of query({
     prompt: stream,
     options: {
+      model: sdkEnv.CLAUDE_MODEL || undefined,
       cwd: '/workspace/group',
       additionalDirectories: extraDirs.length > 0 ? extraDirs : undefined,
       resume: sessionId,
@@ -513,6 +514,11 @@ async function main(): Promise<void> {
   const sdkEnv: Record<string, string | undefined> = { ...process.env };
   for (const [key, value] of Object.entries(containerInput.secrets || {})) {
     sdkEnv[key] = value;
+  }
+
+  // Propagate CLAUDE_MODEL so the Claude Code CLI subprocess uses the configured model
+  if (sdkEnv.CLAUDE_MODEL) {
+    sdkEnv.ANTHROPIC_MODEL = sdkEnv.CLAUDE_MODEL;
   }
 
   const __dirname = path.dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
## Summary

Setting `CLAUDE_MODEL=claude-opus-4-6` in `.env` had no effect — the agent always used the default model. This fixes all three root causes:

- **readSecrets() allowlist**: `CLAUDE_MODEL` was not in the allowlist, so it never reached the container. Added it alongside `CLAUDE_CODE_OAUTH_TOKEN` and `ANTHROPIC_API_KEY`.

- **Agent runner ignoring CLAUDE_MODEL**: The `query()` call had no `model` option. Now passes `sdkEnv.CLAUDE_MODEL` as the model option and also sets `ANTHROPIC_MODEL` so the CLI subprocess picks it up.

- **Stale agent-runner copies**: Per-group `agent-runner-src/` was only copied on first run and never updated. Now syncs on every container spawn so code changes take effect without manual intervention.

- **Belt-and-suspenders**: Model is also written into each group's `settings.json` on every spawn, so the Claude Code CLI reads it from settings as well.

## Test plan

- [x] `npm run build` compiles cleanly
- [x] All tests pass (`npx vitest run`)
- [x] Set `CLAUDE_MODEL=claude-opus-4-6` in `.env`, restart NanoClaw, verify agent uses Opus
- [x] Change `CLAUDE_MODEL` value, restart, verify new model is used without manual source patching
- [x] Verify existing groups with stale `agent-runner-src/` get updated on next spawn

Closes #472