### PR TITLE
feat: add credit top-up skill for Vincent credits

### DIFF
--- a/.claude/skills/credit-top-up/SKILL.md
+++ b/.claude/skills/credit-top-up/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: credit-top-up
+description: Top up Vincent service credits. Use when user needs to add data source credits, check credit balances, manage their Vincent subscription, review LLM gas usage, or troubleshoot payment-required (402) errors.
+---
+
+# Credit Top-Up
+
+Manage Vincent credits for the NanoClaw agent. Three credit types exist, each with a different top-up mechanism.
+
+**Principle:** Diagnose the credit type that's low, top it up or guide the user to the right place, and verify the fix. Don't make the user figure out which credit system applies — determine it from context (error messages, which tool failed, what they're trying to do).
+
+## Credit Types Overview
+
+| Credit Type | What It Covers | Top-Up Method | Check Balance |
+|-------------|---------------|---------------|---------------|
+| **Data source credits** | Brave search, Twitter API, other data source calls | x402 USDC payment (self-service) | `vincent_credit_balance` MCP tool |
+| **LLM credits** | Claude API usage (tokens consumed by the agent) | Stripe payment link (any amount) | `vincent_llm_credit_balance` MCP tool |
+| **Subscription** | Base Vincent service access, monthly platform fee | Stripe via Vincent dashboard | Vincent dashboard |
+
+## 1. Diagnose the Issue
+
+Before topping up, determine which credit type is affected:
+
+- **402 from a data source tool** (Brave search, Twitter, etc.) → Data source credits are empty
+- **"insufficient credit" or "payment required" in MCP tool output** → Data source credits
+- **Agent stops responding or "credits exhausted" message** → LLM credits are depleted
+- **User asks about Claude/LLM usage or token costs** → LLM credit balance
+- **User asks about subscription or billing** → Subscription management
+- **Agent tools stop working entirely** → Could be subscription lapsed or API key revoked
+
+## 2. Data Source Credits (Self-Service)
+
+Data source credits are prepaid USD balance used for API calls (web search, Twitter, etc.). These can be topped up directly.
+
+### Check Balance
+
+The NanoClaw agent uses `mcp__vincent__vincent_credit_balance` via MCP. From the operator side:
+
+```bash
+# Check via the Vincent API directly
+curl -s -H "Authorization: Bearer $VINCENT_API_KEY" \
+  https://api.heyvincent.ai/api/credits/x402 | jq .
+```
+
+This returns available tiers and current balance.
+
+### Top Up
+
+Credits are purchased via USDC on Base network. Available tiers: **$1, $5, $10, $25, $50, $100**.
+
+The NanoClaw agent uses `mcp__vincent__vincent_add_credits` with an `amount` parameter. From the operator side:
+
+```bash
+# Initiate a credit purchase (returns payment instructions)
+curl -s -X POST \
+  -H "Authorization: Bearer $VINCENT_API_KEY" \
+  https://api.heyvincent.ai/api/credits/x402/10 | jq .
+```
+
+The response contains x402 payment instructions with a USDC deposit address on Base mainnet. The flow:
+
+1. Call the endpoint with desired tier amount
+2. Receive a 402 response with a deposit address
+3. Send the exact USDC amount to the deposit address
+4. Credits are added automatically once payment confirms
+
+### Verify
+
+After payment, re-check the balance to confirm credits were added:
+
+```bash
+curl -s -H "Authorization: Bearer $VINCENT_API_KEY" \
+  https://api.heyvincent.ai/api/credits/x402 | jq .balance
+```
+
+## 3. LLM Credits (Self-Service)
+
+LLM credits cover Claude API usage (tokens consumed by the agent). Each subscription includes $25/month, and additional credits can be purchased at any time.
+
+### Check Balance
+
+The NanoClaw agent uses `mcp__vincent__vincent_llm_credit_balance` via MCP. This returns:
+- **includedCreditUsd** — Credits included with the subscription ($25/month)
+- **purchasedCreditUsd** — Additional credits purchased
+- **usedThisPeriodUsd** — Usage since the last subscription renewal
+- **remainingUsd** — Available balance
+
+From the operator side:
+
+```bash
+# Check via the Vincent API directly
+curl -s -X POST -H "Authorization: Bearer $VINCENT_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"vincent_llm_credit_balance","arguments":{}}}' \
+  https://api.heyvincent.ai/mcp | jq .result
+```
+
+### Top Up
+
+The NanoClaw agent uses `mcp__vincent__vincent_llm_add_credits` which returns a Stripe payment link. The user clicks the link, enters any dollar amount, and pays by card. Credits are added automatically after payment.
+
+From the operator side:
+
+```bash
+curl -s -X POST -H "Authorization: Bearer $VINCENT_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"vincent_llm_add_credits","arguments":{}}}' \
+  https://api.heyvincent.ai/mcp | jq .result
+```
+
+The response includes a `checkoutUrl` — share this with the user.
+
+### Verify
+
+After the user completes payment, re-check the balance with `vincent_llm_credit_balance` to confirm credits were added.
+
+## 4. Subscription Management
+
+The Vincent subscription is managed through Stripe via the Vincent dashboard. There are no MCP tools for subscription changes.
+
+**Dashboard URL:** https://heyvincent.ai
+
+Guide the user to:
+1. Log in at https://heyvincent.ai
+2. Navigate to billing/subscription settings
+3. Subscribe, upgrade, or manage payment method
+
+If the subscription has lapsed, the agent's API key may stop working entirely. Check by making any MCP tool call — if all tools fail with auth errors, the subscription likely needs renewal.
+
+Note: Each subscription includes $25/month in LLM credits that reset on renewal. The subscription itself is separate from credit top-ups.
+
+## 5. Troubleshooting
+
+### 402 Payment Required from MCP Tools
+
+1. Check which tool failed — if it's a data source tool (Brave, Twitter), top up data credits
+2. Run balance check: `curl -s -H "Authorization: Bearer $VINCENT_API_KEY" https://api.heyvincent.ai/api/credits/x402 | jq .`
+3. If balance is zero or near-zero, top up using step 2 above
+4. If balance is sufficient but 402 persists, the issue may be subscription-level — check the dashboard
+
+### API Key Not Working
+
+1. Verify the key is set: `echo $VINCENT_API_KEY | head -c 10` (should start with `ssk_`)
+2. Test connectivity: `curl -s -H "Authorization: Bearer $VINCENT_API_KEY" https://api.heyvincent.ai/api/credits/x402 | jq .`
+3. If 401/403, the key may be revoked or the subscription lapsed — check the Vincent dashboard
+
+### MCP Tools Not Showing Credit Tools
+
+The `vincent_credit_balance` and `vincent_add_credits` tools require a DATA_SOURCES scoped API key. If these tools aren't available:
+
+1. Check `.mcp.json` has the Vincent server configured
+2. Verify the API key has DATA_SOURCES scope (check in the Vincent dashboard under the secret's API keys)
+3. If the key is for a different scope (e.g., POLYMARKET_WALLET only), create a new secret with DATA_SOURCES type or use a key that includes that scope
+
+## Environment
+
+| Variable | Purpose |
+|----------|---------|
+| `VINCENT_API_KEY` | API key for Vincent MCP server (set in `.env`) |
+
+The MCP connection is configured in `.mcp.json` at the project root:
+
+```json
+{
+  "mcpServers": {
+    "vincent": {
+      "url": "https://api.heyvincent.ai/mcp",
+      "headers": {
+        "Authorization": "Bearer ${VINCENT_API_KEY}"
+      }
+    }
+  }
+}
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ Single Node.js process that connects to WhatsApp, routes messages to Claude Agen
 |-------|-------------|
 | `/setup` | First-time installation, authentication, service configuration |
 | `/customize` | Adding channels, integrations, changing behavior |
+| `/credit-top-up` | Top up Vincent credits (data source, subscription, LLM gas) |
 | `/debug` | Container issues, logs, troubleshooting |
 | `/update` | Pull upstream NanoClaw changes, merge with customizations, run migrations |
 | `/qodo-pr-resolver` | Fetch and fix Qodo PR review issues interactively or in batch |

--- a/groups/global/CLAUDE.md
+++ b/groups/global/CLAUDE.md
@@ -47,6 +47,33 @@ When you learn something important:
 - Split files larger than 500 lines into folders
 - Keep an index in your memory for the files you create
 
+## Vincent Credits
+
+You have access to Vincent credit management via MCP tools. Use these when a user asks about credits, billing, or when you encounter a payment-required error.
+
+**Available tools:**
+- `mcp__vincent__vincent_credit_balance` — Check data source credit balance and top-up tiers
+- `mcp__vincent__vincent_add_credits` — Get payment instructions for data source credits ($1–$100 USDC on Base)
+- `mcp__vincent__vincent_llm_credit_balance` — Check LLM credit balance (included, purchased, usage, remaining)
+- `mcp__vincent__vincent_llm_add_credits` — Get a Stripe payment link to add LLM credits (any amount)
+
+**Credit types:**
+- *Data source credits* — For web search, Twitter, etc. Top up with `vincent_add_credits`.
+- *LLM credits* — For Claude API usage. $25/month included with subscription, buy more with `vincent_llm_add_credits`.
+- *Subscription* — Monthly Vincent service access. Managed at https://heyvincent.ai
+
+**When you hit a 402 or "insufficient credit" error** from a data source tool:
+1. Tell the user their data source credits are low
+2. Check balance with `mcp__vincent__vincent_credit_balance`
+3. Offer to show top-up options with `mcp__vincent__vincent_add_credits`
+
+**When the agent's LLM credits are low or exhausted:**
+1. Check balance with `mcp__vincent__vincent_llm_credit_balance`
+2. If low, get a payment link with `mcp__vincent__vincent_llm_add_credits`
+3. Send the checkout link to the user — they click it, enter an amount, and pay by card
+
+For subscription questions, direct the user to https://heyvincent.ai
+
 ## Message Formatting
 
 NEVER use markdown. Only use WhatsApp/Telegram formatting:

--- a/groups/main/CLAUDE.md
+++ b/groups/main/CLAUDE.md
@@ -55,6 +55,35 @@ Keep messages clean and readable for WhatsApp.
 
 ---
 
+## Vincent Credits
+
+You have access to Vincent credit management via MCP tools. Use these when the user asks about credits, billing, or when you encounter a payment-required error.
+
+**Available tools:**
+- `mcp__vincent__vincent_credit_balance` — Check data source credit balance and top-up tiers
+- `mcp__vincent__vincent_add_credits` — Get payment instructions for data source credits ($1–$100 USDC on Base)
+- `mcp__vincent__vincent_llm_credit_balance` — Check LLM credit balance (included, purchased, usage, remaining)
+- `mcp__vincent__vincent_llm_add_credits` — Get a Stripe payment link to add LLM credits (any amount)
+
+**Credit types:**
+- *Data source credits* — For web search, Twitter, etc. Top up with `vincent_add_credits`.
+- *LLM credits* — For Claude API usage. $25/month included with subscription, buy more with `vincent_llm_add_credits`.
+- *Subscription* — Monthly Vincent service access. Managed at https://heyvincent.ai
+
+**When you hit a 402 or "insufficient credit" error** from a data source tool:
+1. Tell the user their data source credits are low
+2. Check balance with `mcp__vincent__vincent_credit_balance`
+3. Offer to show top-up options with `mcp__vincent__vincent_add_credits`
+
+**When the agent's LLM credits are low or exhausted:**
+1. Check balance with `mcp__vincent__vincent_llm_credit_balance`
+2. If low, get a payment link with `mcp__vincent__vincent_llm_add_credits`
+3. Send the checkout link to the user — they click it, enter an amount, and pay by card
+
+For subscription questions, direct the user to https://heyvincent.ai
+
+---
+
 ## Admin Context
 
 This is the **main channel**, which has elevated privileges.


### PR DESCRIPTION
## Summary

- Add `/credit-top-up` skill covering all three Vincent credit types: data source credits (x402 USDC), LLM credits (Stripe payment link), and subscription management
- Update `groups/global/CLAUDE.md` and `groups/main/CLAUDE.md` to make the runtime agent (Andy) aware of all four credit MCP tools
- Agent can now proactively check balances and offer top-up when it encounters 402 errors or credit exhaustion
- Update project `CLAUDE.md` skills table to reference the new skill

## Credit types handled

| Credit Type | MCP Tools | Top-Up Method |
|-------------|-----------|---------------|
| Data source | `vincent_credit_balance`, `vincent_add_credits` | x402 USDC on Base |
| LLM | `vincent_llm_credit_balance`, `vincent_llm_add_credits` | Stripe checkout link |
| Subscription | — | Dashboard at heyvincent.ai |

## Dependencies

- LLM credit tools (`vincent_llm_credit_balance`, `vincent_llm_add_credits`) require [Vincent PR](https://github.com/HeyVincent-ai/Vincent/pull/new/feat/llm-credit-mcp-tools) to be deployed first
- Data source credit tools already exist in production

## Test plan

- [ ] Verify `/credit-top-up` skill loads correctly in Claude Code
- [ ] Verify runtime agent sees Vincent Credits section in system prompt
- [ ] Verify `mcp__vincent__vincent_credit_balance` works from the agent
- [ ] Verify `mcp__vincent__vincent_llm_credit_balance` works after Vincent PR deploys
- [ ] Verify `mcp__vincent__vincent_llm_add_credits` returns a checkout URL
- [ ] Verify 402 error handling: agent informs user and offers top-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)