### PR TITLE
fix: format src/index.ts to pass CI prettier check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -480,11 +480,7 @@ async function main(): Promise<void> {
   const channelOpts = {
     onMessage: (chatJid: string, msg: NewMessage) => {
       // Sender allowlist drop mode: discard messages from denied senders before storing
-      if (
-        !msg.is_from_me &&
-        !msg.is_bot_message &&
-        registeredGroups[chatJid]
-      ) {
+      if (!msg.is_from_me && !msg.is_bot_message && registeredGroups[chatJid]) {
         const cfg = loadSenderAllowlist();
         if (
           shouldDropMessage(chatJid, cfg) &&


### PR DESCRIPTION
## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description

`src/index.ts` has a Prettier formatting issue on `main` that causes the `format:check` CI step to fail for **all PRs**, regardless of what files they change.

This is a one-line whitespace fix (Prettier reformats a multiline ternary).

Closes #710

🤖 Generated with [Claude Code](https://claude.com/claude-code)