### PR TITLE
fix(register): update assistant name in all groups/*/CLAUDE.md

### DIFF
--- a/setup/register.ts
+++ b/setup/register.ts
@@ -148,10 +148,11 @@ export async function run(args: string[]): Promise<void> {
       'Updating assistant name',
     );
 
-    const mdFiles = [
-      path.join(projectRoot, 'groups', 'global', 'CLAUDE.md'),
-      path.join(projectRoot, 'groups', parsed.folder, 'CLAUDE.md'),
-    ];
+    const groupsDir = path.join(projectRoot, 'groups');
+    const mdFiles = fs
+      .readdirSync(groupsDir)
+      .map((d) => path.join(groupsDir, d, 'CLAUDE.md'))
+      .filter((f) => fs.existsSync(f));
 
     for (const mdFile of mdFiles) {
       if (fs.existsSync(mdFile)) {


### PR DESCRIPTION
Fixes #753

## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description

The assistant name update on registration only patched `groups/global/CLAUDE.md` and the newly registered group's folder. Pre-existing group folders (e.g. `groups/main/`) kept the hardcoded "Andy" name, causing the agent to introduce itself incorrectly.

Replace the fixed two-file list with a glob of all `groups/*/CLAUDE.md` so every existing group is updated at registration time.

## For Skills

- [ ] I have not made any changes to source code
- [ ] My skill contains instructions for Claude to follow (not pre-built code)
- [ ] I tested this skill on a fresh clone