### PR TITLE
fix: use TIMEZONE constant for 'once' scheduled task timestamps

### DIFF
--- a/src/ipc-auth.test.ts
+++ b/src/ipc-auth.test.ts
@@ -682,7 +682,10 @@ describe('register_group success', () => {
 describe('parseLocalTimestamp', () => {
   it('parses a winter timestamp in UTC-offset timezone correctly', () => {
     // America/New_York is UTC-5 in February (EST)
-    const result = parseLocalTimestamp('2026-02-01T15:30:00', 'America/New_York');
+    const result = parseLocalTimestamp(
+      '2026-02-01T15:30:00',
+      'America/New_York',
+    );
     // 15:30 New York (EST = UTC-5) → 20:30 UTC
     expect(result.toISOString()).toBe('2026-02-01T20:30:00.000Z');
   });
@@ -696,7 +699,10 @@ describe('parseLocalTimestamp', () => {
 
   it('parses midnight correctly', () => {
     // America/Los_Angeles is UTC-8 in January (PST)
-    const result = parseLocalTimestamp('2026-01-20T00:00:00', 'America/Los_Angeles');
+    const result = parseLocalTimestamp(
+      '2026-01-20T00:00:00',
+      'America/Los_Angeles',
+    );
     // 00:00 LA (PST = UTC-8) → 08:00 UTC
     expect(result.toISOString()).toBe('2026-01-20T08:00:00.000Z');
   });
@@ -709,7 +715,10 @@ describe('parseLocalTimestamp', () => {
   it('returns NaN for UTC-suffixed timestamp', () => {
     // Z-suffixed timestamps should not reach this function (rejected earlier),
     // but parseLocalTimestamp correctly rejects them via the regex.
-    const result = parseLocalTimestamp('2026-02-01T15:30:00Z', 'America/New_York');
+    const result = parseLocalTimestamp(
+      '2026-02-01T15:30:00Z',
+      'America/New_York',
+    );
     expect(isNaN(result.getTime())).toBe(true);
   });
 

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -24,7 +24,10 @@ import { RegisteredGroup } from './types.js';
  * then adjust by that offset.  One Newton step is enough for non-ambiguous
  * times; DST gaps/folds resolve to the post-transition side.
  */
-export function parseLocalTimestamp(localTimestamp: string, timezone: string): Date {
+export function parseLocalTimestamp(
+  localTimestamp: string,
+  timezone: string,
+): Date {
   const match = localTimestamp.match(
     /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?$/,
   );


### PR DESCRIPTION
## Problem

`once`-type scheduled tasks parse user-provided local timestamps with bare
`new Date()`, which relies on the host's `TZ` environment variable.
`cron` tasks already pass `{ tz: TIMEZONE }` to cron-parser, so the two
schedule types used different timezone sources.

When `TIMEZONE` (resolved via `Intl.DateTimeFormat`) and `process.env.TZ`
diverge — e.g. a systemd service that inherits no `TZ` env var but whose
system clock is set to a non-UTC zone — `once` tasks fire at the wrong
wall-clock time while `cron` tasks fire correctly.

## Solution

Add `parseLocalTimestamp(timestamp, timezone)` that converts a naive local
timestamp (e.g. `"2026-02-01T15:30:00"`) to UTC by using
`Intl.DateTimeFormat` to determine the zone offset at the scheduled moment.
Wire it into the `once` branch of `processTaskIpc` so both schedule types
draw from the same `TIMEZONE` constant.

The algorithm:
1. Treat the timestamp components as-if UTC to get a reference epoch
2. Find what the target timezone's wall clock shows at that epoch (offset)
3. Shift by the offset to get the true UTC time

DST gaps/folds resolve deterministically to the post-transition side.

## Changes

- `src/ipc.ts` — new `parseLocalTimestamp` helper (exported for testing);
  `once` case in `processTaskIpc` uses it instead of `new Date()`
- `src/ipc-auth.test.ts` — 6 new unit tests for `parseLocalTimestamp`
  (winter/summer offsets, midnight, UTC, invalid format, Z-suffix rejection);
  existing test fixtures updated from Z-suffixed to bare local timestamps,
  matching what the agent MCP tool actually sends (the container already
  rejects UTC-suffixed values from the agent side)

## Test plan

- [x] `npm test` — 337 tests pass
- [x] `npm run typecheck` — clean
- [x] `./scripts/security-scan.sh` — nothing flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)