### PR TITLE
fix: add CJK font support for Chromium screenshots

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -7,6 +7,7 @@ FROM node:22-slim
 RUN apt-get update && apt-get install -y \
     chromium \
     fonts-liberation \
+    fonts-noto-cjk \
     fonts-noto-color-emoji \
     libgbm1 \
     libnss3 \


### PR DESCRIPTION
## Summary
- Add `fonts-noto-cjk` to the container Dockerfile
- Chromium now renders CJK (Chinese, Japanese, Korean) text correctly in screenshots and PDF exports
- Without this, CJK characters appear as empty rectangles (tofu) when using `agent-browser screenshot`

## Changes
- `container/Dockerfile` — Add `fonts-noto-cjk` to apt-get install list (1 line)

## Test plan
- [x] Container rebuild with `./container/build.sh`
- [x] Screenshot of CJK web pages renders text correctly (tested with Korean sites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)