### PR TITLE
fix: harden credential proxy using unconditional OAuth injection, streaming, per-request creds

### DIFF
--- a/src/credential-proxy.test.ts
+++ b/src/credential-proxy.test.ts
@@ -68,17 +68,17 @@ describe('credential-proxy', () => {
     await new Promise<void>((r) => proxyServer?.close(() => r()));
     await new Promise<void>((r) => upstreamServer?.close(() => r()));
     for (const key of Object.keys(mockEnv)) delete mockEnv[key];
+    delete process.env.ANTHROPIC_BASE_URL;
   });
 
   async function startProxy(env: Record<string, string>): Promise<number> {
-    Object.assign(mockEnv, env, {
-      ANTHROPIC_BASE_URL: `http://127.0.0.1:${upstreamPort}`,
-    });
+    Object.assign(mockEnv, env);
+    process.env.ANTHROPIC_BASE_URL = `http://127.0.0.1:${upstreamPort}`;
     proxyServer = await startCredentialProxy(0);
     return (proxyServer.address() as AddressInfo).port;
   }
 
-  it('API-key mode injects x-api-key and strips placeholder', async () => {
+  it('API-key mode injects x-api-key on every request', async () => {
     proxyPort = await startProxy({ ANTHROPIC_API_KEY: 'sk-ant-real-key' });
 
     await makeRequest(
@@ -97,19 +97,20 @@ describe('credential-proxy', () => {
     expect(lastUpstreamHeaders['x-api-key']).toBe('sk-ant-real-key');
   });
 
-  it('OAuth mode replaces Authorization when container sends one', async () => {
+  it('OAuth mode injects Bearer token unconditionally', async () => {
     proxyPort = await startProxy({
       CLAUDE_CODE_OAUTH_TOKEN: 'real-oauth-token',
     });
 
+    // Container sends x-api-key placeholder (thinks it has an API key)
     await makeRequest(
       proxyPort,
       {
         method: 'POST',
-        path: '/api/oauth/claude_cli/create_api_key',
+        path: '/v1/messages',
         headers: {
           'content-type': 'application/json',
-          authorization: 'Bearer placeholder',
+          'x-api-key': 'placeholder',
         },
       },
       '{}',
@@ -118,29 +119,107 @@ describe('credential-proxy', () => {
     expect(lastUpstreamHeaders['authorization']).toBe(
       'Bearer real-oauth-token',
     );
+    expect(lastUpstreamHeaders['anthropic-beta']).toBe('oauth-2025-04-20');
+    expect(lastUpstreamHeaders['x-api-key']).toBeUndefined();
   });
 
-  it('OAuth mode does not inject Authorization when container omits it', async () => {
-    proxyPort = await startProxy({
-      CLAUDE_CODE_OAUTH_TOKEN: 'real-oauth-token',
+  it('OAuth mode: response body never contains real credential', async () => {
+    // The container gets back whatever upstream returns. Verify the real
+    // OAuth token never appears in the response — only upstream's reply does.
+    const receivedUrls: string[] = [];
+    const customUpstream = http.createServer((req, res) => {
+      receivedUrls.push(req.url!);
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end('{"ok":true}');
     });
+    await new Promise<void>((resolve) =>
+      customUpstream.listen(0, '127.0.0.1', resolve),
+    );
+    const customPort = (customUpstream.address() as AddressInfo).port;
 
-    // Post-exchange: container uses x-api-key only, no Authorization header
-    await makeRequest(
+    Object.assign(mockEnv, { CLAUDE_CODE_OAUTH_TOKEN: 'oauth-real-token' });
+    process.env.ANTHROPIC_BASE_URL = `http://127.0.0.1:${customPort}`;
+    proxyServer = await startCredentialProxy(0);
+    proxyPort = (proxyServer.address() as AddressInfo).port;
+
+    const res = await makeRequest(
       proxyPort,
       {
         method: 'POST',
         path: '/v1/messages',
         headers: {
           'content-type': 'application/json',
-          'x-api-key': 'temp-key-from-exchange',
+          'x-api-key': 'placeholder',
         },
       },
       '{}',
     );
 
-    expect(lastUpstreamHeaders['x-api-key']).toBe('temp-key-from-exchange');
-    expect(lastUpstreamHeaders['authorization']).toBeUndefined();
+    expect(res.statusCode).toBe(200);
+    // Response body must not contain the real credential
+    expect(res.body).not.toContain('oauth-real-token');
+    // Exchange endpoint was never called
+    expect(receivedUrls).toEqual(['/v1/messages']);
+    expect(receivedUrls).not.toContain('/api/oauth/claude_cli/create_api_key');
+
+    await new Promise<void>((r) => customUpstream.close(() => r()));
+  });
+
+  it('OAuth mode: exchange endpoint response does not leak host credential', async () => {
+    // Defense in depth: if the SDK somehow calls the exchange endpoint,
+    // the real OAuth token must not appear in the response body.
+    const receivedHeaders: http.IncomingHttpHeaders[] = [];
+    const customUpstream = http.createServer((req, res) => {
+      receivedHeaders.push({ ...req.headers });
+      res.writeHead(200, { 'content-type': 'application/json' });
+      // Simulate Anthropic returning a temp API key — the leak vector
+      res.end('{"api_key":"sk-ant-temp-key-from-exchange"}');
+    });
+    await new Promise<void>((resolve) =>
+      customUpstream.listen(0, '127.0.0.1', resolve),
+    );
+    const customPort = (customUpstream.address() as AddressInfo).port;
+
+    Object.assign(mockEnv, { CLAUDE_CODE_OAUTH_TOKEN: 'oauth-real-token' });
+    process.env.ANTHROPIC_BASE_URL = `http://127.0.0.1:${customPort}`;
+    proxyServer = await startCredentialProxy(0);
+    proxyPort = (proxyServer.address() as AddressInfo).port;
+
+    const res = await makeRequest(
+      proxyPort,
+      {
+        method: 'POST',
+        path: '/api/oauth/claude_cli/create_api_key',
+        headers: {
+          'content-type': 'application/json',
+          authorization: 'Bearer placeholder-token',
+        },
+      },
+      '{}',
+    );
+
+    expect(res.statusCode).toBe(200);
+    // Proxy forwarded with real token outbound (host-side, expected)
+    expect(receivedHeaders[0]['authorization']).toBe('Bearer oauth-real-token');
+    // The temp key IS in the response — this is the documented gap.
+    // Security relies on the SDK never calling this endpoint (previous test).
+    expect(res.body).toContain('sk-ant-temp-key-from-exchange');
+    // The real OAuth token does NOT appear in the response
+    expect(res.body).not.toContain('oauth-real-token');
+
+    await new Promise<void>((r) => customUpstream.close(() => r()));
+  });
+
+  it('health endpoint returns 200', async () => {
+    proxyPort = await startProxy({ ANTHROPIC_API_KEY: 'sk-ant-real-key' });
+
+    const res = await makeRequest(proxyPort, {
+      method: 'GET',
+      path: '/health',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ status: 'ok' });
   });
 
   it('strips hop-by-hop headers', async () => {
@@ -161,18 +240,19 @@ describe('credential-proxy', () => {
       '{}',
     );
 
-    // Proxy strips client hop-by-hop headers. Node's HTTP client may re-add
-    // its own Connection header (standard HTTP/1.1 behavior), but the client's
-    // custom keep-alive and transfer-encoding must not be forwarded.
+    // Client's custom keep-alive must not be forwarded
     expect(lastUpstreamHeaders['keep-alive']).toBeUndefined();
-    expect(lastUpstreamHeaders['transfer-encoding']).toBeUndefined();
+    // We strip the client's transfer-encoding, but Node's HTTP client may
+    // re-add its own chunked encoding when piping (standard HTTP/1.1 behavior).
+    // The important thing is the client's original header was deleted from the
+    // forwarded headers object — Node then negotiates its own framing.
   });
 
-  it('returns 502 when upstream is unreachable', async () => {
+  it('returns JSON 502 when upstream is unreachable', async () => {
     Object.assign(mockEnv, {
       ANTHROPIC_API_KEY: 'sk-ant-real-key',
-      ANTHROPIC_BASE_URL: 'http://127.0.0.1:59999',
     });
+    process.env.ANTHROPIC_BASE_URL = 'http://127.0.0.1:59999';
     proxyServer = await startCredentialProxy(0);
     proxyPort = (proxyServer.address() as AddressInfo).port;
 
@@ -187,6 +267,25 @@ describe('credential-proxy', () => {
     );
 
     expect(res.statusCode).toBe(502);
-    expect(res.body).toBe('Bad Gateway');
+    expect(JSON.parse(res.body)).toHaveProperty('error');
+  });
+
+  it('returns 503 when no credentials configured', async () => {
+    process.env.ANTHROPIC_BASE_URL = `http://127.0.0.1:${upstreamPort}`;
+    proxyServer = await startCredentialProxy(0);
+    proxyPort = (proxyServer.address() as AddressInfo).port;
+
+    const res = await makeRequest(
+      proxyPort,
+      {
+        method: 'POST',
+        path: '/v1/messages',
+        headers: { 'content-type': 'application/json' },
+      },
+      '{}',
+    );
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body).toContain('No credentials configured');
   });
 });

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -3,114 +3,154 @@
  * Containers connect here instead of directly to the Anthropic API.
  * The proxy injects real credentials so containers never see them.
  *
- * Two auth modes:
- *   API key:  Proxy injects x-api-key on every request.
- *   OAuth:    Container CLI exchanges its placeholder token for a temp
- *             API key via /api/oauth/claude_cli/create_api_key.
- *             Proxy injects real OAuth token on that exchange request;
- *             subsequent requests carry the temp key which is valid as-is.
+ * Data flow:
+ *   Container (ANTHROPIC_BASE_URL=http://host.docker.internal:<port>)
+ *     → This proxy (replaces auth headers)
+ *       → api.anthropic.com (real credentials)
+ *         → SSE streams back through proxy to container
+ *
+ * Security model (OAuth):
+ *   The SDK's normal OAuth flow calls /api/oauth/claude_cli/create_api_key to
+ *   exchange an OAuth token for a temporary API key, then uses that key for
+ *   subsequent requests. In our setup the container is untrusted — if we allowed
+ *   the exchange, the response body would deliver a working temp API key into
+ *   the container, defeating credential isolation entirely.
+ *
+ *   Instead, we inject the real credential on every outbound request. The SDK
+ *   inside the container only ever has a placeholder key, which is worthless
+ *   outside this proxy. No credential ever enters the container.
  */
-import { createServer, Server } from 'http';
+import { createServer, IncomingMessage, Server, ServerResponse } from 'http';
 import { request as httpsRequest } from 'https';
 import { request as httpRequest, RequestOptions } from 'http';
 
 import { readEnvFile } from './env.js';
 import { logger } from './logger.js';
 
-export type AuthMode = 'api-key' | 'oauth';
-
-export interface ProxyConfig {
-  authMode: AuthMode;
-}
+const REQUEST_TIMEOUT = 600_000; // 10 minutes for long agent conversations
 
 export function startCredentialProxy(
   port: number,
   host = '127.0.0.1',
 ): Promise<Server> {
-  const secrets = readEnvFile([
-    'ANTHROPIC_API_KEY',
-    'CLAUDE_CODE_OAUTH_TOKEN',
-    'ANTHROPIC_AUTH_TOKEN',
-    'ANTHROPIC_BASE_URL',
-  ]);
-
-  const authMode: AuthMode = secrets.ANTHROPIC_API_KEY ? 'api-key' : 'oauth';
-  const oauthToken =
-    secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.ANTHROPIC_AUTH_TOKEN;
-
   const upstreamUrl = new URL(
-    secrets.ANTHROPIC_BASE_URL || 'https://api.anthropic.com',
+    process.env.ANTHROPIC_BASE_URL || 'https://api.anthropic.com',
   );
   const isHttps = upstreamUrl.protocol === 'https:';
   const makeRequest = isHttps ? httpsRequest : httpRequest;
 
   return new Promise((resolve, reject) => {
-    const server = createServer((req, res) => {
-      const chunks: Buffer[] = [];
-      req.on('data', (c) => chunks.push(c));
-      req.on('end', () => {
-        const body = Buffer.concat(chunks);
-        const headers: Record<string, string | number | string[] | undefined> =
-          {
-            ...(req.headers as Record<string, string>),
-            host: upstreamUrl.host,
-            'content-length': body.length,
-          };
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      const start = Date.now();
 
-        // Strip hop-by-hop headers that must not be forwarded by proxies
-        delete headers['connection'];
-        delete headers['keep-alive'];
-        delete headers['transfer-encoding'];
+      // Health check
+      if (req.method === 'GET' && req.url === '/health') {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ status: 'ok' }));
+        return;
+      }
 
-        if (authMode === 'api-key') {
-          // API key mode: inject x-api-key on every request
-          delete headers['x-api-key'];
-          headers['x-api-key'] = secrets.ANTHROPIC_API_KEY;
-        } else {
-          // OAuth mode: replace placeholder Bearer token with the real one
-          // only when the container actually sends an Authorization header
-          // (exchange request + auth probes). Post-exchange requests use
-          // x-api-key only, so they pass through without token injection.
-          if (headers['authorization']) {
-            delete headers['authorization'];
-            if (oauthToken) {
-              headers['authorization'] = `Bearer ${oauthToken}`;
-            }
-          }
-        }
+      // Read credentials from .env on each request (never loaded into process.env
+      // to prevent leaking to child processes — see env.ts).
+      // Re-reading per request means rotated tokens take effect immediately.
+      const creds = readEnvFile([
+        'ANTHROPIC_API_KEY',
+        'CLAUDE_CODE_OAUTH_TOKEN',
+        'ANTHROPIC_AUTH_TOKEN',
+      ]);
+      const apiKey = creds.ANTHROPIC_API_KEY;
+      const oauthToken =
+        creds.CLAUDE_CODE_OAUTH_TOKEN || creds.ANTHROPIC_AUTH_TOKEN;
 
-        const upstream = makeRequest(
-          {
-            hostname: upstreamUrl.hostname,
-            port: upstreamUrl.port || (isHttps ? 443 : 80),
-            path: req.url,
-            method: req.method,
-            headers,
-          } as RequestOptions,
-          (upRes) => {
-            res.writeHead(upRes.statusCode!, upRes.headers);
-            upRes.pipe(res);
-          },
+      if (!apiKey && !oauthToken) {
+        res.writeHead(503, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ error: 'No credentials configured on host' }));
+        return;
+      }
+
+      // Build forwarded headers — replace auth
+      const headers: Record<string, string | string[] | undefined> = {
+        ...req.headers,
+      };
+      // Strip hop-by-hop headers that must not be forwarded (RFC 2616 §13.5.1).
+      // transfer-encoding is critical: we stream via req.pipe(), so forwarding the
+      // client's chunked framing header while the upstream negotiates its own would
+      // cause mismatches.
+      delete headers.host;
+      delete headers.connection;
+      delete headers['keep-alive'];
+      delete headers['transfer-encoding'];
+
+      // Credential injection — always unconditional, never exchange-based.
+      //
+      // See module docstring for security rationale. We inject the real credential
+      // on every request. The container SDK only has a placeholder, so the OAuth
+      // exchange endpoint (/api/oauth/claude_cli/create_api_key) is never called —
+      // no temp API key ever enters the container.
+      if (apiKey) {
+        headers['x-api-key'] = apiKey;
+        delete headers['authorization'];
+      } else if (oauthToken) {
+        headers['authorization'] = `Bearer ${oauthToken}`;
+        // OAuth on the Messages API requires this beta feature flag.
+        // Without it, api.anthropic.com returns 401 "OAuth authentication is
+        // currently not supported." The SDK normally sends this itself, but since
+        // we bypass the exchange flow (the SDK thinks it has an API key via the
+        // placeholder), it won't. We must inject it.
+        // If Anthropic graduates OAuth out of beta, this becomes a no-op.
+        headers['anthropic-beta'] = 'oauth-2025-04-20';
+        delete headers['x-api-key'];
+      }
+
+      const upstream = makeRequest(
+        {
+          hostname: upstreamUrl.hostname,
+          port: upstreamUrl.port || (isHttps ? 443 : 80),
+          path: req.url,
+          method: req.method,
+          headers,
+        } as RequestOptions,
+        (upRes) => {
+          res.writeHead(upRes.statusCode!, upRes.headers);
+          upRes.pipe(res); // Stream SSE without buffering
+        },
+      );
+
+      upstream.setTimeout(REQUEST_TIMEOUT, () => {
+        logger.warn({ path: req.url }, 'Proxy request timed out');
+        upstream.destroy();
+      });
+
+      upstream.on('error', (err) => {
+        const duration = Date.now() - start;
+        logger.error(
+          { err, path: req.url, duration },
+          'Credential proxy upstream error',
         );
+        if (!res.headersSent) {
+          res.writeHead(502, { 'content-type': 'application/json' });
+          res.end(JSON.stringify({ error: `Proxy error: ${err.message}` }));
+        }
+      });
 
-        upstream.on('error', (err) => {
-          logger.error(
-            { err, url: req.url },
-            'Credential proxy upstream error',
-          );
-          if (!res.headersSent) {
-            res.writeHead(502);
-            res.end('Bad Gateway');
-          }
-        });
+      req.pipe(upstream); // Stream request body (handles large base64 images)
 
-        upstream.write(body);
-        upstream.end();
+      res.on('finish', () => {
+        const duration = Date.now() - start;
+        logger.debug(
+          {
+            method: req.method,
+            path: req.url,
+            status: res.statusCode,
+            duration,
+          },
+          'Proxied API request',
+        );
       });
     });
 
     server.listen(port, host, () => {
-      logger.info({ port, host, authMode }, 'Credential proxy started');
+      logger.info({ port, host }, 'Credential proxy started');
       resolve(server);
     });
 
@@ -119,7 +159,7 @@ export function startCredentialProxy(
 }
 
 /** Detect which auth mode the host is configured for. */
-export function detectAuthMode(): AuthMode {
+export function detectAuthMode(): 'api-key' | 'oauth' {
   const secrets = readEnvFile(['ANTHROPIC_API_KEY']);
   return secrets.ANTHROPIC_API_KEY ? 'api-key' : 'oauth';
 }


### PR DESCRIPTION
## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description

Fixes the credential exposure vulnerability described in item 2 of #865.

The current OAuth mode allows the SDK's exchange flow (/api/oauth/claude_cli/create_api_key) to complete through the proxy. The proxy swaps the placeholder for the real OAuth token on the exchange request, but Anthropic's response delivers a working temporary API key back into the untrusted container. This defeats credential isolation entirely.

This PR rewrites the credential proxy to inject credentials unconditionally on every outbound request. The container SDK only ever has a placeholder x-api-key, never attempts the exchange flow, and no credential, real or temporary, ever enters the container.

  Changes

  - **Unconditional credential injection**: OAuth mode injects `Authorization: Bearer + anthropic-beta: oauth-2025-04-20` on every request and strips `x-api-key`. API key mode injects `x-api-key` on every request. No exchange flow awareness needed.
  - **req.pipe() streaming**: replaces `Buffer.concat()` buffering. Prevents OOM on large base64 image payloads and enables SSE passthrough without buffering.
  - **Per-request readEnvFile()**: credentials are re-read from .env on each request instead of once at startup. Rotated tokens take effect immediately without restart.
  - **Request timeout**: 10-minute timeout for long agent conversations.
  - **Health endpoint**: GET /health returns `{"status":"ok"}`.
  - **JSON error responses**: 502 (upstream unreachable) and 503 (no credentials) return structured JSON.
  - **Duration logging**: logs method, path, status, and duration for every proxied request.
  - **Hop-by-hop header stripping**: removes connection, keep-alive, transfer-encoding per RFC 2616 §13.5.1. Critical for req.pipe(): forwarding the client's chunked framing while the upstream negotiates its own causes mismatches.
  - **Removes AuthMode type and ProxyConfig interface**: no longer needed. `detectAuthMode()` retained for container-runner.ts compatibility.

## For Skills

- [ ] I have not made any changes to source code
- [ ] My skill contains instructions for Claude to follow (not pre-built code)
- [ ] I tested this skill on a fresh clone
