### PR TITLE
docs: use canonical lowercase clone URL in Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ NanoClaw provides that same core functionality, but in a codebase small enough t
 ## Quick Start
 
 ```bash
-git clone https://github.com/qwibitai/NanoClaw.git
+git clone https://github.com/qwibitai/nanoclaw.git
 cd NanoClaw
 claude
 ```


### PR DESCRIPTION
Updates the Quick Start clone command to use the canonical lowercase repository URL (`nanoclaw` instead of `NanoClaw`).

- Scope: docs only
- Behavior change: none