### PR TITLE
test: evaluate issue #737 container /proc credential isolation

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -51,16 +51,19 @@ RUN npm run build
 # Create workspace directories
 RUN mkdir -p /workspace/group /workspace/global /workspace/extra /workspace/ipc/messages /workspace/ipc/tasks /workspace/ipc/input
 
-# Create entrypoint script
+# Copy entrypoint script
 # Secrets are passed via stdin JSON — temp file is deleted immediately after Node reads it
 # Follow-up messages arrive via IPC files in /workspace/ipc/input/
-RUN printf '#!/bin/bash\nset -e\ncd /app && npx tsc --outDir /tmp/dist 2>&1 >&2\nln -s /app/node_modules /tmp/dist/node_modules\nchmod -R a-w /tmp/dist\ncat > /tmp/input.json\nnode /tmp/dist/index.js < /tmp/input.json\n' > /app/entrypoint.sh && chmod +x /app/entrypoint.sh
+# Entrypoint starts as root to remount /proc with hidepid=2 (blocks /proc/$PPID/environ
+# attack), then drops to unprivileged user via setpriv
+COPY entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
 
 # Set ownership to node user (non-root) for writable directories
 RUN chown -R node:node /workspace && chmod 777 /home/node
 
-# Switch to non-root user (required for --dangerously-skip-permissions)
-USER node
+# Note: no USER directive — entrypoint starts as root to remount /proc with
+# hidepid=2, then drops to unprivileged user via setpriv before running Node.
 
 # Set working directory to group workspace
 WORKDIR /workspace/group

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -196,6 +196,24 @@ function createSanitizeBashHook(): HookCallback {
     const command = (preInput.tool_input as { command?: string })?.command;
     if (!command) return {};
 
+    // Defense-in-depth: detect /proc environment access attempts.
+    // The primary defense is hidepid=2 (kernel-level), but log and block
+    // obvious attempts as an additional signal.
+    const lowerCmd = command.toLowerCase();
+    if (
+      (lowerCmd.includes('/proc/') && lowerCmd.includes('environ')) ||
+      lowerCmd.includes('ps eww') ||
+      lowerCmd.includes('ps auxe')
+    ) {
+      log('SECURITY: Blocked /proc/environ access attempt');
+      return {
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'deny',
+        },
+      };
+    }
+
     const unsetPrefix = `unset ${SECRET_ENV_VARS.join(' ')} 2>/dev/null; `;
     return {
       hookSpecificOutput: {

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+# --- Build phase (as root) ---
+cd /app && npx tsc --outDir /tmp/dist 2>&1 >&2
+ln -s /app/node_modules /tmp/dist/node_modules
+chmod -R a-w /tmp/dist
+
+# --- Security: /proc hardening ---
+# Remount /proc with hidepid=2 so processes cannot see other processes'
+# /proc/PID entries. This blocks the /proc/$PPID/environ attack vector
+# where Bash tool commands read the CLI subprocess's API key.
+if mount -o remount,hidepid=2 /proc 2>/dev/null; then
+    echo "[entrypoint] /proc remounted with hidepid=2" >&2
+else
+    echo "[entrypoint] WARNING: hidepid=2 failed - falling back to hook-only defense" >&2
+fi
+
+# --- Read input and drop privileges ---
+cat > /tmp/input.json
+
+TARGET_UID=${RUN_UID:-1000}
+TARGET_GID=${RUN_GID:-1000}
+chown "$TARGET_UID:$TARGET_GID" /tmp/input.json
+
+# Drop to unprivileged user. The UID transition clears all capabilities
+# (including SYS_ADMIN) per capabilities(7). --no-new-privs prevents
+# regaining privileges via setuid binaries.
+exec setpriv --reuid="$TARGET_UID" --regid="$TARGET_GID" --clear-groups \
+    --no-new-privs node /tmp/dist/index.js < /tmp/input.json

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -80,7 +80,16 @@ Only these environment variables are exposed to containers:
 const allowedVars = ['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_API_KEY'];
 ```
 
-> **Note:** Anthropic credentials are mounted so that Claude Code can authenticate when the agent runs. However, this means the agent itself can discover these credentials via Bash or file operations. Ideally, Claude Code would authenticate without exposing credentials to the agent's execution environment, but I couldn't figure this out. **PRs welcome** if you have ideas for credential isolation.
+**In-Container Credential Protection:**
+
+The Claude Agent SDK requires API credentials as environment variables for its CLI
+subprocess. To prevent Bash tool commands from reading these via `/proc/PID/environ`:
+
+1. `/proc` is remounted with `hidepid=2` in the container entrypoint (kernel-level)
+2. The container starts as root for the remount, then drops to unprivileged `node` user
+3. Bash commands attempting `/proc/*/environ` access are detected and blocked (hook-level)
+4. Secret env vars are `unset` in every Bash subprocess (defense-in-depth)
+5. After `setpriv` drops to unprivileged user, all capabilities (including `SYS_ADMIN`) are lost per `capabilities(7)`
 
 ## Privilege Comparison
 

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -232,13 +232,20 @@ function buildContainerArgs(
   // Pass host timezone so container's local time matches the user's
   args.push('-e', `TZ=${TIMEZONE}`);
 
-  // Run as host user so bind-mounted files are accessible.
-  // Skip when running as root (uid 0), as the container's node user (uid 1000),
-  // or when getuid is unavailable (native Windows without WSL).
+  // Security: add SYS_ADMIN for /proc hidepid=2 remount in entrypoint.
+  // After setpriv drops to unprivileged user, all capabilities (including
+  // SYS_ADMIN) are lost per capabilities(7). We keep Docker's default cap set
+  // because --cap-drop=ALL would break Chromium's sandbox in agent-browser.
+  args.push('--cap-add=SYS_ADMIN');
+
+  // Pass target UID/GID as env vars for entrypoint privilege drop.
+  // The container starts as root (for /proc remount), then setpriv drops to
+  // the target user. Skip when running as root (uid 0), as the container's
+  // node user (uid 1000), or when getuid is unavailable (native Windows without WSL).
   const hostUid = process.getuid?.();
   const hostGid = process.getgid?.();
   if (hostUid != null && hostUid !== 0 && hostUid !== 1000) {
-    args.push('--user', `${hostUid}:${hostGid}`);
+    args.push('-e', `RUN_UID=${hostUid}`, '-e', `RUN_GID=${hostGid}`);
     args.push('-e', 'HOME=/home/node');
   }
 


### PR DESCRIPTION
## Summary

Prevents API key exposure via `/proc/$PPID/environ` inspection inside containers ().

- **Kernel-level defense:** Entrypoint remounts `/proc` with `hidepid=2` before any user code runs, blocking cross-process `/proc/PID` visibility
- **Privilege drop:** Container starts as root for the one-time remount, then drops to unprivileged user via `setpriv --no-new-privs --clear-groups`
- **Capability handling:** Adds `SYS_ADMIN` for the remount; keeps Docker's default cap set to preserve Chromium's sandbox for `agent-browser`
- **Bash hook (defense-in-depth):** Detects and denies `/proc/*/environ`, `ps eww`, `ps auxe` access patterns
- **Graceful fallback:** If `hidepid=2` fails (e.g., rootless Docker), the hook and `unset` prefix layers still provide defense

### Files changed

| File | Change |
|------|--------|
| `container/entrypoint.sh` | New — extracted entrypoint with hidepid remount + setpriv privilege drop |
| `container/Dockerfile` | Replace inline printf with COPY entrypoint; remove `USER node` directive |
| `src/container-runner.ts` | Add `--cap-add=SYS_ADMIN`; replace `--user` with `RUN_UID`/`RUN_GID` env vars |
| `container/agent-runner/src/index.ts` | Add /proc/environ detection to Bash sanitize hook |
| `docs/SECURITY.md` | Document the new credential protection layers |

## Test plan

- [ ] `./container/build.sh` — verify container builds
- [ ] Inside container: `cat /proc/$PPID/environ` should fail with Permission denied
- [ ] Inside container: `ps eww $PPID` should be blocked by hook
- [ ] Run `npm run dev`, send a normal message, verify agent responds correctly
- [ ] Temporarily remove `--cap-add=SYS_ADMIN` to verify graceful fallback (hook still blocks)
- [ ] Test `agent-browser` still works (Chromium sandbox not broken)
- [ ] Test on host where `getuid()` != 1000 to verify `RUN_UID`/`RUN_GID` passthrough

Resolves 

🤖 Generated with [Claude Code](https://claude.com/claude-code)