### PR TITLE
feat(telegram): download media files and save to group workspace

### DIFF
--- a/src/channels/telegram.test.ts
+++ b/src/channels/telegram.test.ts
@@ -1,0 +1,1051 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+// --- Mocks ---
+
+// Mock registry (registerChannel runs at import time)
+vi.mock('./registry.js', () => ({ registerChannel: vi.fn() }));
+
+// Mock env reader (used by the factory, not needed in unit tests)
+vi.mock('../env.js', () => ({ readEnvFile: vi.fn(() => ({})) }));
+
+// Mock config
+vi.mock('../config.js', () => ({
+  ASSISTANT_NAME: 'Andy',
+  TRIGGER_PATTERN: /^@Andy\b/i,
+  GROUPS_DIR: '/tmp/test-groups',
+}));
+
+// Mock fs
+vi.mock('node:fs/promises', () => ({
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock logger
+vi.mock('../logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// --- Grammy mock ---
+
+type Handler = (...args: any[]) => any;
+
+const botRef = vi.hoisted(() => ({ current: null as any }));
+
+vi.mock('grammy', () => ({
+  Bot: class MockBot {
+    token: string;
+    commandHandlers = new Map<string, Handler>();
+    filterHandlers = new Map<string, Handler[]>();
+    errorHandler: Handler | null = null;
+
+    api = {
+      sendMessage: vi.fn().mockResolvedValue(undefined),
+      sendChatAction: vi.fn().mockResolvedValue(undefined),
+      getFile: vi.fn().mockResolvedValue({
+        file_id: 'test-file-id',
+        file_path: 'photos/file_0.jpg',
+        file_size: 1024,
+      }),
+    };
+
+    constructor(token: string) {
+      this.token = token;
+      botRef.current = this;
+    }
+
+    command(name: string, handler: Handler) {
+      this.commandHandlers.set(name, handler);
+    }
+
+    on(filter: string, handler: Handler) {
+      const existing = this.filterHandlers.get(filter) || [];
+      existing.push(handler);
+      this.filterHandlers.set(filter, existing);
+    }
+
+    catch(handler: Handler) {
+      this.errorHandler = handler;
+    }
+
+    start(opts: { onStart: (botInfo: any) => void }) {
+      opts.onStart({ username: 'andy_ai_bot', id: 12345 });
+    }
+
+    stop() {}
+  },
+}));
+
+import * as fs from 'node:fs/promises';
+
+import { TelegramChannel, TelegramChannelOpts } from './telegram.js';
+
+// --- Test helpers ---
+
+function createTestOpts(
+  overrides?: Partial<TelegramChannelOpts>,
+): TelegramChannelOpts {
+  return {
+    onMessage: vi.fn(),
+    onChatMetadata: vi.fn(),
+    registeredGroups: vi.fn(() => ({
+      'tg:100200300': {
+        name: 'Test Group',
+        folder: 'test-group',
+        trigger: '@Andy',
+        added_at: '2024-01-01T00:00:00.000Z',
+      },
+    })),
+    ...overrides,
+  };
+}
+
+function createTextCtx(overrides: {
+  chatId?: number;
+  chatType?: string;
+  chatTitle?: string;
+  text: string;
+  fromId?: number;
+  firstName?: string;
+  username?: string;
+  messageId?: number;
+  date?: number;
+  entities?: any[];
+}) {
+  const chatId = overrides.chatId ?? 100200300;
+  const chatType = overrides.chatType ?? 'group';
+  return {
+    chat: {
+      id: chatId,
+      type: chatType,
+      title: overrides.chatTitle ?? 'Test Group',
+    },
+    from: {
+      id: overrides.fromId ?? 99001,
+      first_name: overrides.firstName ?? 'Alice',
+      username: overrides.username ?? 'alice_user',
+    },
+    message: {
+      text: overrides.text,
+      date: overrides.date ?? Math.floor(Date.now() / 1000),
+      message_id: overrides.messageId ?? 1,
+      entities: overrides.entities ?? [],
+    },
+    me: { username: 'andy_ai_bot' },
+    reply: vi.fn(),
+  };
+}
+
+function createMediaCtx(overrides: {
+  chatId?: number;
+  chatType?: string;
+  fromId?: number;
+  firstName?: string;
+  date?: number;
+  messageId?: number;
+  caption?: string;
+  extra?: Record<string, any>;
+}) {
+  const chatId = overrides.chatId ?? 100200300;
+  return {
+    chat: {
+      id: chatId,
+      type: overrides.chatType ?? 'group',
+      title: 'Test Group',
+    },
+    from: {
+      id: overrides.fromId ?? 99001,
+      first_name: overrides.firstName ?? 'Alice',
+      username: 'alice_user',
+    },
+    message: {
+      date: overrides.date ?? Math.floor(Date.now() / 1000),
+      message_id: overrides.messageId ?? 1,
+      caption: overrides.caption,
+      photo: [{ file_id: 'photo-file-id', width: 800, height: 600 }],
+      video: { file_id: 'video-file-id' },
+      voice: { file_id: 'voice-file-id' },
+      audio: { file_id: 'audio-file-id' },
+      document: { file_id: 'doc-file-id', file_name: 'report.pdf' },
+      sticker: { file_id: 'sticker-file-id', emoji: '😂' },
+      ...(overrides.extra || {}),
+    },
+    me: { username: 'andy_ai_bot' },
+  };
+}
+
+function currentBot() {
+  return botRef.current;
+}
+
+async function triggerTextMessage(ctx: ReturnType<typeof createTextCtx>) {
+  const handlers = currentBot().filterHandlers.get('message:text') || [];
+  for (const h of handlers) await h(ctx);
+}
+
+async function triggerMediaMessage(
+  filter: string,
+  ctx: ReturnType<typeof createMediaCtx>,
+) {
+  const handlers = currentBot().filterHandlers.get(filter) || [];
+  for (const h of handlers) await h(ctx);
+}
+
+// --- Tests ---
+
+describe('TelegramChannel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(1024)),
+    }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // --- Connection lifecycle ---
+
+  describe('connection lifecycle', () => {
+    it('resolves connect() when bot starts', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+
+      await channel.connect();
+
+      expect(channel.isConnected()).toBe(true);
+    });
+
+    it('registers command and message handlers on connect', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+
+      await channel.connect();
+
+      expect(currentBot().commandHandlers.has('chatid')).toBe(true);
+      expect(currentBot().commandHandlers.has('ping')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:text')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:photo')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:video')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:voice')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:audio')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:document')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:sticker')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:location')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:contact')).toBe(true);
+    });
+
+    it('registers error handler on connect', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+
+      await channel.connect();
+
+      expect(currentBot().errorHandler).not.toBeNull();
+    });
+
+    it('disconnects cleanly', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+
+      await channel.connect();
+      expect(channel.isConnected()).toBe(true);
+
+      await channel.disconnect();
+      expect(channel.isConnected()).toBe(false);
+    });
+
+    it('isConnected() returns false before connect', () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+
+      expect(channel.isConnected()).toBe(false);
+    });
+  });
+
+  // --- Text message handling ---
+
+  describe('text message handling', () => {
+    it('delivers message for registered group', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ text: 'Hello everyone' });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.any(String),
+        'Test Group',
+        'telegram',
+        true,
+      );
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          id: '1',
+          chat_jid: 'tg:100200300',
+          sender: '99001',
+          sender_name: 'Alice',
+          content: 'Hello everyone',
+          is_from_me: false,
+        }),
+      );
+    });
+
+    it('only emits metadata for unregistered chats', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ chatId: 999999, text: 'Unknown chat' });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        'tg:999999',
+        expect.any(String),
+        'Test Group',
+        'telegram',
+        true,
+      );
+      expect(opts.onMessage).not.toHaveBeenCalled();
+    });
+
+    it('skips command messages (starting with /)', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ text: '/start' });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).not.toHaveBeenCalled();
+      expect(opts.onChatMetadata).not.toHaveBeenCalled();
+    });
+
+    it('extracts sender name from first_name', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ text: 'Hi', firstName: 'Bob' });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ sender_name: 'Bob' }),
+      );
+    });
+
+    it('falls back to username when first_name missing', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ text: 'Hi' });
+      ctx.from.first_name = undefined as any;
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ sender_name: 'alice_user' }),
+      );
+    });
+
+    it('falls back to user ID when name and username missing', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ text: 'Hi', fromId: 42 });
+      ctx.from.first_name = undefined as any;
+      ctx.from.username = undefined as any;
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ sender_name: '42' }),
+      );
+    });
+
+    it('uses sender name as chat name for private chats', async () => {
+      const opts = createTestOpts({
+        registeredGroups: vi.fn(() => ({
+          'tg:100200300': {
+            name: 'Private',
+            folder: 'private',
+            trigger: '@Andy',
+            added_at: '2024-01-01T00:00:00.000Z',
+          },
+        })),
+      });
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: 'Hello',
+        chatType: 'private',
+        firstName: 'Alice',
+      });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.any(String),
+        'Alice', // Private chats use sender name
+        'telegram',
+        false,
+      );
+    });
+
+    it('uses chat title as name for group chats', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: 'Hello',
+        chatType: 'supergroup',
+        chatTitle: 'Project Team',
+      });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.any(String),
+        'Project Team',
+        'telegram',
+        true,
+      );
+    });
+
+    it('converts message.date to ISO timestamp', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const unixTime = 1704067200; // 2024-01-01T00:00:00.000Z
+      const ctx = createTextCtx({ text: 'Hello', date: unixTime });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          timestamp: '2024-01-01T00:00:00.000Z',
+        }),
+      );
+    });
+  });
+
+  // --- @mention translation ---
+
+  describe('@mention translation', () => {
+    it('translates @bot_username mention to trigger format', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: '@andy_ai_bot what time is it?',
+        entities: [{ type: 'mention', offset: 0, length: 12 }],
+      });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '@Andy @andy_ai_bot what time is it?',
+        }),
+      );
+    });
+
+    it('does not translate if message already matches trigger', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: '@Andy @andy_ai_bot hello',
+        entities: [{ type: 'mention', offset: 6, length: 12 }],
+      });
+      await triggerTextMessage(ctx);
+
+      // Should NOT double-prepend — already starts with @Andy
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '@Andy @andy_ai_bot hello',
+        }),
+      );
+    });
+
+    it('does not translate mentions of other bots', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: '@some_other_bot hi',
+        entities: [{ type: 'mention', offset: 0, length: 15 }],
+      });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '@some_other_bot hi', // No translation
+        }),
+      );
+    });
+
+    it('handles mention in middle of message', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: 'hey @andy_ai_bot check this',
+        entities: [{ type: 'mention', offset: 4, length: 12 }],
+      });
+      await triggerTextMessage(ctx);
+
+      // Bot is mentioned, message doesn't match trigger → prepend trigger
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '@Andy hey @andy_ai_bot check this',
+        }),
+      );
+    });
+
+    it('handles message with no entities', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ text: 'plain message' });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: 'plain message',
+        }),
+      );
+    });
+
+    it('ignores non-mention entities', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: 'check https://example.com',
+        entities: [{ type: 'url', offset: 6, length: 19 }],
+      });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: 'check https://example.com',
+        }),
+      );
+    });
+  });
+
+  // --- Non-text messages ---
+
+  describe('non-text messages', () => {
+    it('stores photo with downloaded file path', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({});
+      await triggerMediaMessage('message:photo', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Photo saved: media/photo_1.jpg]' }),
+      );
+    });
+
+    it('stores photo with caption after file path', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({ caption: 'Look at this' });
+      await triggerMediaMessage('message:photo', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '[Photo saved: media/photo_1.jpg] Look at this',
+        }),
+      );
+    });
+
+    it('stores video with downloaded file path', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({});
+      await triggerMediaMessage('message:video', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Video saved: media/video_1.mp4]' }),
+      );
+    });
+
+    it('stores voice message with downloaded file path', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({});
+      await triggerMediaMessage('message:voice', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Voice message saved: media/voice_1.ogg]' }),
+      );
+    });
+
+    it('stores audio with downloaded file path', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({});
+      await triggerMediaMessage('message:audio', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Audio saved: media/audio_1.mp3]' }),
+      );
+    });
+
+    it('stores document with downloaded file path and original extension', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({
+        messageId: 7,
+        extra: { document: { file_id: 'doc-id', file_name: 'report.pdf' } },
+      });
+      await triggerMediaMessage('message:document', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '[Document saved: media/document_7.pdf]',
+        }),
+      );
+    });
+
+    it('stores document with .bin fallback when filename missing', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({ extra: { document: { file_id: 'doc-id' } } });
+      await triggerMediaMessage('message:document', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '[Document saved: media/document_1.bin]',
+        }),
+      );
+    });
+
+    it('stores sticker with downloaded file path', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({
+        messageId: 5,
+        extra: { sticker: { file_id: 'sticker-id', emoji: '🔥' } },
+      });
+      await triggerMediaMessage('message:sticker', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '[Sticker saved: media/sticker_5.webp]',
+        }),
+      );
+    });
+
+    it('location stays as placeholder (no download)', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({});
+      await triggerMediaMessage('message:location', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Location]' }),
+      );
+      expect(currentBot().api.getFile).not.toHaveBeenCalled();
+    });
+
+    it('contact stays as placeholder (no download)', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({});
+      await triggerMediaMessage('message:contact', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Contact]' }),
+      );
+      expect(currentBot().api.getFile).not.toHaveBeenCalled();
+    });
+
+    it('ignores non-text messages from unregistered chats', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({ chatId: 999999 });
+      await triggerMediaMessage('message:photo', ctx);
+
+      expect(opts.onMessage).not.toHaveBeenCalled();
+    });
+
+    it('falls back to placeholder when download fails', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      currentBot().api.getFile.mockRejectedValueOnce(new Error('API error'));
+
+      const ctx = createMediaCtx({});
+      await triggerMediaMessage('message:photo', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Photo]' }),
+      );
+    });
+
+    it('falls back to placeholder when file exceeds 20MB', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      currentBot().api.getFile.mockResolvedValueOnce({
+        file_id: 'big-file',
+        file_path: 'videos/big.mp4',
+        file_size: 25 * 1024 * 1024,
+      });
+
+      const ctx = createMediaCtx({});
+      await triggerMediaMessage('message:video', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Video]' }),
+      );
+    });
+
+    it('falls back to placeholder when fetch returns non-ok', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+      } as Response);
+
+      const ctx = createMediaCtx({});
+      await triggerMediaMessage('message:photo', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Photo]' }),
+      );
+    });
+
+    it('creates media directory with recursive flag', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({});
+      await triggerMediaMessage('message:photo', ctx);
+
+      expect(fs.mkdir).toHaveBeenCalledWith(
+        '/tmp/test-groups/test-group/media',
+        { recursive: true },
+      );
+    });
+
+    it('writes file buffer to correct path', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({ messageId: 42 });
+      await triggerMediaMessage('message:photo', ctx);
+
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        '/tmp/test-groups/test-group/media/photo_42.jpg',
+        expect.any(Buffer),
+      );
+    });
+  });
+
+  // --- sendMessage ---
+
+  describe('sendMessage', () => {
+    it('sends message via bot API', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      await channel.sendMessage('tg:100200300', 'Hello');
+
+      expect(currentBot().api.sendMessage).toHaveBeenCalledWith(
+        '100200300',
+        'Hello',
+      );
+    });
+
+    it('strips tg: prefix from JID', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      await channel.sendMessage('tg:-1001234567890', 'Group message');
+
+      expect(currentBot().api.sendMessage).toHaveBeenCalledWith(
+        '-1001234567890',
+        'Group message',
+      );
+    });
+
+    it('splits messages exceeding 4096 characters', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const longText = 'x'.repeat(5000);
+      await channel.sendMessage('tg:100200300', longText);
+
+      expect(currentBot().api.sendMessage).toHaveBeenCalledTimes(2);
+      expect(currentBot().api.sendMessage).toHaveBeenNthCalledWith(
+        1,
+        '100200300',
+        'x'.repeat(4096),
+      );
+      expect(currentBot().api.sendMessage).toHaveBeenNthCalledWith(
+        2,
+        '100200300',
+        'x'.repeat(904),
+      );
+    });
+
+    it('sends exactly one message at 4096 characters', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const exactText = 'y'.repeat(4096);
+      await channel.sendMessage('tg:100200300', exactText);
+
+      expect(currentBot().api.sendMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles send failure gracefully', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      currentBot().api.sendMessage.mockRejectedValueOnce(
+        new Error('Network error'),
+      );
+
+      // Should not throw
+      await expect(
+        channel.sendMessage('tg:100200300', 'Will fail'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('does nothing when bot is not initialized', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+
+      // Don't connect — bot is null
+      await channel.sendMessage('tg:100200300', 'No bot');
+
+      // No error, no API call
+    });
+  });
+
+  // --- ownsJid ---
+
+  describe('ownsJid', () => {
+    it('owns tg: JIDs', () => {
+      const channel = new TelegramChannel('test-token', createTestOpts());
+      expect(channel.ownsJid('tg:123456')).toBe(true);
+    });
+
+    it('owns tg: JIDs with negative IDs (groups)', () => {
+      const channel = new TelegramChannel('test-token', createTestOpts());
+      expect(channel.ownsJid('tg:-1001234567890')).toBe(true);
+    });
+
+    it('does not own WhatsApp group JIDs', () => {
+      const channel = new TelegramChannel('test-token', createTestOpts());
+      expect(channel.ownsJid('12345@g.us')).toBe(false);
+    });
+
+    it('does not own WhatsApp DM JIDs', () => {
+      const channel = new TelegramChannel('test-token', createTestOpts());
+      expect(channel.ownsJid('12345@s.whatsapp.net')).toBe(false);
+    });
+
+    it('does not own unknown JID formats', () => {
+      const channel = new TelegramChannel('test-token', createTestOpts());
+      expect(channel.ownsJid('random-string')).toBe(false);
+    });
+  });
+
+  // --- setTyping ---
+
+  describe('setTyping', () => {
+    it('sends typing action when isTyping is true', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      await channel.setTyping('tg:100200300', true);
+
+      expect(currentBot().api.sendChatAction).toHaveBeenCalledWith(
+        '100200300',
+        'typing',
+      );
+    });
+
+    it('does nothing when isTyping is false', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      await channel.setTyping('tg:100200300', false);
+
+      expect(currentBot().api.sendChatAction).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when bot is not initialized', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+
+      // Don't connect
+      await channel.setTyping('tg:100200300', true);
+
+      // No error, no API call
+    });
+
+    it('handles typing indicator failure gracefully', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      currentBot().api.sendChatAction.mockRejectedValueOnce(
+        new Error('Rate limited'),
+      );
+
+      await expect(
+        channel.setTyping('tg:100200300', true),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  // --- Bot commands ---
+
+  describe('bot commands', () => {
+    it('/chatid replies with chat ID and metadata', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const handler = currentBot().commandHandlers.get('chatid')!;
+      const ctx = {
+        chat: { id: 100200300, type: 'group' as const },
+        from: { first_name: 'Alice' },
+        reply: vi.fn(),
+      };
+
+      await handler(ctx);
+
+      expect(ctx.reply).toHaveBeenCalledWith(
+        expect.stringContaining('tg:100200300'),
+        expect.objectContaining({ parse_mode: 'Markdown' }),
+      );
+    });
+
+    it('/chatid shows chat type', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const handler = currentBot().commandHandlers.get('chatid')!;
+      const ctx = {
+        chat: { id: 555, type: 'private' as const },
+        from: { first_name: 'Bob' },
+        reply: vi.fn(),
+      };
+
+      await handler(ctx);
+
+      expect(ctx.reply).toHaveBeenCalledWith(
+        expect.stringContaining('private'),
+        expect.any(Object),
+      );
+    });
+
+    it('/ping replies with bot status', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const handler = currentBot().commandHandlers.get('ping')!;
+      const ctx = { reply: vi.fn() };
+
+      await handler(ctx);
+
+      expect(ctx.reply).toHaveBeenCalledWith('Andy is online.');
+    });
+  });
+
+  // --- Channel properties ---
+
+  describe('channel properties', () => {
+    it('has name "telegram"', () => {
+      const channel = new TelegramChannel('test-token', createTestOpts());
+      expect(channel.name).toBe('telegram');
+    });
+  });
+});

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -1,0 +1,378 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+import { Bot } from 'grammy';
+
+import { ASSISTANT_NAME, TRIGGER_PATTERN, GROUPS_DIR } from '../config.js';
+import { readEnvFile } from '../env.js';
+import { logger } from '../logger.js';
+import { registerChannel, ChannelOpts } from './registry.js';
+import {
+  Channel,
+  OnChatMetadata,
+  OnInboundMessage,
+  RegisteredGroup,
+} from '../types.js';
+
+export interface TelegramChannelOpts {
+  onMessage: OnInboundMessage;
+  onChatMetadata: OnChatMetadata;
+  registeredGroups: () => Record<string, RegisteredGroup>;
+}
+
+export class TelegramChannel implements Channel {
+  name = 'telegram';
+
+  private bot: Bot | null = null;
+  private opts: TelegramChannelOpts;
+  private botToken: string;
+
+  constructor(botToken: string, opts: TelegramChannelOpts) {
+    this.botToken = botToken;
+    this.opts = opts;
+  }
+
+  async connect(): Promise<void> {
+    this.bot = new Bot(this.botToken);
+
+    // Command to get chat ID (useful for registration)
+    this.bot.command('chatid', (ctx) => {
+      const chatId = ctx.chat.id;
+      const chatType = ctx.chat.type;
+      const chatName =
+        chatType === 'private'
+          ? ctx.from?.first_name || 'Private'
+          : (ctx.chat as any).title || 'Unknown';
+
+      ctx.reply(
+        `Chat ID: \`tg:${chatId}\`\nName: ${chatName}\nType: ${chatType}`,
+        { parse_mode: 'Markdown' },
+      );
+    });
+
+    // Command to check bot status
+    this.bot.command('ping', (ctx) => {
+      ctx.reply(`${ASSISTANT_NAME} is online.`);
+    });
+
+    this.bot.on('message:text', async (ctx) => {
+      // Skip commands
+      if (ctx.message.text.startsWith('/')) return;
+
+      const chatJid = `tg:${ctx.chat.id}`;
+      let content = ctx.message.text;
+      const timestamp = new Date(ctx.message.date * 1000).toISOString();
+      const senderName =
+        ctx.from?.first_name ||
+        ctx.from?.username ||
+        ctx.from?.id.toString() ||
+        'Unknown';
+      const sender = ctx.from?.id.toString() || '';
+      const msgId = ctx.message.message_id.toString();
+
+      // Determine chat name
+      const chatName =
+        ctx.chat.type === 'private'
+          ? senderName
+          : (ctx.chat as any).title || chatJid;
+
+      // Translate Telegram @bot_username mentions into TRIGGER_PATTERN format.
+      // Telegram @mentions (e.g., @andy_ai_bot) won't match TRIGGER_PATTERN
+      // (e.g., ^@Andy\b), so we prepend the trigger when the bot is @mentioned.
+      const botUsername = ctx.me?.username?.toLowerCase();
+      if (botUsername) {
+        const entities = ctx.message.entities || [];
+        const isBotMentioned = entities.some((entity) => {
+          if (entity.type === 'mention') {
+            const mentionText = content
+              .substring(entity.offset, entity.offset + entity.length)
+              .toLowerCase();
+            return mentionText === `@${botUsername}`;
+          }
+          return false;
+        });
+        if (isBotMentioned && !TRIGGER_PATTERN.test(content)) {
+          content = `@${ASSISTANT_NAME} ${content}`;
+        }
+      }
+
+      // Store chat metadata for discovery
+      const isGroup = ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
+      this.opts.onChatMetadata(chatJid, timestamp, chatName, 'telegram', isGroup);
+
+      // Only deliver full message for registered groups
+      const group = this.opts.registeredGroups()[chatJid];
+      if (!group) {
+        logger.debug(
+          { chatJid, chatName },
+          'Message from unregistered Telegram chat',
+        );
+        return;
+      }
+
+      // Deliver message — startMessageLoop() will pick it up
+      this.opts.onMessage(chatJid, {
+        id: msgId,
+        chat_jid: chatJid,
+        sender,
+        sender_name: senderName,
+        content,
+        timestamp,
+        is_from_me: false,
+      });
+
+      logger.info(
+        { chatJid, chatName, sender: senderName },
+        'Telegram message stored',
+      );
+    });
+
+    // Handle non-text messages — download media when possible.
+    const storeNonText = async (
+      ctx: any,
+      placeholder: string,
+      download?: { fileId: string; label: string; prefix: string; extension: string },
+    ) => {
+      const chatJid = `tg:${ctx.chat.id}`;
+      const group = this.opts.registeredGroups()[chatJid];
+      if (!group) return;
+
+      const timestamp = new Date(ctx.message.date * 1000).toISOString();
+      const senderName =
+        ctx.from?.first_name ||
+        ctx.from?.username ||
+        ctx.from?.id?.toString() ||
+        'Unknown';
+      const caption = ctx.message.caption ? ` ${ctx.message.caption}` : '';
+      const messageId = ctx.message.message_id.toString();
+
+      let content: string;
+      if (download) {
+        const savedPath = await this.downloadMedia(
+          group.folder,
+          download.fileId,
+          download.prefix,
+          download.extension,
+          messageId,
+        );
+        if (savedPath) {
+          content = `[${download.label} saved: ${savedPath}]${caption}`;
+        } else {
+          content = `${placeholder}${caption}`;
+        }
+      } else {
+        content = `${placeholder}${caption}`;
+      }
+
+      const isGroup = ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
+      this.opts.onChatMetadata(chatJid, timestamp, undefined, 'telegram', isGroup);
+      this.opts.onMessage(chatJid, {
+        id: messageId,
+        chat_jid: chatJid,
+        sender: ctx.from?.id?.toString() || '',
+        sender_name: senderName,
+        content,
+        timestamp,
+        is_from_me: false,
+      });
+    };
+
+    this.bot.on('message:photo', (ctx) => {
+      const photos = ctx.message.photo!;
+      const largest = photos[photos.length - 1];
+      return storeNonText(ctx, '[Photo]', {
+        fileId: largest.file_id,
+        label: 'Photo',
+        prefix: 'photo',
+        extension: '.jpg',
+      });
+    });
+
+    this.bot.on('message:video', (ctx) =>
+      storeNonText(ctx, '[Video]', {
+        fileId: ctx.message.video!.file_id,
+        label: 'Video',
+        prefix: 'video',
+        extension: '.mp4',
+      })
+    );
+
+    this.bot.on('message:voice', (ctx) =>
+      storeNonText(ctx, '[Voice message]', {
+        fileId: ctx.message.voice!.file_id,
+        label: 'Voice message',
+        prefix: 'voice',
+        extension: '.ogg',
+      })
+    );
+
+    this.bot.on('message:audio', (ctx) =>
+      storeNonText(ctx, '[Audio]', {
+        fileId: ctx.message.audio!.file_id,
+        label: 'Audio',
+        prefix: 'audio',
+        extension: '.mp3',
+      })
+    );
+
+    this.bot.on('message:document', (ctx) => {
+      const doc = ctx.message.document!;
+      const name = path.basename(doc.file_name || 'file').replace(/[\x00-\x1f]/g, '');
+      const ext = path.extname(name) || '.bin';
+      return storeNonText(ctx, `[Document: ${name}]`, {
+        fileId: doc.file_id,
+        label: 'Document',
+        prefix: 'document',
+        extension: ext,
+      });
+    });
+
+    this.bot.on('message:sticker', (ctx) => {
+      const sticker = ctx.message.sticker!;
+      const emoji = sticker.emoji || '';
+      return storeNonText(ctx, `[Sticker ${emoji}]`, {
+        fileId: sticker.file_id,
+        label: 'Sticker',
+        prefix: 'sticker',
+        extension: '.webp',
+      });
+    });
+
+    // Location and contact have no downloadable file
+    this.bot.on('message:location', (ctx) => storeNonText(ctx, '[Location]'));
+    this.bot.on('message:contact', (ctx) => storeNonText(ctx, '[Contact]'));
+
+    // Handle errors gracefully
+    this.bot.catch((err) => {
+      logger.error({ err: err.message }, 'Telegram bot error');
+    });
+
+    // Start polling — returns a Promise that resolves when started
+    return new Promise<void>((resolve) => {
+      this.bot!.start({
+        onStart: (botInfo) => {
+          logger.info(
+            { username: botInfo.username, id: botInfo.id },
+            'Telegram bot connected',
+          );
+          console.log(`\n  Telegram bot: @${botInfo.username}`);
+          console.log(
+            `  Send /chatid to the bot to get a chat's registration ID\n`,
+          );
+          resolve();
+        },
+      });
+    });
+  }
+
+  async sendMessage(jid: string, text: string): Promise<void> {
+    if (!this.bot) {
+      logger.warn('Telegram bot not initialized');
+      return;
+    }
+
+    try {
+      const numericId = jid.replace(/^tg:/, '');
+
+      // Telegram has a 4096 character limit per message — split if needed
+      const MAX_LENGTH = 4096;
+      if (text.length <= MAX_LENGTH) {
+        await this.bot.api.sendMessage(numericId, text);
+      } else {
+        for (let i = 0; i < text.length; i += MAX_LENGTH) {
+          await this.bot.api.sendMessage(
+            numericId,
+            text.slice(i, i + MAX_LENGTH),
+          );
+        }
+      }
+      logger.info({ jid, length: text.length }, 'Telegram message sent');
+    } catch (err) {
+      logger.error({ jid, err }, 'Failed to send Telegram message');
+    }
+  }
+
+  isConnected(): boolean {
+    return this.bot !== null;
+  }
+
+  ownsJid(jid: string): boolean {
+    return jid.startsWith('tg:');
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.bot) {
+      this.bot.stop();
+      this.bot = null;
+      logger.info('Telegram bot stopped');
+    }
+  }
+
+  async setTyping(jid: string, isTyping: boolean): Promise<void> {
+    if (!this.bot || !isTyping) return;
+    try {
+      const numericId = jid.replace(/^tg:/, '');
+      await this.bot.api.sendChatAction(numericId, 'typing');
+    } catch (err) {
+      logger.debug({ jid, err }, 'Failed to send Telegram typing indicator');
+    }
+  }
+
+  private async downloadMedia(
+    groupFolder: string,
+    fileId: string,
+    prefix: string,
+    extension: string,
+    messageId: string,
+  ): Promise<string | null> {
+    if (!this.bot) return null;
+
+    try {
+      const file = await this.bot.api.getFile(fileId);
+
+      if (file.file_size && file.file_size > 20 * 1024 * 1024) {
+        logger.warn({ fileId, size: file.file_size }, 'Telegram file exceeds 20MB limit');
+        return null;
+      }
+
+      if (!file.file_path) {
+        logger.warn({ fileId }, 'Telegram getFile returned no file_path');
+        return null;
+      }
+
+      // SECURITY: This URL contains the bot token — never log it
+      const url = `https://api.telegram.org/file/bot${this.botToken}/${file.file_path}`;
+      const response = await fetch(url);
+      if (!response.ok) {
+        logger.warn({ fileId, status: response.status }, 'Telegram file download failed');
+        return null;
+      }
+
+      const buffer = Buffer.from(await response.arrayBuffer());
+
+      const mediaDir = path.join(GROUPS_DIR, groupFolder, 'media');
+      await fs.mkdir(mediaDir, { recursive: true });
+
+      const filename = `${prefix}_${messageId}${extension}`;
+      const filePath = path.join(mediaDir, filename);
+      await fs.writeFile(filePath, buffer);
+
+      logger.info({ fileId, filePath }, 'Telegram media file saved');
+      return `media/${filename}`;
+    } catch (err) {
+      logger.warn({ fileId, err }, 'Failed to download Telegram media');
+      return null;
+    }
+  }
+}
+
+registerChannel('telegram', (opts: ChannelOpts) => {
+  const envVars = readEnvFile(['TELEGRAM_BOT_TOKEN']);
+  const token =
+    process.env.TELEGRAM_BOT_TOKEN || envVars.TELEGRAM_BOT_TOKEN || '';
+  if (!token) {
+    logger.warn('Telegram: TELEGRAM_BOT_TOKEN not set');
+    return null;
+  }
+  return new TelegramChannel(token, opts);
+});

--- a/thoughts/shared/plans/2026-03-09-telegram-media-downloads.md
+++ b/thoughts/shared/plans/2026-03-09-telegram-media-downloads.md
@@ -1,0 +1,626 @@
+# Telegram Media File Downloads — Implementation Plan
+
+## Overview
+
+Download media files sent via Telegram (photos, videos, voice messages, audio, documents, stickers) and save them to the group workspace folder so the agent can access the actual content. Replace placeholder strings like `[Photo]` with paths like `[Photo saved: media/photo_42.jpg]`.
+
+## Current State Analysis
+
+The `storeNonText` helper (`src/channels/telegram.ts:128-152`) handles all non-text message types synchronously. It builds a placeholder string (e.g. `[Photo]`), appends any caption, and calls `onMessage`. No bytes are ever downloaded.
+
+### Key Discoveries:
+- Grammy's `bot.api.getFile(fileId)` returns `{ file_path, file_size }` — then fetch `https://api.telegram.org/file/bot<TOKEN>/<file_path>` for the bytes
+- Photos are arrays — use `ctx.message.photo[photos.length - 1]` (largest resolution) for the `file_id`
+- Other types expose `file_id` directly: `ctx.message.video.file_id`, `ctx.message.voice.file_id`, etc.
+- Telegram Bot API enforces a **20MB file size limit** — `file_size` is available before downloading
+- Group folders mount at `/workspace/group/` in containers, so `groups/<folder>/media/` → `/workspace/group/media/`
+- Existing WhatsApp skills use `attachments/` as the subdirectory; this ticket specifies `media/`
+
+### File ID access per media type:
+| Type | file_id location | Extension strategy |
+|------|------------------|--------------------|
+| photo | `ctx.message.photo[last].file_id` | `.jpg` (Telegram always serves JPEG) |
+| video | `ctx.message.video.file_id` | from `mime_type` or `.mp4` |
+| voice | `ctx.message.voice.file_id` | `.ogg` (Telegram voice = opus in ogg) |
+| audio | `ctx.message.audio.file_id` | from `mime_type` or `.mp3` |
+| document | `ctx.message.document.file_id` | from `file_name` or `.bin` |
+| sticker | `ctx.message.sticker.file_id` | `.webp` |
+
+## Desired End State
+
+- Every downloadable media message saves the file to `groups/<folder>/media/`
+- Message content becomes `[Photo saved: media/photo_42.jpg] optional caption`
+- Files over 20MB keep the old placeholder with a note: `[Photo — file too large to download] caption`
+- Location and Contact remain as placeholders (no file to download)
+- All existing tests pass; new tests cover download success, failure, and size-limit paths
+
+## What We're NOT Doing
+
+- Multimodal/vision processing (sending images to Claude as content blocks)
+- Transcription of voice/audio messages
+- Thumbnail generation
+- File deduplication
+- Downloading location/contact (no binary content)
+
+## Implementation Approach
+
+Keep all changes within `src/channels/telegram.ts`. Add a private `downloadMedia` method to `TelegramChannel` that handles the getFile → fetch → save flow. Convert `storeNonText` to async and have each media handler extract the `file_id` and desired extension, then call the download method. On failure or size limit, fall back to the original placeholder.
+
+---
+
+## Phase 1: Add `downloadMedia` helper method
+
+### Overview
+Add a private method to `TelegramChannel` that downloads a file by `file_id` and saves it to the group's `media/` directory.
+
+### Changes Required:
+
+#### 1. Add import for `fs`, `path`, and `GROUPS_DIR`
+**File**: `src/channels/telegram.ts`
+**Changes**: Add imports at top
+
+```typescript
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { ASSISTANT_NAME, TRIGGER_PATTERN, GROUPS_DIR } from '../config.js';
+```
+
+#### 2. Add `downloadMedia` private method
+**File**: `src/channels/telegram.ts`
+**Changes**: Add method to `TelegramChannel` class (after `setTyping`, before the closing brace)
+
+```typescript
+/**
+ * Download a Telegram file and save it to the group's media/ directory.
+ * Returns the relative path (e.g. "media/photo_42.jpg") on success, or null on failure.
+ */
+private async downloadMedia(
+  groupFolder: string,
+  fileId: string,
+  prefix: string,
+  extension: string,
+  messageId: string,
+): Promise<string | null> {
+  if (!this.bot) return null;
+
+  try {
+    const file = await this.bot.api.getFile(fileId);
+
+    // Check 20MB limit (file_size may be undefined for some types)
+    if (file.file_size && file.file_size > 20 * 1024 * 1024) {
+      logger.warn({ fileId, size: file.file_size }, 'Telegram file exceeds 20MB limit');
+      return null;
+    }
+
+    if (!file.file_path) {
+      logger.warn({ fileId }, 'Telegram getFile returned no file_path');
+      return null;
+    }
+
+    // SECURITY: This URL contains the bot token — never log it
+    const url = `https://api.telegram.org/file/bot${this.botToken}/${file.file_path}`;
+    const response = await fetch(url);
+    if (!response.ok) {
+      logger.warn({ fileId, status: response.status }, 'Telegram file download failed');
+      return null;
+    }
+
+    const buffer = Buffer.from(await response.arrayBuffer());
+
+    const mediaDir = path.join(GROUPS_DIR, groupFolder, 'media');
+    await fs.mkdir(mediaDir, { recursive: true });
+
+    const filename = `${prefix}_${messageId}${extension}`;
+    const filePath = path.join(mediaDir, filename);
+    await fs.writeFile(filePath, buffer);
+
+    logger.info({ fileId, filePath }, 'Telegram media file saved');
+    return `media/${filename}`;
+  } catch (err) {
+    logger.warn({ fileId, err }, 'Failed to download Telegram media');
+    return null;
+  }
+}
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] TypeScript compiles without errors (`npm run build`)
+- [x] Existing tests still pass (`npm test`)
+
+**Implementation Note**: After completing this phase and verifying compilation, proceed to Phase 2.
+
+---
+
+## Phase 2: Wire download into media handlers
+
+### Overview
+Convert `storeNonText` to an async function that accepts download parameters. Update each media handler to extract the `file_id` and call the download. Fall back to the original placeholder on failure.
+
+### Changes Required:
+
+#### 1. Rewrite `storeNonText` to support downloads
+**File**: `src/channels/telegram.ts`
+**Changes**: Replace the existing `storeNonText` function and media handler registrations (lines 128-169)
+
+```typescript
+// Handle non-text messages — download media when possible.
+// Grammy awaits the promise returned by event handlers, so all handlers
+// must return the promise from storeNonText (use expression body, not block body).
+const storeNonText = async (
+  ctx: any,
+  placeholder: string,
+  download?: { fileId: string; label: string; prefix: string; extension: string },
+) => {
+  const chatJid = `tg:${ctx.chat.id}`;
+  const group = this.opts.registeredGroups()[chatJid];
+  if (!group) return;
+
+  const timestamp = new Date(ctx.message.date * 1000).toISOString();
+  const senderName =
+    ctx.from?.first_name ||
+    ctx.from?.username ||
+    ctx.from?.id?.toString() ||
+    'Unknown';
+  const caption = ctx.message.caption ? ` ${ctx.message.caption}` : '';
+  const messageId = ctx.message.message_id.toString();
+
+  let content: string;
+  if (download) {
+    const savedPath = await this.downloadMedia(
+      group.folder,
+      download.fileId,
+      download.prefix,
+      download.extension,
+      messageId,
+    );
+    if (savedPath) {
+      // e.g. "[Photo saved: media/photo_42.jpg] Look at this"
+      content = `[${download.label} saved: ${savedPath}]${caption}`;
+    } else {
+      content = `${placeholder}${caption}`;
+    }
+  } else {
+    content = `${placeholder}${caption}`;
+  }
+
+  const isGroup = ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
+  this.opts.onChatMetadata(chatJid, timestamp, undefined, 'telegram', isGroup);
+  this.opts.onMessage(chatJid, {
+    id: messageId,
+    chat_jid: chatJid,
+    sender: ctx.from?.id?.toString() || '',
+    sender_name: senderName,
+    content,
+    timestamp,
+    is_from_me: false,
+  });
+};
+
+// IMPORTANT: All handlers use expression body (no braces) so the promise
+// returned by storeNonText is passed back to Grammy for proper error handling.
+this.bot.on('message:photo', (ctx) => {
+  const photos = ctx.message.photo!;
+  const largest = photos[photos.length - 1];
+  return storeNonText(ctx, '[Photo]', {
+    fileId: largest.file_id,
+    label: 'Photo',
+    prefix: 'photo',
+    extension: '.jpg',
+  });
+});
+
+this.bot.on('message:video', (ctx) =>
+  storeNonText(ctx, '[Video]', {
+    fileId: ctx.message.video!.file_id,
+    label: 'Video',
+    prefix: 'video',
+    extension: '.mp4',
+  })
+);
+
+this.bot.on('message:voice', (ctx) =>
+  storeNonText(ctx, '[Voice message]', {
+    fileId: ctx.message.voice!.file_id,
+    label: 'Voice message',
+    prefix: 'voice',
+    extension: '.ogg',
+  })
+);
+
+this.bot.on('message:audio', (ctx) =>
+  storeNonText(ctx, '[Audio]', {
+    fileId: ctx.message.audio!.file_id,
+    label: 'Audio',
+    prefix: 'audio',
+    extension: '.mp3',
+  })
+);
+
+this.bot.on('message:document', (ctx) => {
+  const doc = ctx.message.document!;
+  // Sanitize user-provided filename: strip path components and control characters
+  const name = path.basename(doc.file_name || 'file').replace(/[\x00-\x1f]/g, '');
+  const ext = path.extname(name) || '.bin';
+  return storeNonText(ctx, `[Document: ${name}]`, {
+    fileId: doc.file_id,
+    label: 'Document',
+    prefix: 'document',
+    extension: ext,
+  });
+});
+
+this.bot.on('message:sticker', (ctx) => {
+  const sticker = ctx.message.sticker!;
+  const emoji = sticker.emoji || '';
+  return storeNonText(ctx, `[Sticker ${emoji}]`, {
+    fileId: sticker.file_id,
+    label: 'Sticker',
+    prefix: 'sticker',
+    extension: '.webp',
+  });
+});
+
+// Location and contact have no downloadable file
+this.bot.on('message:location', (ctx) => storeNonText(ctx, '[Location]'));
+this.bot.on('message:contact', (ctx) => storeNonText(ctx, '[Contact]'));
+```
+
+### Key Design Decisions:
+- **`download` is optional** — location/contact pass no download params, keeping the old placeholder-only path
+- **Graceful fallback** — if download returns null (failure or size limit), the original placeholder is used, so the agent still knows *something* was sent
+- **Message ID for filenames** — `photo_42.jpg` is unique per chat and deterministic (no random suffix needed)
+- **Extension from `path.extname` for documents** — preserves the original file extension; falls back to `.bin`
+- **Separate `label` and `prefix`** — `label` is human-readable display text (e.g. "Voice message"), `prefix` is the filename component (e.g. "voice"). Prevents display bugs like "Voice_message saved:"
+- **Handlers return the promise** — Grammy awaits returned promises for error handling. Expression body `(ctx) => storeNonText(...)` or explicit `return` in block body ensures the promise is not silently discarded
+- **Filename sanitization** — `doc.file_name` is user-provided; `path.basename()` strips path traversal, `.replace()` strips control characters
+- **Async FS operations** — `fs.promises.mkdir` / `fs.promises.writeFile` avoid blocking the event loop during file writes
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] TypeScript compiles without errors
+- [x] Existing tests still pass (some media content assertions will change — update in Phase 3)
+
+**Implementation Note**: Existing tests may fail because content strings changed. That's expected — Phase 3 updates the tests.
+
+---
+
+## Phase 3: Update tests
+
+### Overview
+Update the Grammy mock to support `getFile` API calls and `fetch`. Add tests for successful downloads, download failures, and the 20MB size limit.
+
+### Changes Required:
+
+#### 1. Extend Grammy mock with `getFile`
+**File**: `src/channels/telegram.test.ts`
+**Changes**: Add `getFile` to the mock `api` object
+
+```typescript
+api = {
+  sendMessage: vi.fn().mockResolvedValue(undefined),
+  sendChatAction: vi.fn().mockResolvedValue(undefined),
+  getFile: vi.fn().mockResolvedValue({
+    file_id: 'test-file-id',
+    file_path: 'photos/file_0.jpg',
+    file_size: 1024,
+  }),
+};
+```
+
+#### 2. Add `fs` and `path` mocks
+**File**: `src/channels/telegram.test.ts`
+**Changes**: Mock `node:fs` and config's `GROUPS_DIR`
+
+```typescript
+vi.mock('node:fs/promises', () => ({
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Update config mock to include GROUPS_DIR
+vi.mock('../config.js', () => ({
+  ASSISTANT_NAME: 'Andy',
+  TRIGGER_PATTERN: /^@Andy\b/i,
+  GROUPS_DIR: '/tmp/test-groups',
+}));
+```
+
+#### 3. Mock global `fetch`
+**File**: `src/channels/telegram.test.ts`
+
+```typescript
+// In beforeEach:
+vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+  ok: true,
+  arrayBuffer: () => Promise.resolve(new ArrayBuffer(1024)),
+}));
+```
+
+#### 4. Update `createMediaCtx` to include media-type-specific fields
+**File**: `src/channels/telegram.test.ts`
+
+```typescript
+function createMediaCtx(overrides: {
+  chatId?: number;
+  chatType?: string;
+  fromId?: number;
+  firstName?: string;
+  date?: number;
+  messageId?: number;
+  caption?: string;
+  extra?: Record<string, any>;
+}) {
+  const chatId = overrides.chatId ?? 100200300;
+  return {
+    chat: {
+      id: chatId,
+      type: overrides.chatType ?? 'group',
+      title: 'Test Group',
+    },
+    from: {
+      id: overrides.fromId ?? 99001,
+      first_name: overrides.firstName ?? 'Alice',
+      username: 'alice_user',
+    },
+    message: {
+      date: overrides.date ?? Math.floor(Date.now() / 1000),
+      message_id: overrides.messageId ?? 1,
+      caption: overrides.caption,
+      // Default media fields so handlers don't crash
+      photo: [{ file_id: 'photo-file-id', width: 800, height: 600 }],
+      video: { file_id: 'video-file-id' },
+      voice: { file_id: 'voice-file-id' },
+      audio: { file_id: 'audio-file-id' },
+      document: { file_id: 'doc-file-id', file_name: 'report.pdf' },
+      sticker: { file_id: 'sticker-file-id', emoji: '😂' },
+      ...(overrides.extra || {}),
+    },
+    me: { username: 'andy_ai_bot' },
+  };
+}
+```
+
+#### 5. Update existing media content assertions
+**File**: `src/channels/telegram.test.ts`
+**Changes**: Existing tests that check `[Photo]` should now expect `[Photo saved: media/photo_1.jpg]` etc.
+
+```typescript
+it('stores photo with downloaded file path', async () => {
+  const opts = createTestOpts();
+  const channel = new TelegramChannel('test-token', opts);
+  await channel.connect();
+
+  const ctx = createMediaCtx({});
+  await triggerMediaMessage('message:photo', ctx);
+
+  expect(opts.onMessage).toHaveBeenCalledWith(
+    'tg:100200300',
+    expect.objectContaining({ content: '[Photo saved: media/photo_1.jpg]' }),
+  );
+});
+
+it('stores photo with caption after file path', async () => {
+  const opts = createTestOpts();
+  const channel = new TelegramChannel('test-token', opts);
+  await channel.connect();
+
+  const ctx = createMediaCtx({ caption: 'Look at this' });
+  await triggerMediaMessage('message:photo', ctx);
+
+  expect(opts.onMessage).toHaveBeenCalledWith(
+    'tg:100200300',
+    expect.objectContaining({
+      content: '[Photo saved: media/photo_1.jpg] Look at this',
+    }),
+  );
+});
+```
+
+#### 6. Add new test cases
+
+```typescript
+it('falls back to placeholder when download fails', async () => {
+  const opts = createTestOpts();
+  const channel = new TelegramChannel('test-token', opts);
+  await channel.connect();
+
+  currentBot().api.getFile.mockRejectedValueOnce(new Error('API error'));
+
+  const ctx = createMediaCtx({});
+  await triggerMediaMessage('message:photo', ctx);
+
+  expect(opts.onMessage).toHaveBeenCalledWith(
+    'tg:100200300',
+    expect.objectContaining({ content: '[Photo]' }),
+  );
+});
+
+it('falls back to placeholder when file exceeds 20MB', async () => {
+  const opts = createTestOpts();
+  const channel = new TelegramChannel('test-token', opts);
+  await channel.connect();
+
+  currentBot().api.getFile.mockResolvedValueOnce({
+    file_id: 'big-file',
+    file_path: 'videos/big.mp4',
+    file_size: 25 * 1024 * 1024, // 25MB
+  });
+
+  const ctx = createMediaCtx({});
+  await triggerMediaMessage('message:video', ctx);
+
+  expect(opts.onMessage).toHaveBeenCalledWith(
+    'tg:100200300',
+    expect.objectContaining({ content: '[Video]' }),
+  );
+});
+
+it('falls back to placeholder when fetch returns non-ok', async () => {
+  const opts = createTestOpts();
+  const channel = new TelegramChannel('test-token', opts);
+  await channel.connect();
+
+  vi.mocked(fetch).mockResolvedValueOnce({
+    ok: false,
+    status: 404,
+  } as Response);
+
+  const ctx = createMediaCtx({});
+  await triggerMediaMessage('message:photo', ctx);
+
+  expect(opts.onMessage).toHaveBeenCalledWith(
+    'tg:100200300',
+    expect.objectContaining({ content: '[Photo]' }),
+  );
+});
+
+it('creates media directory with recursive flag', async () => {
+  const opts = createTestOpts();
+  const channel = new TelegramChannel('test-token', opts);
+  await channel.connect();
+
+  const ctx = createMediaCtx({});
+  await triggerMediaMessage('message:photo', ctx);
+
+  expect(fs.mkdir).toHaveBeenCalledWith(
+    '/tmp/test-groups/test-group/media',
+    { recursive: true },
+  );
+});
+
+it('writes file buffer to correct path', async () => {
+  const opts = createTestOpts();
+  const channel = new TelegramChannel('test-token', opts);
+  await channel.connect();
+
+  const ctx = createMediaCtx({ messageId: 42 });
+  await triggerMediaMessage('message:photo', ctx);
+
+  expect(fs.writeFile).toHaveBeenCalledWith(
+    '/tmp/test-groups/test-group/media/photo_42.jpg',
+    expect.any(Buffer),
+  );
+});
+
+it('downloads document with original extension', async () => {
+  const opts = createTestOpts();
+  const channel = new TelegramChannel('test-token', opts);
+  await channel.connect();
+
+  const ctx = createMediaCtx({
+    messageId: 7,
+    extra: { document: { file_id: 'doc-id', file_name: 'report.pdf' } },
+  });
+  await triggerMediaMessage('message:document', ctx);
+
+  expect(opts.onMessage).toHaveBeenCalledWith(
+    'tg:100200300',
+    expect.objectContaining({
+      content: '[Document saved: media/document_7.pdf]',
+    }),
+  );
+});
+
+it('downloads sticker as webp', async () => {
+  const opts = createTestOpts();
+  const channel = new TelegramChannel('test-token', opts);
+  await channel.connect();
+
+  const ctx = createMediaCtx({
+    messageId: 5,
+    extra: { sticker: { file_id: 'sticker-id', emoji: '🔥' } },
+  });
+  await triggerMediaMessage('message:sticker', ctx);
+
+  expect(opts.onMessage).toHaveBeenCalledWith(
+    'tg:100200300',
+    expect.objectContaining({
+      content: '[Sticker saved: media/sticker_5.webp]',
+    }),
+  );
+});
+
+it('location stays as placeholder (no download)', async () => {
+  const opts = createTestOpts();
+  const channel = new TelegramChannel('test-token', opts);
+  await channel.connect();
+
+  const ctx = createMediaCtx({});
+  await triggerMediaMessage('message:location', ctx);
+
+  expect(opts.onMessage).toHaveBeenCalledWith(
+    'tg:100200300',
+    expect.objectContaining({ content: '[Location]' }),
+  );
+  expect(currentBot().api.getFile).not.toHaveBeenCalled();
+});
+
+it('contact stays as placeholder (no download)', async () => {
+  const opts = createTestOpts();
+  const channel = new TelegramChannel('test-token', opts);
+  await channel.connect();
+
+  const ctx = createMediaCtx({});
+  await triggerMediaMessage('message:contact', ctx);
+
+  expect(opts.onMessage).toHaveBeenCalledWith(
+    'tg:100200300',
+    expect.objectContaining({ content: '[Contact]' }),
+  );
+  expect(currentBot().api.getFile).not.toHaveBeenCalled();
+});
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] All tests pass (`npm test`)
+- [x] TypeScript compiles without errors (`npm run build`)
+- [x] No lint errors
+
+#### Manual Verification:
+- [ ] Send a photo to the Telegram bot → check `groups/<folder>/media/photo_<id>.jpg` exists
+- [ ] Send a document → check file saved with correct extension
+- [ ] Send a photo with caption → message content includes both path and caption
+- [ ] Verify the agent can reference the file from inside the container at `/workspace/group/media/`
+
+**Implementation Note**: After all automated verification passes, test manually with a real Telegram bot before considering the feature complete.
+
+---
+
+## Testing Strategy
+
+### Unit Tests:
+- Download success → content string includes saved path
+- Download failure (API error) → falls back to placeholder
+- File exceeds 20MB → falls back to placeholder
+- Fetch returns non-ok → falls back to placeholder
+- `getFile` returns no `file_path` → falls back to placeholder
+- Correct directory creation (`fs.mkdir` with `recursive: true`)
+- Correct file write path (`fs.writeFile` with expected path)
+- Each media type produces correct label and extension
+- Caption preserved alongside file path
+- Location/contact remain as placeholders (no download attempted)
+- Unregistered chats still ignored
+
+**Test harness note**: The existing `triggerMediaMessage()` helper already `await`s each handler (`for (const h of handlers) await h(ctx)`), so async handlers are correctly awaited in tests. No changes needed to the test infrastructure.
+
+### Manual Testing Steps:
+1. Send a photo → verify file saved and content shows path
+2. Send a video → verify `.mp4` saved
+3. Send a voice message → verify `.ogg` saved
+4. Send an audio file → verify `.mp3` saved
+5. Send a PDF document → verify `.pdf` saved with correct extension
+6. Send a sticker → verify `.webp` saved
+7. Send a photo with caption → verify caption appears after path
+8. Send a file > 20MB → verify placeholder is used, warning logged
+9. Verify agent can read the saved file from inside the container
+
+## References
+
+- Original ticket: `thoughts/shared/tickets/2026-03-09-telegram-media-downloads.md`
+- Grammy Bot API docs: `getFile` method
+- Existing pattern: `.claude/skills/add-image-vision/add/src/image.ts` (WhatsApp image save flow)


### PR DESCRIPTION
## Summary
- Download media files (photos, videos, voice, audio, documents, stickers) sent via Telegram and save to `groups/<folder>/media/`
- Messages now show `[Photo saved: media/photo_42.jpg]` instead of `[Photo]`
- Graceful fallback to placeholder on download failure or 20MB file size limit
- Location/contact remain placeholder-only (no binary content)
- Document filenames sanitized against path traversal

## Test Plan
- [ ] Send a photo → verify `groups/<folder>/media/photo_<id>.jpg` exists
- [ ] Send a document → verify file saved with correct extension
- [ ] Send a photo with caption → message content includes both path and caption
- [ ] Verify the agent can reference the file from inside the container at `/workspace/group/media/`

## Ticket
`thoughts/shared/tickets/2026-03-09-telegram-media-downloads.md`