### PR TITLE
docs: fix NanoClaw clone command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ NanoClaw provides that same core functionality, but in a codebase small enough t
 ## Quick Start
 
 ```bash
-git clone https://github.com/qwibitai/nanoclaw.git
+git clone https://github.com/qwibitai/nanoclaw.git NanoClaw
 cd NanoClaw
 claude
 ```


### PR DESCRIPTION
## Summary
- clone the repository into `NanoClaw` so the documented `cd NanoClaw` command works as written
- keep the Quick Start snippet consistent for first-time setup