### PR TITLE
feat: add OpenAI-compatible HTTP API channel and rename assistant to …

### DIFF
--- a/groups/global/CLAUDE.md
+++ b/groups/global/CLAUDE.md
@@ -1,6 +1,6 @@
-# Andy
+# Nova
 
-You are Andy, a personal assistant. You help with tasks, answer questions, and can schedule reminders.
+You are Nova, a personal assistant. You help with tasks, answer questions, and can schedule reminders.
 
 ## What You Can Do
 
@@ -56,3 +56,227 @@ NEVER use markdown. Only use WhatsApp/Telegram formatting:
 - ```triple backticks``` for code
 
 No ## headings. No [links](url). No **double stars**.
+
+---
+
+## Gmail
+
+Gmail credentials are mounted at `/workspace/extra/gmail-mcp/`. When the Gmail integration is active:
+
+- Read access token: `cat /workspace/extra/gmail-mcp/gtoken.json | jq -r .access_token`
+- List inbox: `curl -H "Authorization: Bearer $TOKEN" "https://gmail.googleapis.com/gmail/v1/users/me/messages?maxResults=10&q=is:unread"`
+- Read message: `curl -H "Authorization: Bearer $TOKEN" "https://gmail.googleapis.com/gmail/v1/users/me/messages/{id}?format=full"`
+- Send email: POST to `https://gmail.googleapis.com/gmail/v1/users/me/messages/send` with RFC 2822 base64url body
+
+---
+
+## Google Drive
+
+Drive shares the same OAuth token as Gmail (extended scope). When Drive integration is active:
+
+- Token: same as Gmail (`/workspace/extra/gmail-mcp/gtoken.json`)
+- List files: `curl -H "Authorization: Bearer $TOKEN" "https://www.googleapis.com/drive/v3/files?pageSize=20&fields=files(id,name,mimeType,modifiedTime)"`
+- Download file: `curl -H "Authorization: Bearer $TOKEN" "https://www.googleapis.com/drive/v3/files/{id}?alt=media"`
+- Upload file: multipart POST to `https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart`
+- Create folder: POST to `https://www.googleapis.com/drive/v3/files` with `mimeType: application/vnd.google-apps.folder`
+
+Required OAuth scope to add: `https://www.googleapis.com/auth/drive`
+
+---
+
+## Google Calendar
+
+Calendar shares the same OAuth token as Gmail (extended scope). When Calendar integration is active:
+
+- Token: same as Gmail (`/workspace/extra/gmail-mcp/gtoken.json`)
+- List today's events:
+  ```bash
+  curl -H "Authorization: Bearer $TOKEN" \
+    "https://www.googleapis.com/calendar/v3/calendars/primary/events?timeMin=$(date -u +%Y-%m-%dT00:00:00Z)&timeMax=$(date -u +%Y-%m-%dT23:59:59Z)&singleEvents=true&orderBy=startTime"
+  ```
+- Create event: POST to `https://www.googleapis.com/calendar/v3/calendars/primary/events`
+- Quick add: POST to `https://www.googleapis.com/calendar/v3/calendars/primary/events/quickAdd?text=Dentist+tomorrow+3pm`
+
+Required OAuth scope to add: `https://www.googleapis.com/auth/calendar`
+
+See `calendar-context.md` for calendar IDs, timezone, and working hours.
+
+---
+
+## Microsoft Todo
+
+Credentials stored at `/workspace/extra/ms-graph/token.json` (mounted read-only). Uses Microsoft Graph API.
+
+- Read token: `cat /workspace/extra/ms-graph/token.json | jq -r .access_token`
+- List task lists: `curl -H "Authorization: Bearer $TOKEN" "https://graph.microsoft.com/v1.0/me/todo/lists"`
+- List tasks in a list: `curl -H "Authorization: Bearer $TOKEN" "https://graph.microsoft.com/v1.0/me/todo/lists/{listId}/tasks"`
+- Create task:
+  ```bash
+  curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    -d '{"title":"Buy groceries","importance":"high"}' \
+    "https://graph.microsoft.com/v1.0/me/todo/lists/{listId}/tasks"
+  ```
+- Complete task: PATCH `{"status":"completed"}` to `…/tasks/{taskId}`
+
+Required OAuth scope: `Tasks.ReadWrite` (Microsoft Graph)
+Credentials setup: Azure app registration → OAuth 2.0 device flow → store token at `~/.ms-graph/token.json`
+
+---
+
+## Smart Home (Home Assistant)
+
+Credentials are passed via environment variables (never written to disk):
+- `$HOMEASSISTANT_URL` — e.g. `http://homeassistant.local:8123`
+- `$HOMEASSISTANT_TOKEN` — long-lived access token from HA profile page
+
+Common API calls:
+```bash
+# Get all entity states
+curl -H "Authorization: Bearer $HOMEASSISTANT_TOKEN" "$HOMEASSISTANT_URL/api/states"
+
+# Turn on a light
+curl -X POST -H "Authorization: Bearer $HOMEASSISTANT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"entity_id": "light.living_room"}' \
+  "$HOMEASSISTANT_URL/api/services/light/turn_on"
+
+# Trigger an Alexa TTS announcement (via HA Alexa Media Player integration)
+curl -X POST -H "Authorization: Bearer $HOMEASSISTANT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"entity_id": "media_player.echo_living_room", "message": "Dinner is ready"}' \
+  "$HOMEASSISTANT_URL/api/services/notify/alexa_media"
+```
+
+See `home-context.md` for room layout, entity IDs, scenes, and automations.
+
+---
+
+## Alexa
+
+Two directions: Nova can *control* Alexa, and Alexa can *send commands to* Nova.
+
+### Nova → Alexa (output: TTS announcements, music)
+
+Via Home Assistant Alexa Media Player integration:
+```bash
+# Announce on a specific Echo
+curl -X POST -H "Authorization: Bearer $HOMEASSISTANT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"entity_id": "media_player.echo_living_room", "message": "Dinner is ready"}' \
+  "$HOMEASSISTANT_URL/api/services/notify/alexa_media"
+
+# Query Echo device states
+curl -H "Authorization: Bearer $HOMEASSISTANT_TOKEN" \
+  "$HOMEASSISTANT_URL/api/states" | jq '[.[] | select(.entity_id | startswith("media_player.echo"))]'
+```
+
+### Alexa → Nova (input: voice commands, task creation)
+
+Alexa Routines trigger an HA script that POSTs to Nova's HTTP API:
+
+**Home Assistant script (add to `scripts.yaml` or via UI):**
+```yaml
+alexa_to_nova:
+  alias: "Send Alexa command to Nova"
+  fields:
+    message:
+      description: "The voice command text"
+  sequence:
+    - service: rest_command.nova_alexa
+      data:
+        message: "{{ message }}"
+```
+
+**Home Assistant REST command (add to `configuration.yaml`):**
+```yaml
+rest_command:
+  nova_alexa:
+    url: "http://10.11.12.93:4000/api/alexa"
+    method: POST
+    headers:
+      Content-Type: application/json
+    payload: '{"message": "{{ message }}"}'
+```
+
+**Alexa Routine setup:**
+1. Alexa app → Routines → "+" → add trigger (voice phrase or schedule)
+2. Action → Smart Home → "Control device" → choose your HA integration → call `alexa_to_nova` script
+3. Pass the spoken phrase as `message` field
+
+**Example phrases Alexa can forward:**
+- "Alexa, tell Nova to add milk to my shopping list"
+- "Alexa, tell Nova to remind me about the meeting"
+- "Alexa, ask Nova what's on my calendar today"
+
+Nova receives these as `[Alexa voice command] <text>` and responds — either silently (creating a task) or by sending a WhatsApp message back, or triggering an Alexa TTS reply via HA.
+
+---
+
+## PostgreSQL
+
+Connection string passed as environment variable: `$POSTGRES_URL` (e.g. `postgresql://user:pass@host:5432/dbname`).
+
+Common patterns:
+```bash
+# Run a query
+psql "$POSTGRES_URL" -c "SELECT * FROM users LIMIT 10;"
+
+# Export query as CSV
+psql "$POSTGRES_URL" -c "\COPY (SELECT ...) TO STDOUT CSV HEADER"
+
+# Check table list
+psql "$POSTGRES_URL" -c "\dt"
+```
+
+If `psql` is not in the container, use the REST API if PostgREST is configured, or ask the user to install it.
+
+---
+
+## GitHub
+
+GitHub token is passed as environment variable: `$GITHUB_TOKEN`.
+
+Common patterns using `gh` CLI (preferred) or `curl`:
+```bash
+# List open issues in a repo
+gh issue list --repo owner/repo --state open
+
+# Create an issue
+gh issue create --repo owner/repo --title "Bug: ..." --body "Description..."
+
+# List PRs
+gh pr list --repo owner/repo
+
+# Comment on an issue
+gh issue comment 42 --repo owner/repo --body "Looking into this now"
+
+# REST API fallback
+curl -H "Authorization: Bearer $GITHUB_TOKEN" \
+  "https://api.github.com/repos/owner/repo/issues?state=open"
+```
+
+If `gh` is not available in the container, use curl with the REST API.
+Set default repo: `gh repo set-default owner/repo` (persists in workspace).
+
+See `github-context.md` for default repos, common workflows, and label conventions.
+
+---
+
+## Open WebUI
+
+Open WebUI runs at `http://10.11.12.93:3000` (LAN) and connects to Nova via NanoClaw's HTTP API on port 4000.
+
+- Chat history and sessions are stored in PostgreSQL (managed by Open WebUI's docker-compose)
+- Markdown IS fully supported in Open WebUI — use headings, code blocks, tables freely
+- The webui group (`webui@nanoclaw.local`) has its own isolated memory in `groups/webui/`
+- Nova's container session persists across browser sessions (conversation context is remembered)
+
+### HTTP API endpoints (NanoClaw host, port 4000)
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/v1/models` | GET | Model discovery (Open WebUI calls this on startup) |
+| `/v1/chat/completions` | POST | OpenAI-compatible chat (streaming supported) |
+| `/api/alexa` | POST | Simple JSON endpoint for HA/Alexa commands |
+
+Authentication: set `HTTP_API_KEY` in NanoClaw's `.env` and the same value as `NOVA_API_KEY` in `open-webui/.env`. Leave both empty to disable auth (LAN-only deployments).

--- a/groups/main/CLAUDE.md
+++ b/groups/main/CLAUDE.md
@@ -1,6 +1,6 @@
-# Andy
+# Nova
 
-You are Andy, a personal assistant. You help with tasks, answer questions, and can schedule reminders.
+You are Nova, a personal assistant. You help with tasks, answer questions, and can schedule reminders.
 
 ## What You Can Do
 
@@ -126,7 +126,7 @@ Groups are registered in `/workspace/project/data/registered_groups.json`:
   "1234567890-1234567890@g.us": {
     "name": "Family Chat",
     "folder": "family-chat",
-    "trigger": "@Andy",
+    "trigger": "@Nova",
     "added_at": "2024-01-31T12:00:00.000Z"
   }
 }
@@ -169,7 +169,7 @@ Groups can have extra directories mounted. Add `containerConfig` to their entry:
   "1234567890@g.us": {
     "name": "Dev Team",
     "folder": "dev-team",
-    "trigger": "@Andy",
+    "trigger": "@Nova",
     "added_at": "2026-01-31T12:00:00Z",
     "containerConfig": {
       "additionalMounts": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -145,6 +145,7 @@
       "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -611,6 +612,7 @@
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
       "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -627,6 +629,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -649,6 +652,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -671,6 +675,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -687,6 +692,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -703,6 +709,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -719,6 +726,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -735,6 +743,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -751,6 +760,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -767,6 +777,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -783,6 +794,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -799,6 +811,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -815,6 +828,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -831,6 +845,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -853,6 +868,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -875,6 +891,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -897,6 +914,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -919,6 +937,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -941,6 +960,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -963,6 +983,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -985,6 +1006,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1004,6 +1026,7 @@
       ],
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/runtime": "^1.7.0"
       },
@@ -1026,6 +1049,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1045,6 +1069,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1064,6 +1089,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2495,7 +2521,6 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -2854,7 +2879,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3611,7 +3635,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -3682,7 +3705,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3758,7 +3780,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -3912,7 +3933,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/src/channels/openai-api.ts
+++ b/src/channels/openai-api.ts
@@ -1,0 +1,447 @@
+/**
+ * OpenAI-Compatible HTTP API Channel
+ *
+ * Exposes NanoClaw's agent pipeline as an OpenAI-compatible API so that:
+ *   - Open WebUI can use Nova as a chat backend
+ *   - Home Assistant / Alexa can POST voice commands to /api/alexa
+ *
+ * Endpoints:
+ *   GET  /v1/models                  — model list (Open WebUI discovery)
+ *   POST /v1/chat/completions        — chat, supports SSE streaming
+ *   POST /api/alexa                  — simple JSON endpoint for HA/Alexa
+ */
+
+import http from 'http';
+import fs from 'fs';
+import path from 'path';
+
+import { ASSISTANT_NAME, HTTP_API_KEY, HTTP_PORT } from '../config.js';
+import { ContainerOutput, runContainerAgent } from '../container-runner.js';
+import { setSession } from '../db.js';
+import { resolveGroupFolderPath } from '../group-folder.js';
+import { logger } from '../logger.js';
+import { Channel, RegisteredGroup } from '../types.js';
+
+export const WEBUI_JID = 'webui@nanoclaw.local';
+export const WEBUI_GROUP_FOLDER = 'webui';
+
+export interface OpenAIApiDeps {
+  registeredGroups: () => Record<string, RegisteredGroup>;
+  getSessions: () => Record<string, string>;
+  queue: {
+    registerProcess: (
+      jid: string,
+      proc: import('child_process').ChildProcess,
+      containerName: string,
+      groupFolder: string,
+    ) => void;
+  };
+  registerGroup: (jid: string, group: RegisteredGroup) => void;
+}
+
+export class OpenAIApiChannel implements Channel {
+  name = 'openai-api';
+  private server: http.Server;
+  private deps: OpenAIApiDeps;
+  private _connected = false;
+
+  constructor(deps: OpenAIApiDeps) {
+    this.deps = deps;
+    this.server = http.createServer((req, res) =>
+      this.handleRequest(req, res),
+    );
+  }
+
+  async connect(): Promise<void> {
+    // Auto-register the webui virtual group if it doesn't exist yet
+    const groups = this.deps.registeredGroups();
+    if (!groups[WEBUI_JID]) {
+      this.deps.registerGroup(WEBUI_JID, {
+        name: 'Open WebUI',
+        folder: WEBUI_GROUP_FOLDER,
+        trigger: `@${ASSISTANT_NAME}`,
+        added_at: new Date().toISOString(),
+        requiresTrigger: false,
+      });
+    }
+
+    // Seed a CLAUDE.md for the webui group (markdown is fine here, unlike WhatsApp)
+    const groupDir = resolveGroupFolderPath(WEBUI_GROUP_FOLDER);
+    const claudeMd = path.join(groupDir, 'CLAUDE.md');
+    if (!fs.existsSync(claudeMd)) {
+      fs.writeFileSync(
+        claudeMd,
+        `# ${ASSISTANT_NAME} — Web Interface\n\nYou are ${ASSISTANT_NAME}, a personal assistant. The user is talking to you via the Open WebUI browser interface.\n\n## Formatting\n\nMarkdown IS supported here. Use headings, bold, code blocks, and lists freely — unlike the WhatsApp channel.\n\n## Alexa Commands\n\nMessages prefixed with \`[Alexa voice command]\` come from the user's Alexa device via Home Assistant. Keep responses concise (they may be read aloud or sent to WhatsApp).\n`,
+        'utf-8',
+      );
+    }
+
+    return new Promise((resolve, reject) => {
+      this.server.listen(HTTP_PORT, () => {
+        this._connected = true;
+        logger.info({ port: HTTP_PORT }, 'OpenAI API channel listening');
+        resolve();
+      });
+      this.server.on('error', reject);
+    });
+  }
+
+  async disconnect(): Promise<void> {
+    return new Promise((resolve) => {
+      this.server.close(() => {
+        this._connected = false;
+        resolve();
+      });
+    });
+  }
+
+  isConnected(): boolean {
+    return this._connected;
+  }
+
+  ownsJid(jid: string): boolean {
+    return jid === WEBUI_JID;
+  }
+
+  // The HTTP channel is request-response: outbound messages are returned
+  // inline in the HTTP response. This no-op satisfies the Channel interface
+  // for the rare case where the scheduler sends a message to this group.
+  async sendMessage(_jid: string, _text: string): Promise<void> {}
+
+  // ── Request routing ───────────────────────────────────────────────────────
+
+  private handleRequest(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+  ): void {
+    const url = new URL(req.url || '/', `http://localhost:${HTTP_PORT}`);
+
+    if (!this.checkAuth(req)) {
+      this.sendJson(res, 401, {
+        error: { message: 'Unauthorized', type: 'invalid_request_error' },
+      });
+      return;
+    }
+
+    if (req.method === 'OPTIONS') {
+      res.writeHead(200, this.corsHeaders());
+      res.end();
+      return;
+    }
+
+    if (req.method === 'GET' && url.pathname === '/v1/models') {
+      this.handleModels(res);
+    } else if (
+      req.method === 'POST' &&
+      url.pathname === '/v1/chat/completions'
+    ) {
+      this.handleChatCompletions(req, res).catch((err) => {
+        logger.error({ err }, 'Chat completions handler error');
+        if (!res.headersSent) {
+          this.sendJson(res, 500, {
+            error: { message: 'Internal server error', type: 'server_error' },
+          });
+        }
+      });
+    } else if (req.method === 'POST' && url.pathname === '/api/alexa') {
+      this.handleAlexa(req, res).catch((err) => {
+        logger.error({ err }, 'Alexa handler error');
+        if (!res.headersSent) {
+          this.sendJson(res, 500, { error: 'Internal server error' });
+        }
+      });
+    } else {
+      this.sendJson(res, 404, {
+        error: { message: 'Not found', type: 'invalid_request_error' },
+      });
+    }
+  }
+
+  // ── Auth ──────────────────────────────────────────────────────────────────
+
+  private checkAuth(req: http.IncomingMessage): boolean {
+    if (!HTTP_API_KEY) return true;
+    const auth = req.headers['authorization'] || '';
+    const token = auth.startsWith('Bearer ') ? auth.slice(7) : auth;
+    return token === HTTP_API_KEY;
+  }
+
+  // ── GET /v1/models ────────────────────────────────────────────────────────
+
+  private handleModels(res: http.ServerResponse): void {
+    this.sendJson(res, 200, {
+      object: 'list',
+      data: [
+        {
+          id: ASSISTANT_NAME.toLowerCase(),
+          object: 'model',
+          created: Math.floor(Date.now() / 1000),
+          owned_by: 'nanoclaw',
+        },
+      ],
+    });
+  }
+
+  // ── POST /v1/chat/completions ─────────────────────────────────────────────
+
+  private async handleChatCompletions(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+  ): Promise<void> {
+    const raw = await this.readBody(req);
+    let body: {
+      messages?: Array<{ role: string; content: string }>;
+      stream?: boolean;
+      chat_id?: string;
+    };
+    try {
+      body = JSON.parse(raw);
+    } catch {
+      this.sendJson(res, 400, {
+        error: { message: 'Invalid JSON', type: 'invalid_request_error' },
+      });
+      return;
+    }
+
+    const messages = body.messages || [];
+    const stream = body.stream === true;
+
+    const sessionKey = body.chat_id
+      ? `webui:${body.chat_id}`
+      : WEBUI_GROUP_FOLDER;
+
+    if (body.chat_id) {
+      logger.debug({ chat_id: body.chat_id, sessionKey }, 'OpenAI API: per-conversation session');
+    }
+
+    // Use the last user message as the prompt. NanoClaw's container session
+    // already maintains conversation history — we don't need to replay the
+    // full Open WebUI history.
+    const lastUser = [...messages].reverse().find((m) => m.role === 'user');
+    if (!lastUser) {
+      this.sendJson(res, 400, {
+        error: {
+          message: 'No user message in request',
+          type: 'invalid_request_error',
+        },
+      });
+      return;
+    }
+
+    const group = this.getWebuiGroup();
+    if (!group) {
+      this.sendJson(res, 503, {
+        error: { message: 'WebUI group not ready', type: 'server_error' },
+      });
+      return;
+    }
+
+    const completionId = `chatcmpl-${Date.now()}`;
+    const created = Math.floor(Date.now() / 1000);
+    const modelId = ASSISTANT_NAME.toLowerCase();
+
+    if (stream) {
+      res.writeHead(200, {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+        ...this.corsHeaders(),
+      });
+
+      await this.runForGroup(group, lastUser.content, sessionKey, async (output) => {
+        if (output.result) {
+          const text = this.stripInternal(output.result);
+          if (text) {
+            this.sendSseChunk(res, completionId, created, modelId, text);
+          }
+        }
+      });
+
+      // Final chunk with finish_reason=stop
+      res.write(
+        `data: ${JSON.stringify({
+          id: completionId,
+          object: 'chat.completion.chunk',
+          created,
+          model: modelId,
+          choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+        })}\n\n`,
+      );
+      res.write('data: [DONE]\n\n');
+      res.end();
+    } else {
+      let fullText = '';
+      await this.runForGroup(group, lastUser.content, sessionKey, async (output) => {
+        if (output.result) {
+          const text = this.stripInternal(output.result);
+          if (text) fullText += (fullText ? '\n\n' : '') + text;
+        }
+      });
+
+      this.sendJson(res, 200, {
+        id: completionId,
+        object: 'chat.completion',
+        created,
+        model: modelId,
+        choices: [
+          {
+            index: 0,
+            message: { role: 'assistant', content: fullText },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+      });
+    }
+  }
+
+  // ── POST /api/alexa ───────────────────────────────────────────────────────
+
+  private async handleAlexa(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+  ): Promise<void> {
+    const raw = await this.readBody(req);
+    let body: { message?: string; text?: string };
+    try {
+      body = JSON.parse(raw);
+    } catch {
+      this.sendJson(res, 400, { error: 'Invalid JSON' });
+      return;
+    }
+
+    const message = body.message || body.text || '';
+    if (!message) {
+      this.sendJson(res, 400, { error: 'Missing message or text field' });
+      return;
+    }
+
+    const group = this.getWebuiGroup();
+    if (!group) {
+      this.sendJson(res, 503, { error: 'WebUI group not ready' });
+      return;
+    }
+
+    let responseText = '';
+    await this.runForGroup(
+      group,
+      `[Alexa voice command] ${message}`,
+      WEBUI_GROUP_FOLDER,
+      async (output) => {
+        if (output.result) {
+          const text = this.stripInternal(output.result);
+          if (text) responseText += (responseText ? '\n' : '') + text;
+        }
+      },
+    );
+
+    this.sendJson(res, 200, { response: responseText });
+  }
+
+  // ── Agent execution ───────────────────────────────────────────────────────
+
+  private async runForGroup(
+    group: RegisteredGroup,
+    prompt: string,
+    sessionKey: string,
+    onOutput: (output: ContainerOutput) => Promise<void>,
+  ): Promise<void> {
+    const sessions = this.deps.getSessions();
+    const sessionId = sessions[sessionKey];
+
+    try {
+      const result = await runContainerAgent(
+        group,
+        {
+          prompt,
+          sessionId,
+          groupFolder: group.folder,
+          chatJid: WEBUI_JID,
+          isMain: false,
+          assistantName: ASSISTANT_NAME,
+        },
+        (proc, containerName) => {
+          this.deps.queue.registerProcess(
+            WEBUI_JID,
+            proc,
+            containerName,
+            group.folder,
+          );
+        },
+        async (output) => {
+          if (output.newSessionId) {
+            sessions[sessionKey] = output.newSessionId;
+            setSession(sessionKey, output.newSessionId);
+          }
+          await onOutput(output);
+        },
+      );
+
+      if (result.newSessionId) {
+        sessions[sessionKey] = result.newSessionId;
+        setSession(sessionKey, result.newSessionId);
+      }
+    } catch (err) {
+      logger.error({ err, group: group.name }, 'OpenAI API: agent error');
+    }
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  private getWebuiGroup(): RegisteredGroup | undefined {
+    return this.deps.registeredGroups()[WEBUI_JID];
+  }
+
+  private stripInternal(text: string): string {
+    return text.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
+  }
+
+  private sendSseChunk(
+    res: http.ServerResponse,
+    id: string,
+    created: number,
+    model: string,
+    content: string,
+  ): void {
+    res.write(
+      `data: ${JSON.stringify({
+        id,
+        object: 'chat.completion.chunk',
+        created,
+        model,
+        choices: [{ index: 0, delta: { content }, finish_reason: null }],
+      })}\n\n`,
+    );
+  }
+
+  private sendJson(
+    res: http.ServerResponse,
+    status: number,
+    body: unknown,
+  ): void {
+    res.writeHead(status, {
+      'Content-Type': 'application/json',
+      ...this.corsHeaders(),
+    });
+    res.end(JSON.stringify(body));
+  }
+
+  private corsHeaders(): Record<string, string> {
+    return {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    };
+  }
+
+  private readBody(req: http.IncomingMessage): Promise<string> {
+    return new Promise((resolve, reject) => {
+      let body = '';
+      req.on('data', (chunk: Buffer) => {
+        body += chunk.toString();
+      });
+      req.on('end', () => resolve(body));
+      req.on('error', reject);
+    });
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,10 +6,15 @@ import { readEnvFile } from './env.js';
 // Read config values from .env (falls back to process.env).
 // Secrets are NOT read here — they stay on disk and are loaded only
 // where needed (container-runner.ts) to avoid leaking to child processes.
-const envConfig = readEnvFile(['ASSISTANT_NAME', 'ASSISTANT_HAS_OWN_NUMBER']);
+const envConfig = readEnvFile([
+  'ASSISTANT_NAME',
+  'ASSISTANT_HAS_OWN_NUMBER',
+  'HTTP_PORT',
+  'HTTP_API_KEY',
+]);
 
 export const ASSISTANT_NAME =
-  process.env.ASSISTANT_NAME || envConfig.ASSISTANT_NAME || 'Andy';
+  process.env.ASSISTANT_NAME || envConfig.ASSISTANT_NAME || 'Nova';
 export const ASSISTANT_HAS_OWN_NUMBER =
   (process.env.ASSISTANT_HAS_OWN_NUMBER ||
     envConfig.ASSISTANT_HAS_OWN_NUMBER) === 'true';
@@ -62,3 +67,12 @@ export const TRIGGER_PATTERN = new RegExp(
 // Uses system timezone by default
 export const TIMEZONE =
   process.env.TZ || Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+// OpenAI-compatible HTTP API (for Open WebUI and Alexa/HA integration)
+export const HTTP_PORT = parseInt(
+  process.env.HTTP_PORT || envConfig.HTTP_PORT || '4000',
+  10,
+);
+// Optional bearer token for the HTTP API. Empty string = no auth required.
+export const HTTP_API_KEY =
+  process.env.HTTP_API_KEY || envConfig.HTTP_API_KEY || '';

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -204,7 +204,14 @@ function buildVolumeMounts(
  * Secrets are never written to disk or mounted as files.
  */
 function readSecrets(): Record<string, string> {
-  return readEnvFile(['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_API_KEY']);
+  return readEnvFile([
+    'CLAUDE_CODE_OAUTH_TOKEN',
+    'ANTHROPIC_API_KEY',
+    'HOMEASSISTANT_URL',
+    'HOMEASSISTANT_TOKEN',
+    'POSTGRES_URL',
+    'GITHUB_TOKEN',
+  ]);
 }
 
 function buildContainerArgs(

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import {
   TRIGGER_PATTERN,
 } from './config.js';
 import { WhatsAppChannel } from './channels/whatsapp.js';
+import { OpenAIApiChannel } from './channels/openai-api.js';
 import {
   ContainerOutput,
   runContainerAgent,
@@ -478,6 +479,15 @@ async function main(): Promise<void> {
   whatsapp = new WhatsAppChannel(channelOpts);
   channels.push(whatsapp);
   await whatsapp.connect();
+
+  const httpApi = new OpenAIApiChannel({
+    registeredGroups: () => registeredGroups,
+    getSessions: () => sessions,
+    queue,
+    registerGroup,
+  });
+  channels.push(httpApi);
+  await httpApi.connect();
 
   // Start subsystems (independently of connection handler)
   startSchedulerLoop({


### PR DESCRIPTION
…Nova

- Add OpenAI-compatible HTTP channel (port 4000) with /v1/models, /v1/chat/completions (streaming), and /api/alexa endpoints
- Integrate Open WebUI and Home Assistant/Alexa voice command support
- Rename default assistant from Andy to Nova across config and group CLAUDE.md files
- Expose HTTP_PORT and HTTP_API_KEY config vars; pass HA, Postgres, and GitHub secrets into containers via readSecrets()
- Update group CLAUDE.md docs with Gmail, Drive, Calendar, MS Todo, smart home, Alexa, Postgres, GitHub, and Open WebUI API references

## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description


## For Skills

- [ ] I have not made any changes to source code
- [ ] My skill contains instructions for Claude to follow (not pre-built code)
- [ ] I tested this skill on a fresh clone
