### PR TITLE
fix: reduce docker stop timeout for faster restarts

### DIFF
--- a/src/container-runtime.test.ts
+++ b/src/container-runtime.test.ts
@@ -41,7 +41,7 @@ describe('readonlyMountArgs', () => {
 describe('stopContainer', () => {
   it('returns stop command using CONTAINER_RUNTIME_BIN', () => {
     expect(stopContainer('nanoclaw-test-123')).toBe(
-      `${CONTAINER_RUNTIME_BIN} stop nanoclaw-test-123`,
+      `${CONTAINER_RUNTIME_BIN} stop -t 1 nanoclaw-test-123`,
     );
   });
 });
@@ -93,12 +93,12 @@ describe('cleanupOrphans', () => {
     expect(mockExecSync).toHaveBeenCalledTimes(3);
     expect(mockExecSync).toHaveBeenNthCalledWith(
       2,
-      `${CONTAINER_RUNTIME_BIN} stop nanoclaw-group1-111`,
+      `${CONTAINER_RUNTIME_BIN} stop -t 1 nanoclaw-group1-111`,
       { stdio: 'pipe' },
     );
     expect(mockExecSync).toHaveBeenNthCalledWith(
       3,
-      `${CONTAINER_RUNTIME_BIN} stop nanoclaw-group2-222`,
+      `${CONTAINER_RUNTIME_BIN} stop -t 1 nanoclaw-group2-222`,
       { stdio: 'pipe' },
     );
     expect(logger.info).toHaveBeenCalledWith(

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -59,7 +59,7 @@ export function readonlyMountArgs(
 
 /** Returns the shell command to stop a container by name. */
 export function stopContainer(name: string): string {
-  return `${CONTAINER_RUNTIME_BIN} stop ${name}`;
+  return `${CONTAINER_RUNTIME_BIN} stop -t 1 ${name}`;
 }
 
 /** Ensure the container runtime is running, starting it if needed. */


### PR DESCRIPTION
## Summary

- Reduce `docker stop` timeout from default 10s to 1s with `-t 1` flag
- NanoClaw containers are stateless (`--rm`, mounted filesystems) so they don't need a long grace period
- This makes service restarts ~10x faster (from ~20s down to ~2s)

## Problem

When NanoClaw restarts (e.g. `systemctl --user restart nanoclaw`), each running container takes the default 10s `docker stop` grace period before receiving SIGKILL. With 2+ containers, restarts take 20+ seconds — most of which is just waiting for a timeout that serves no purpose since the containers are stateless.

## Fix

Pass `-t 1` to `docker stop` in `stopContainer()`, reducing the SIGTERM-to-SIGKILL grace period to 1 second. Updated the corresponding test expectations to match.

**Updated:** Rebased onto latest origin/main.

## Test plan

- [x] `npx vitest run src/container-runtime.test.ts` — all 8 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)