### PR TITLE
fix(whatsapp): use sender's JID for DM-with-bot registration, skip trigger

### DIFF
--- a/.claude/skills/add-whatsapp/SKILL.md
+++ b/.claude/skills/add-whatsapp/SKILL.md
@@ -201,7 +201,11 @@ AskUserQuestion: Where do you want to chat with the assistant?
 node -e "const c=JSON.parse(require('fs').readFileSync('store/auth/creds.json','utf-8'));console.log(c.me?.id?.split(':')[0]+'@s.whatsapp.net')"
 ```
 
-**DM with bot:** Ask for the bot's phone number. JID = `NUMBER@s.whatsapp.net`
+**DM with bot:** The JID is the **user's** phone number — the number they will message *from* (not the bot's own number). Ask:
+
+AskUserQuestion: What is your personal phone number? (The number you'll use to message the bot — include country code without +, e.g. 1234567890)
+
+JID = `<user-number>@s.whatsapp.net`
 
 **Group (solo, existing):** Run group sync and list available groups:
 
@@ -223,7 +227,7 @@ npx tsx setup/index.ts --step register \
   --channel whatsapp \
   --assistant-name "<name>" \
   --is-main \
-  --no-trigger-required  # Only for main/self-chat
+  --no-trigger-required  # For self-chat and DM with bot (1:1 conversations don't need a trigger prefix)
 ```
 
 For additional groups (trigger-required):


### PR DESCRIPTION
Closes #750

## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description

Two bugs in the "dedicated number + DM with bot" setup path:

1. **Wrong JID** — the skill used the bot's own number as the registration JID. Incoming DMs arrive with the *sender's* JID (the user's personal number), so no messages ever matched → bot silently ignored all messages. Fix: ask for the user's personal number and register that.

2. **Trigger required** — `--no-trigger-required` was only applied for self-chat, not DM with bot. A trigger prefix in a private 1:1 DM is unnecessary. Fix: apply `--no-trigger-required` for both self-chat and DM with bot.

## For Skills

- [x] I have not made any changes to source code
- [x] My skill contains instructions for Claude to follow (not pre-built code)
- [ ] I tested this skill on a fresh clone