### PR TITLE
fix: normalize phone number and increase credential save delay in WhatsApp auth

### DIFF
--- a/src/whatsapp-auth.ts
+++ b/src/whatsapp-auth.ts
@@ -83,7 +83,9 @@ async function connectSocket(
     // Only on first connect (not reconnect after 515)
     setTimeout(async () => {
       try {
-        const code = await sock.requestPairingCode(phoneNumber!);
+        // Strip non-numeric characters (e.g. leading +) — Baileys expects digits only
+        const normalizedPhone = phoneNumber!.replace(/\D/g, '');
+        const code = await sock.requestPairingCode(normalizedPhone);
         console.log(`\n🔗 Your pairing code: ${code}\n`);
         console.log('  1. Open WhatsApp on your phone');
         console.log('  2. Tap Settings → Linked Devices → Link a Device');
@@ -143,8 +145,8 @@ async function connectSocket(
       console.log('  Credentials saved to store/auth/');
       console.log('  You can now start the NanoClaw service.\n');
 
-      // Give it a moment to save credentials, then exit
-      setTimeout(() => process.exit(0), 1000);
+      // Give credentials time to finish writing, then exit
+      setTimeout(() => process.exit(0), 3000);
     }
   });
 


### PR DESCRIPTION
## Summary

- Strip non-numeric characters (e.g. leading `+`) from the phone number before calling `requestPairingCode` — Baileys requires digits only and silently fails otherwise, breaking auth for anyone who enters their number with a `+`
- Increase post-authentication exit delay from 1s to 3s to give credentials time to finish writing to disk before the process exits

## Test plan

- [ ] Run setup with a phone number prefixed with `+` and verify pairing code is requested successfully
- [ ] Authenticate and confirm credentials are fully written before process exits

🤖 Generated with [Claude Code](https://claude.com/claude-code)