### PR TITLE
fix: correct misleading send_message tool description for scheduled tasks

### DIFF
--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -41,7 +41,7 @@ const server = new McpServer({
 
 server.tool(
   'send_message',
-  "Send a message to the user or group immediately while you're still running. Use this for progress updates or to send multiple messages. You can call this multiple times. Note: when running as a scheduled task, your final output is NOT sent to the user — use this tool if you need to communicate with the user or group.",
+  "Send a message to the user or group immediately while you're still running. Use this for progress updates or to send multiple messages. You can call this multiple times.",
   {
     text: z.string().describe('The message text to send'),
     sender: z.string().optional().describe('Your role/identity name (e.g. "Researcher"). When set, messages appear from a dedicated bot in Telegram.'),

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -203,7 +203,7 @@ async function runTask(
     if (output.status === 'error') {
       error = output.error || 'Unknown error';
     } else if (output.result) {
-      // Messages are sent via MCP tool (IPC), result text is just logged
+      // Result was already forwarded to the user via the streaming callback above
       result = output.result;
     }
 


### PR DESCRIPTION
## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description

Fixes #728

### Problem

The `send_message` tool description told agents that scheduled task output is **not** delivered to the user, instructing them to call the tool explicitly for any communication. This is incorrect — `task-scheduler.ts` unconditionally forwards the agent's result to the user via a streaming output callback.

### Why the description was wrong

The streaming callback passed to `runContainerAgent` calls `deps.sendMessage` whenever the agent produces a result. This `deps.sendMessage` is injected by the host process as a direct call to the channel layer (`channel.sendMessage`) — it has no relation to the MCP tool. The MCP `send_message` tool goes through an entirely separate IPC path handled by `startIpcWatcher`.

An agent following the incorrect description would call `send_message` explicitly, while the streaming callback simultaneously delivered the same content — resulting in duplicate messages for the user.

### Changes

**`container/agent-runner/src/ipc-mcp-stdio.ts`** — remove the note beginning with *"Note: when running as a scheduled task…"* from the `send_message` tool description.

**`src/task-scheduler.ts`** — fix the comment at line 206, which incorrectly attributed result delivery to the MCP tool rather than the streaming callback.