### PR TITLE
feat: log tool_use calls in agent-runner for debugging

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -461,6 +461,15 @@ async function runQuery(
 
     if (message.type === 'assistant' && 'uuid' in message) {
       lastAssistantUuid = (message as { uuid: string }).uuid;
+      // Log tool use for debugging
+      const content = (message as { content?: Array<{ type: string; name?: string; input?: unknown }> }).content;
+      if (content) {
+        for (const block of content) {
+          if (block.type === 'tool_use') {
+            log(`Tool use: ${block.name} input=${JSON.stringify(block.input).slice(0, 200)}`);
+          }
+        }
+      }
     }
 
     if (message.type === 'system' && message.subtype === 'init') {


### PR DESCRIPTION
## Summary
- Log each tool invocation (name + truncated input) from assistant messages in the agent-runner
- Helps diagnose which tools the agent is calling and with what arguments during container execution
- Input is truncated to 200 chars to avoid log bloat

## Changes
- `container/agent-runner/src/index.ts` — Add tool_use logging in the assistant message handler

## Example output
```
Tool use: Bash input={"command":"ls -la /workspace/group","description":"List files"}
Tool use: Read input={"file_path":"/workspace/group/CLAUDE.md"}
Tool use: mcp__nanoclaw__send_message input={"message":"Hello from the agent"}
```

## Test plan
- [x] Verified logging output in container logs during agent execution
- [x] Confirmed truncation works for large tool inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)