### PR TITLE
fix: close task container promptly when agent uses IPC-only messaging

### DIFF
--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -191,6 +191,7 @@ async function runTask(
         }
         if (streamedOutput.status === 'success') {
           deps.queue.notifyIdle(task.chat_jid);
+          scheduleClose(); // Close promptly even when result is null (e.g. IPC-only tasks)
         }
         if (streamedOutput.status === 'error') {
           error = streamedOutput.error || 'Unknown error';


### PR DESCRIPTION
Fixes #839

## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description

Scheduled tasks that send messages via `send_message` (IPC) instead of returning text as `result` left the container idle for ~30 minutes until the hard timeout killed it (exit 137). This blocked new messages for the group during that window.

`scheduleClose()` was only called inside `if (streamedOutput.result)`. Tasks that communicate solely through IPC complete with `result=null`, so the 10s close timer was never set.

Fix: also call `scheduleClose()` on `status === 'success'`, covering both result-based and IPC-only task completions.

## For Skills

- [x] I have not made any changes to source code (N/A - source fix)