### PR TITLE
fix: prevent message loss when container times out after pipe

### DIFF
--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -147,6 +147,20 @@ export class GroupQueue {
     }
   }
 
+  private onPipeCallbacks = new Map<string, () => void>();
+
+  /**
+   * Register a callback to be invoked when a message is piped to the container.
+   * Used to reset the idle timer so the agent has time to process piped input.
+   */
+  setOnPipeCallback(groupJid: string, cb: (() => void) | null): void {
+    if (cb) {
+      this.onPipeCallbacks.set(groupJid, cb);
+    } else {
+      this.onPipeCallbacks.delete(groupJid);
+    }
+  }
+
   /**
    * Send a follow-up message to the active container via IPC file.
    * Returns true if the message was written, false if no active container.
@@ -156,6 +170,7 @@ export class GroupQueue {
     if (!state.active || !state.groupFolder || state.isTaskContainer)
       return false;
     state.idleWaiting = false; // Agent is about to receive work, no longer idle
+    state.pendingMessages = true; // Ensure drain re-checks after container exits
 
     const inputDir = path.join(DATA_DIR, 'ipc', state.groupFolder, 'input');
     try {
@@ -165,6 +180,7 @@ export class GroupQueue {
       const tempPath = `${filepath}.tmp`;
       fs.writeFileSync(tempPath, JSON.stringify({ type: 'message', text }));
       fs.renameSync(tempPath, filepath);
+      this.onPipeCallbacks.get(groupJid)?.();
       return true;
     } catch {
       return false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ let lastTimestamp = '';
 let sessions: Record<string, string> = {};
 let registeredGroups: Record<string, RegisteredGroup> = {};
 let lastAgentTimestamp: Record<string, string> = {};
+let lastPipedTimestamp: Record<string, string> = {};
 let messageLoopRunning = false;
 
 const channels: Channel[] = [];
@@ -189,6 +190,10 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     }, IDLE_TIMEOUT);
   };
 
+  // Reset idle timer when messages are piped to the container via IPC,
+  // so the container doesn't shut down while processing new input.
+  queue.setOnPipeCallback(chatJid, resetIdleTimer);
+
   await channel.setTyping?.(chatJid, true);
   let hadError = false;
   let outputSentToUser = false;
@@ -222,6 +227,8 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
 
   await channel.setTyping?.(chatJid, false);
   if (idleTimer) clearTimeout(idleTimer);
+  queue.setOnPipeCallback(chatJid, null);
+  delete lastPipedTimestamp[chatJid];
 
   if (output === 'error' || hadError) {
     // If we already sent output to the user, don't roll back the cursor —
@@ -386,25 +393,28 @@ async function startMessageLoop(): Promise<void> {
             if (!hasTrigger) continue;
           }
 
-          // Pull all messages since lastAgentTimestamp so non-trigger
-          // context that accumulated between triggers is included.
-          const allPending = getMessagesSince(
-            chatJid,
-            lastAgentTimestamp[chatJid] || '',
-            ASSISTANT_NAME,
-          );
-          const messagesToSend =
-            allPending.length > 0 ? allPending : groupMessages;
-          const formatted = formatMessages(messagesToSend);
+          // Pull messages since the later of lastAgentTimestamp and
+          // lastPipedTimestamp to avoid re-piping already-sent messages.
+          const sinceTs =
+            [lastPipedTimestamp[chatJid], lastAgentTimestamp[chatJid]]
+              .filter(Boolean)
+              .sort()
+              .pop() || '';
+          const allPending = getMessagesSince(chatJid, sinceTs, ASSISTANT_NAME);
+          if (allPending.length === 0) continue; // already piped, skip
+          const formatted = formatMessages(allPending);
 
           if (queue.sendMessage(chatJid, formatted)) {
             logger.debug(
-              { chatJid, count: messagesToSend.length },
+              { chatJid, count: allPending.length },
               'Piped messages to active container',
             );
-            lastAgentTimestamp[chatJid] =
-              messagesToSend[messagesToSend.length - 1].timestamp;
-            saveState();
+            // Track piped timestamp to prevent re-piping, but DON'T advance
+            // lastAgentTimestamp — only processGroupMessages should do that.
+            // This ensures piped messages are re-processed if the container
+            // times out before handling them.
+            lastPipedTimestamp[chatJid] =
+              allPending[allPending.length - 1].timestamp;
             // Show typing indicator while the container processes the piped message
             channel
               .setTyping?.(chatJid, true)


### PR DESCRIPTION
## Summary

- **Separate `lastPipedTimestamp` from `lastAgentTimestamp`**: piping follow-up messages to an active container no longer advances the authoritative cursor. Only `processGroupMessages` does. If the container times out before processing piped messages, they are re-queued on the next cycle.
- **Set `pendingMessages = true` on pipe**: ensures the drain loop re-checks for unprocessed messages after container exit.
- **Add `onPipeCallback` to reset idle timer**: piped messages now reset the container idle timer, preventing premature timeout immediately after receiving input.

## Problem

When a user sends follow-up messages while the agent is processing, the message loop pipes them to the active container via IPC. Previously, `lastAgentTimestamp` was advanced immediately on pipe. If the container then timed out (e.g., due to network instability), those piped messages were permanently lost — the cursor had already moved past them.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — no regressions
- [ ] Send follow-up messages while agent is processing, then force-kill the container → messages should be re-processed on next cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)