### PR TITLE
fix: add-voice-transcription skill drops WhatsApp registerChannel call

### DIFF
--- a/.claude/skills/add-voice-transcription/modify/src/channels/whatsapp.ts
+++ b/.claude/skills/add-voice-transcription/modify/src/channels/whatsapp.ts
@@ -20,6 +20,7 @@ import {
 import { logger } from '../logger.js';
 import { isVoiceMessage, transcribeAudioMessage } from '../transcription.js';
 import { Channel, OnInboundMessage, OnChatMetadata, RegisteredGroup } from '../types.js';
+import { registerChannel, ChannelOpts } from './registry.js';
 
 const GROUP_SYNC_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
@@ -354,3 +355,12 @@ export class WhatsAppChannel implements Channel {
     }
   }
 }
+
+registerChannel('whatsapp', (opts: ChannelOpts) => {
+  const authDir = path.join(STORE_DIR, 'auth');
+  if (!fs.existsSync(path.join(authDir, 'creds.json'))) {
+    logger.warn('WhatsApp: credentials not found. Run /add-whatsapp to authenticate.');
+    return null;
+  }
+  return new WhatsAppChannel(opts);
+});


### PR DESCRIPTION
## Summary

- The `modify/src/channels/whatsapp.ts` patch in the `add-voice-transcription` skill was missing the `registerChannel()` call and its `registry.js` import
- When the three-way merge ran after applying the skill, the WhatsApp channel silently lost its self-registration — causing it to never start on service restarts
- Messages were never received after a restart even though WhatsApp credentials were valid

## Root cause

The `add-whatsapp` skill's `whatsapp.ts` template correctly ends with:
```ts
registerChannel('whatsapp', (opts: ChannelOpts) => ...);
```

But the `add-voice-transcription` skill's version of the same file (used as the "new" side of the three-way merge) was missing this entirely — so the merge dropped it.

## Fix

Added the missing import and `registerChannel` factory with a `creds.json` guard to the `add-voice-transcription` skill's patch file, matching the pattern in `add-whatsapp`.

## Test plan

- [ ] Apply `add-whatsapp` then `add-voice-transcription`
- [ ] Restart the service
- [ ] Confirm WhatsApp channel connects on restart (look for `Connected to WhatsApp` in logs)
- [ ] Send a voice note — confirm transcription works

🤖 Generated with [Claude Code](https://claude.com/claude-code)