### PR TITLE
feat: add signal channel skill

### DIFF
--- a/.claude/skills/add-signal/SIGNAL_BRIDGE_API.md
+++ b/.claude/skills/add-signal/SIGNAL_BRIDGE_API.md
@@ -1,0 +1,126 @@
+# Signal Bridge API
+
+This document defines the Android bridge contract expected by the NanoClaw `add-signal` skill.
+
+## Authentication
+
+Every request must include:
+
+```http
+Authorization: Bearer <SIGNAL_BRIDGE_TOKEN>
+```
+
+## Endpoints
+
+### `GET /health`
+
+Used at NanoClaw startup to verify the bridge is reachable.
+
+Example response:
+
+```json
+{
+  "ok": true,
+  "bridgeVersion": "1.0.0",
+  "deviceName": "Pixel 9"
+}
+```
+
+### `GET /threads`
+
+Returns known Signal conversations for registration and metadata sync.
+
+Example response:
+
+```json
+{
+  "threads": [
+    {
+      "id": "thread-123",
+      "name": "Family",
+      "isGroup": true,
+      "lastMessageAt": "2026-03-09T12:00:00.000Z"
+    },
+    {
+      "id": "thread-456",
+      "name": "Teemu",
+      "isGroup": false,
+      "lastMessageAt": "2026-03-09T12:05:00.000Z"
+    }
+  ]
+}
+```
+
+## `GET /events?cursor=...`
+
+Long-poll or short-poll endpoint for incremental inbound and outbound message events.
+
+Example response:
+
+```json
+{
+  "events": [
+    {
+      "id": "evt-001",
+      "type": "message",
+      "direction": "incoming",
+      "threadId": "thread-123",
+      "threadName": "Family",
+      "senderId": "+358401234567",
+      "senderName": "Alice",
+      "text": "@Andy what time is dinner?",
+      "timestamp": "2026-03-09T12:10:00.000Z",
+      "isGroup": true,
+      "attachments": []
+    }
+  ],
+  "nextCursor": "cursor-002"
+}
+```
+
+Supported attachment kinds:
+
+- `image`
+- `video`
+- `voice`
+- `audio`
+- `document`
+- `sticker`
+
+Unsupported kinds should still be returned, but the NanoClaw adapter may render them as `[Attachment]`.
+
+### `POST /messages`
+
+Used for outbound replies.
+
+Request body:
+
+```json
+{
+  "threadId": "thread-123",
+  "text": "Dinner is at 18:00."
+}
+```
+
+Success response:
+
+```json
+{
+  "ok": true,
+  "messageId": "out-123"
+}
+```
+
+## Event Semantics
+
+- `threadId` must be stable across restarts.
+- `direction` must be `incoming` or `outgoing`.
+- `outgoing` is how the bridge tells NanoClaw that a message came from itself; the adapter uses this to avoid feedback loops.
+- `timestamp` must be ISO 8601 UTC.
+- `threadName` should be included whenever available, but the adapter tolerates it being omitted.
+
+## Security Notes
+
+- Bind the bridge to localhost or a trusted LAN only.
+- Use a random bearer token.
+- Do not expose the bridge unauthenticated on the public internet.

--- a/.claude/skills/add-signal/SKILL.md
+++ b/.claude/skills/add-signal/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: add-signal
+description: Add Signal as a channel via an authenticated Android bridge. Keeps Signal-specific runtime logic outside the NanoClaw core.
+---
+
+# Add Signal Channel
+
+This skill adds Signal support to NanoClaw without baking Signal runtime code into the core repo. The NanoClaw side stays small: a `SignalChannel` adapter talks to a separate Android bridge over HTTP.
+
+## Phase 1: Pre-flight
+
+### Check if already applied
+
+Read `.nanoclaw/state.yaml`. If `signal` is already in `applied_skills`, skip to Phase 3.
+
+### Confirm bridge availability
+
+Ask the user:
+
+- Do you already have the Android Signal bridge running?
+- If yes, collect:
+  - Bridge base URL (example: `http://192.168.1.50:8420`)
+  - Bridge bearer token
+
+If not, stop and tell the user they need the companion Android bridge first. This skill only installs the NanoClaw-side adapter.
+
+## Phase 2: Apply Code Changes
+
+### Initialize skills system if needed
+
+```bash
+npx tsx scripts/apply-skill.ts --init
+```
+
+### Apply the skill
+
+```bash
+npx tsx scripts/apply-skill.ts .claude/skills/add-signal
+```
+
+This skill:
+
+- Adds `src/channels/signal.ts`
+- Adds `src/channels/signal.test.ts`
+- Appends `import './signal.js'` to `src/channels/index.ts`
+- Extends `setup/verify.ts` to detect Signal bridge credentials
+- Records the application in `.nanoclaw/state.yaml`
+
+### Validate code changes
+
+```bash
+npm test
+npm run build
+```
+
+Build and tests must be clean before proceeding.
+
+## Phase 3: Configure Bridge Access
+
+Add these values to `.env`:
+
+```bash
+SIGNAL_BRIDGE_URL=http://<bridge-host>:<port>
+SIGNAL_BRIDGE_TOKEN=<bridge-token>
+```
+
+Sync the environment into the runtime copy:
+
+```bash
+mkdir -p data/env
+cp .env data/env/env
+```
+
+## Phase 4: Registration
+
+### Discover available chats
+
+List the bridge threads:
+
+```bash
+curl -s \
+  -H "Authorization: Bearer ${SIGNAL_BRIDGE_TOKEN}" \
+  "${SIGNAL_BRIDGE_URL%/}/threads"
+```
+
+The bridge should return thread objects with stable IDs. Register NanoClaw chats using JIDs in the form `signal:<threadId>`.
+
+### Register the main chat
+
+```bash
+npx tsx setup/index.ts --step register -- \
+  --jid "signal:<thread-id>" \
+  --name "Signal Main" \
+  --folder "signal_main" \
+  --trigger "@Andy" \
+  --channel signal \
+  --is-main \
+  --no-trigger-required
+```
+
+### Register additional chats
+
+```bash
+npx tsx setup/index.ts --step register -- \
+  --jid "signal:<thread-id>" \
+  --name "<chat-name>" \
+  --folder "signal_<chat-name>" \
+  --trigger "@Andy" \
+  --channel signal
+```
+
+## Phase 5: Verify
+
+### Run the built-in verification step
+
+```bash
+npx tsx setup/index.ts --step verify
+```
+
+`CHANNEL_AUTH` should include `signal`.
+
+### Manual canary
+
+Tell the user:
+
+1. Send a plain text message from the registered Signal chat.
+2. For non-main chats, include the trigger word (example: `@Andy hello`).
+3. Confirm NanoClaw replies to the same Signal thread.
+
+## Bridge Contract
+
+The bridge API is documented in `SIGNAL_BRIDGE_API.md` in this skill directory. The NanoClaw adapter assumes:
+
+- `GET /health`
+- `GET /threads`
+- `GET /events?cursor=...`
+- `POST /messages`
+
+All requests must use `Authorization: Bearer <token>`.
+
+## Troubleshooting
+
+### Verify does not show `signal`
+
+Check:
+
+1. `SIGNAL_BRIDGE_URL` and `SIGNAL_BRIDGE_TOKEN` exist in `.env`
+2. `data/env/env` was refreshed after editing `.env`
+3. The bridge responds on `/health`
+
+### Messages do not arrive
+
+Check:
+
+1. The bridge can still read Signal notifications/messages on Android
+2. The bridge returns new entries from `/events`
+3. The chat is registered in SQLite using the exact `signal:<threadId>` JID
+
+### Replies fail
+
+Check:
+
+1. `POST /messages` works with the same bearer token
+2. The bridge is not filtering the NanoClaw sender as unauthorized
+3. The thread ID from `/threads` matches the thread ID in incoming `/events`

--- a/.claude/skills/add-signal/add/src/channels/signal.test.ts
+++ b/.claude/skills/add-signal/add/src/channels/signal.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+vi.mock('./registry.js', () => ({ registerChannel: vi.fn() }));
+
+vi.mock('../config.js', () => ({
+  ASSISTANT_NAME: 'Andy',
+}));
+
+vi.mock('../env.js', () => ({
+  readEnvFile: vi.fn().mockReturnValue({
+    SIGNAL_BRIDGE_URL: 'http://signal-bridge.local:8420',
+    SIGNAL_BRIDGE_TOKEN: 'secret-token',
+  }),
+}));
+
+vi.mock('../logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { SignalChannel } from './signal.js';
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'ERR',
+    json: async () => body,
+  } as Response;
+}
+
+function createTestOpts() {
+  return {
+    onMessage: vi.fn(),
+    onChatMetadata: vi.fn(),
+    registeredGroups: vi.fn(() => ({
+      'signal:thread-1': {
+        name: 'Signal Main',
+        folder: 'signal_main',
+        trigger: '@Andy',
+        added_at: '2026-03-09T12:00:00.000Z',
+      },
+    })),
+  };
+}
+
+describe('SignalChannel', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('connects, syncs metadata, and polls events', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ ok: true }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          threads: [
+            {
+              id: 'thread-1',
+              name: 'Signal Main',
+              isGroup: false,
+              lastMessageAt: '2026-03-09T12:01:00.000Z',
+            },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          events: [
+            {
+              id: 'evt-1',
+              type: 'message',
+              direction: 'incoming',
+              threadId: 'thread-1',
+              threadName: 'Signal Main',
+              senderId: '+358401234567',
+              senderName: 'Alice',
+              text: '@Andy hello',
+              timestamp: '2026-03-09T12:02:00.000Z',
+              isGroup: false,
+              attachments: [],
+            },
+          ],
+          nextCursor: 'cursor-1',
+        }),
+      );
+
+    const opts = createTestOpts();
+    const channel = new SignalChannel(
+      'http://signal-bridge.local:8420',
+      'secret-token',
+      opts,
+    );
+
+    await channel.connect();
+
+    expect(channel.isConnected()).toBe(true);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'http://signal-bridge.local:8420/health',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer secret-token',
+        }),
+      }),
+    );
+    expect(opts.onChatMetadata).toHaveBeenCalledWith(
+      'signal:thread-1',
+      '2026-03-09T12:01:00.000Z',
+      'Signal Main',
+      'signal',
+      false,
+    );
+    expect(opts.onMessage).toHaveBeenCalledWith(
+      'signal:thread-1',
+      expect.objectContaining({
+        id: 'evt-1',
+        sender_name: 'Alice',
+        content: '@Andy hello',
+        is_from_me: false,
+      }),
+    );
+
+    await channel.disconnect();
+  });
+
+  it('formats attachment placeholders for non-text messages', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ ok: true }))
+      .mockResolvedValueOnce(jsonResponse({ threads: [] }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          events: [
+            {
+              id: 'evt-2',
+              threadId: 'thread-1',
+              direction: 'incoming',
+              senderId: '+358401234567',
+              senderName: 'Alice',
+              timestamp: '2026-03-09T12:03:00.000Z',
+              attachments: [{ kind: 'image' }, { kind: 'document', name: 'a.pdf' }],
+            },
+          ],
+        }),
+      );
+
+    const opts = createTestOpts();
+    const channel = new SignalChannel(
+      'http://signal-bridge.local:8420',
+      'secret-token',
+      opts,
+    );
+
+    await channel.connect();
+
+    expect(opts.onMessage).toHaveBeenCalledWith(
+      'signal:thread-1',
+      expect.objectContaining({
+        content: '[Photo] [Document: a.pdf]',
+      }),
+    );
+
+    await channel.disconnect();
+  });
+
+  it('posts outbound messages to the bridge', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ ok: true }));
+
+    const channel = new SignalChannel(
+      'http://signal-bridge.local:8420',
+      'secret-token',
+      createTestOpts(),
+    );
+
+    await channel.sendMessage('signal:thread-9', 'hello');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://signal-bridge.local:8420/messages',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ threadId: 'thread-9', text: 'hello' }),
+      }),
+    );
+  });
+
+  it('owns the signal jid namespace', () => {
+    const channel = new SignalChannel(
+      'http://signal-bridge.local:8420',
+      'secret-token',
+      createTestOpts(),
+    );
+
+    expect(channel.ownsJid('signal:thread-9')).toBe(true);
+    expect(channel.ownsJid('tg:123')).toBe(false);
+  });
+});

--- a/.claude/skills/add-signal/add/src/channels/signal.ts
+++ b/.claude/skills/add-signal/add/src/channels/signal.ts
@@ -1,0 +1,272 @@
+import { ASSISTANT_NAME } from '../config.js';
+import { readEnvFile } from '../env.js';
+import { logger } from '../logger.js';
+import { registerChannel, ChannelOpts } from './registry.js';
+import {
+  Channel,
+  OnChatMetadata,
+  OnInboundMessage,
+  RegisteredGroup,
+} from '../types.js';
+
+const POLL_INTERVAL_MS = 3000;
+const RETRY_DELAY_MS = 5000;
+
+interface SignalBridgeThread {
+  id: string;
+  name?: string;
+  isGroup?: boolean;
+  lastMessageAt?: string;
+}
+
+interface SignalBridgeAttachment {
+  kind?: string;
+  name?: string;
+}
+
+interface SignalBridgeEvent {
+  id?: string;
+  type?: string;
+  direction?: 'incoming' | 'outgoing';
+  threadId: string;
+  threadName?: string;
+  senderId?: string;
+  senderName?: string;
+  text?: string;
+  timestamp?: string;
+  isGroup?: boolean;
+  attachments?: SignalBridgeAttachment[];
+}
+
+interface SignalBridgeThreadBatch {
+  threads?: SignalBridgeThread[];
+}
+
+interface SignalBridgeEventBatch {
+  events?: SignalBridgeEvent[];
+  nextCursor?: string;
+}
+
+interface SignalChannelOpts {
+  onMessage: OnInboundMessage;
+  onChatMetadata: OnChatMetadata;
+  registeredGroups: () => Record<string, RegisteredGroup>;
+}
+
+export class SignalChannel implements Channel {
+  name = 'signal';
+
+  private connected = false;
+  private pollTimer: ReturnType<typeof setTimeout> | null = null;
+  private cursor = '';
+  private polling = false;
+
+  constructor(
+    private readonly bridgeUrl: string,
+    private readonly bridgeToken: string,
+    private readonly opts: SignalChannelOpts,
+  ) {}
+
+  async connect(): Promise<void> {
+    await this.fetchJson('/health');
+    this.connected = true;
+    logger.info({ bridgeUrl: this.bridgeUrl }, 'Connected to Signal bridge');
+    await this.syncGroups(true);
+    await this.pollEvents();
+  }
+
+  async sendMessage(jid: string, text: string): Promise<void> {
+    const threadId = jid.replace(/^signal:/, '');
+    await this.fetchJson('/messages', {
+      method: 'POST',
+      body: JSON.stringify({ threadId, text }),
+    });
+    logger.info({ jid, length: text.length }, 'Signal message sent');
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  ownsJid(jid: string): boolean {
+    return jid.startsWith('signal:');
+  }
+
+  async disconnect(): Promise<void> {
+    this.connected = false;
+    if (this.pollTimer) {
+      clearTimeout(this.pollTimer);
+      this.pollTimer = null;
+    }
+    logger.info('Signal channel disconnected');
+  }
+
+  async setTyping(_jid: string, _isTyping: boolean): Promise<void> {
+    // Signal bridge v1 does not expose typing.
+  }
+
+  async syncGroups(_force = false): Promise<void> {
+    try {
+      const payload = await this.fetchJson<SignalBridgeThreadBatch>('/threads');
+      const now = new Date().toISOString();
+      for (const thread of payload.threads || []) {
+        this.opts.onChatMetadata(
+          `signal:${thread.id}`,
+          thread.lastMessageAt || now,
+          thread.name,
+          'signal',
+          thread.isGroup,
+        );
+      }
+    } catch (err) {
+      logger.warn({ err }, 'Failed to sync Signal thread metadata');
+    }
+  }
+
+  private schedulePoll(delayMs: number): void {
+    if (!this.connected) return;
+    if (this.pollTimer) clearTimeout(this.pollTimer);
+    this.pollTimer = setTimeout(() => {
+      void this.pollEvents();
+    }, delayMs);
+  }
+
+  private async pollEvents(): Promise<void> {
+    if (!this.connected || this.polling) return;
+    this.polling = true;
+
+    try {
+      const suffix = this.cursor
+        ? `?cursor=${encodeURIComponent(this.cursor)}`
+        : '';
+      const payload =
+        await this.fetchJson<SignalBridgeEventBatch>(`/events${suffix}`);
+
+      if (payload.nextCursor) this.cursor = payload.nextCursor;
+      for (const event of payload.events || []) {
+        this.handleEvent(event);
+      }
+
+      this.schedulePoll(POLL_INTERVAL_MS);
+    } catch (err) {
+      logger.warn({ err }, 'Signal event poll failed');
+      this.schedulePoll(RETRY_DELAY_MS);
+    } finally {
+      this.polling = false;
+    }
+  }
+
+  private handleEvent(event: SignalBridgeEvent): void {
+    if (event.type && event.type !== 'message') return;
+
+    const chatJid = `signal:${event.threadId}`;
+    const timestamp = event.timestamp || new Date().toISOString();
+    const isBotMessage =
+      event.direction === 'outgoing' || event.senderId === 'assistant';
+
+    this.opts.onChatMetadata(
+      chatJid,
+      timestamp,
+      event.threadName,
+      'signal',
+      event.isGroup,
+    );
+
+    if (!this.opts.registeredGroups()[chatJid]) return;
+
+    const content = formatSignalContent(event.text, event.attachments);
+    if (!content) return;
+
+    this.opts.onMessage(chatJid, {
+      id: event.id || `${event.threadId}:${timestamp}`,
+      chat_jid: chatJid,
+      sender: event.senderId || (isBotMessage ? 'assistant' : 'unknown'),
+      sender_name:
+        event.senderName ||
+        (isBotMessage ? ASSISTANT_NAME : event.senderId || 'Unknown'),
+      content,
+      timestamp,
+      is_from_me: isBotMessage,
+      is_bot_message: isBotMessage,
+    });
+  }
+
+  private async fetchJson<T>(
+    pathname: string,
+    init?: RequestInit,
+  ): Promise<T> {
+    const response = await fetch(this.resolveUrl(pathname), {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${this.bridgeToken}`,
+        'Content-Type': 'application/json',
+        ...(init?.headers || {}),
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Signal bridge request failed: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    if (response.status === 204) return {} as T;
+    return (await response.json()) as T;
+  }
+
+  private resolveUrl(pathname: string): string {
+    const base = this.bridgeUrl.endsWith('/')
+      ? this.bridgeUrl
+      : `${this.bridgeUrl}/`;
+    return new URL(pathname.replace(/^\//, ''), base).toString();
+  }
+}
+
+function formatSignalContent(
+  text?: string,
+  attachments?: SignalBridgeAttachment[],
+): string {
+  const placeholderText = (attachments || [])
+    .map(formatAttachment)
+    .filter(Boolean)
+    .join(' ');
+  return [placeholderText, text?.trim() || ''].filter(Boolean).join(' ').trim();
+}
+
+function formatAttachment(attachment: SignalBridgeAttachment): string {
+  switch (attachment.kind) {
+    case 'image':
+      return '[Photo]';
+    case 'video':
+      return '[Video]';
+    case 'voice':
+      return '[Voice message]';
+    case 'audio':
+      return '[Audio]';
+    case 'document':
+      return attachment.name
+        ? `[Document: ${attachment.name}]`
+        : '[Document]';
+    case 'sticker':
+      return '[Sticker]';
+    default:
+      return attachment.kind ? `[${attachment.kind}]` : '[Attachment]';
+  }
+}
+
+registerChannel('signal', (opts: ChannelOpts) => {
+  const envVars = readEnvFile(['SIGNAL_BRIDGE_URL', 'SIGNAL_BRIDGE_TOKEN']);
+  const bridgeUrl =
+    process.env.SIGNAL_BRIDGE_URL || envVars.SIGNAL_BRIDGE_URL || '';
+  const bridgeToken =
+    process.env.SIGNAL_BRIDGE_TOKEN || envVars.SIGNAL_BRIDGE_TOKEN || '';
+
+  if (!bridgeUrl || !bridgeToken) {
+    logger.warn(
+      'Signal: SIGNAL_BRIDGE_URL or SIGNAL_BRIDGE_TOKEN is not configured',
+    );
+    return null;
+  }
+
+  return new SignalChannel(bridgeUrl, bridgeToken, opts);
+});

--- a/.claude/skills/add-signal/manifest.yaml
+++ b/.claude/skills/add-signal/manifest.yaml
@@ -1,0 +1,17 @@
+skill: signal
+version: 1.0.0
+description: "Signal channel via an authenticated Android bridge"
+core_version: 0.1.0
+adds:
+  - src/channels/signal.ts
+  - src/channels/signal.test.ts
+modifies:
+  - src/channels/index.ts
+  - setup/verify.ts
+structured:
+  env_additions:
+    - SIGNAL_BRIDGE_URL
+    - SIGNAL_BRIDGE_TOKEN
+conflicts: []
+depends: []
+test: "npx vitest run src/channels/signal.test.ts"

--- a/.claude/skills/add-signal/modify/setup/verify.ts
+++ b/.claude/skills/add-signal/modify/setup/verify.ts
@@ -1,0 +1,200 @@
+/**
+ * Step: verify — End-to-end health check of the full installation.
+ * Replaces 09-verify.sh
+ *
+ * Uses better-sqlite3 directly (no sqlite3 CLI), platform-aware service checks.
+ */
+import { execSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import Database from 'better-sqlite3';
+
+import { STORE_DIR } from '../src/config.js';
+import { readEnvFile } from '../src/env.js';
+import { logger } from '../src/logger.js';
+import {
+  getPlatform,
+  getServiceManager,
+  hasSystemd,
+  isRoot,
+} from './platform.js';
+import { emitStatus } from './status.js';
+
+export async function run(_args: string[]): Promise<void> {
+  const projectRoot = process.cwd();
+  const platform = getPlatform();
+  const homeDir = os.homedir();
+
+  logger.info('Starting verification');
+
+  // 1. Check service status
+  let service = 'not_found';
+  const mgr = getServiceManager();
+
+  if (mgr === 'launchd') {
+    try {
+      const output = execSync('launchctl list', { encoding: 'utf-8' });
+      if (output.includes('com.nanoclaw')) {
+        // Check if it has a PID (actually running)
+        const line = output.split('\n').find((l) => l.includes('com.nanoclaw'));
+        if (line) {
+          const pidField = line.trim().split(/\s+/)[0];
+          service = pidField !== '-' && pidField ? 'running' : 'stopped';
+        }
+      }
+    } catch {
+      // launchctl not available
+    }
+  } else if (mgr === 'systemd') {
+    const prefix = isRoot() ? 'systemctl' : 'systemctl --user';
+    try {
+      execSync(`${prefix} is-active nanoclaw`, { stdio: 'ignore' });
+      service = 'running';
+    } catch {
+      try {
+        const output = execSync(`${prefix} list-unit-files`, {
+          encoding: 'utf-8',
+        });
+        if (output.includes('nanoclaw')) {
+          service = 'stopped';
+        }
+      } catch {
+        // systemctl not available
+      }
+    }
+  } else {
+    // Check for nohup PID file
+    const pidFile = path.join(projectRoot, 'nanoclaw.pid');
+    if (fs.existsSync(pidFile)) {
+      try {
+        const raw = fs.readFileSync(pidFile, 'utf-8').trim();
+        const pid = Number(raw);
+        if (raw && Number.isInteger(pid) && pid > 0) {
+          process.kill(pid, 0);
+          service = 'running';
+        }
+      } catch {
+        service = 'stopped';
+      }
+    }
+  }
+  logger.info({ service }, 'Service status');
+
+  // 2. Check container runtime
+  let containerRuntime = 'none';
+  try {
+    execSync('command -v container', { stdio: 'ignore' });
+    containerRuntime = 'apple-container';
+  } catch {
+    try {
+      execSync('docker info', { stdio: 'ignore' });
+      containerRuntime = 'docker';
+    } catch {
+      // No runtime
+    }
+  }
+
+  // 3. Check credentials
+  let credentials = 'missing';
+  const envFile = path.join(projectRoot, '.env');
+  if (fs.existsSync(envFile)) {
+    const envContent = fs.readFileSync(envFile, 'utf-8');
+    if (/^(CLAUDE_CODE_OAUTH_TOKEN|ANTHROPIC_API_KEY)=/m.test(envContent)) {
+      credentials = 'configured';
+    }
+  }
+
+  // 4. Check channel auth (detect configured channels by credentials)
+  const envVars = readEnvFile([
+    'TELEGRAM_BOT_TOKEN',
+    'SLACK_BOT_TOKEN',
+    'SLACK_APP_TOKEN',
+    'DISCORD_BOT_TOKEN',
+    'SIGNAL_BRIDGE_URL',
+    'SIGNAL_BRIDGE_TOKEN',
+  ]);
+
+  const channelAuth: Record<string, string> = {};
+
+  // WhatsApp: check for auth credentials on disk
+  const authDir = path.join(projectRoot, 'store', 'auth');
+  if (fs.existsSync(authDir) && fs.readdirSync(authDir).length > 0) {
+    channelAuth.whatsapp = 'authenticated';
+  }
+
+  // Token-based channels: check .env
+  if (process.env.TELEGRAM_BOT_TOKEN || envVars.TELEGRAM_BOT_TOKEN) {
+    channelAuth.telegram = 'configured';
+  }
+  if (
+    (process.env.SLACK_BOT_TOKEN || envVars.SLACK_BOT_TOKEN) &&
+    (process.env.SLACK_APP_TOKEN || envVars.SLACK_APP_TOKEN)
+  ) {
+    channelAuth.slack = 'configured';
+  }
+  if (process.env.DISCORD_BOT_TOKEN || envVars.DISCORD_BOT_TOKEN) {
+    channelAuth.discord = 'configured';
+  }
+  if (
+    (process.env.SIGNAL_BRIDGE_URL || envVars.SIGNAL_BRIDGE_URL) &&
+    (process.env.SIGNAL_BRIDGE_TOKEN || envVars.SIGNAL_BRIDGE_TOKEN)
+  ) {
+    channelAuth.signal = 'configured';
+  }
+
+  const configuredChannels = Object.keys(channelAuth);
+  const anyChannelConfigured = configuredChannels.length > 0;
+
+  // 5. Check registered groups (using better-sqlite3, not sqlite3 CLI)
+  let registeredGroups = 0;
+  const dbPath = path.join(STORE_DIR, 'messages.db');
+  if (fs.existsSync(dbPath)) {
+    try {
+      const db = new Database(dbPath, { readonly: true });
+      const row = db
+        .prepare('SELECT COUNT(*) as count FROM registered_groups')
+        .get() as { count: number };
+      registeredGroups = row.count;
+      db.close();
+    } catch {
+      // Table might not exist
+    }
+  }
+
+  // 6. Check mount allowlist
+  let mountAllowlist = 'missing';
+  if (
+    fs.existsSync(
+      path.join(homeDir, '.config', 'nanoclaw', 'mount-allowlist.json'),
+    )
+  ) {
+    mountAllowlist = 'configured';
+  }
+
+  // Determine overall status
+  const status =
+    service === 'running' &&
+    credentials !== 'missing' &&
+    anyChannelConfigured &&
+    registeredGroups > 0
+      ? 'success'
+      : 'failed';
+
+  logger.info({ status, channelAuth }, 'Verification complete');
+
+  emitStatus('VERIFY', {
+    SERVICE: service,
+    CONTAINER_RUNTIME: containerRuntime,
+    CREDENTIALS: credentials,
+    CONFIGURED_CHANNELS: configuredChannels.join(','),
+    CHANNEL_AUTH: JSON.stringify(channelAuth),
+    REGISTERED_GROUPS: registeredGroups,
+    MOUNT_ALLOWLIST: mountAllowlist,
+    STATUS: status,
+    LOG: 'logs/setup.log',
+  });
+
+  if (status === 'failed') process.exit(1);
+}

--- a/.claude/skills/add-signal/modify/setup/verify.ts.intent.md
+++ b/.claude/skills/add-signal/modify/setup/verify.ts.intent.md
@@ -1,0 +1,10 @@
+# Intent: Add Signal verification support
+
+Extend the verify step so NanoClaw recognizes Signal as a configured channel
+when both `SIGNAL_BRIDGE_URL` and `SIGNAL_BRIDGE_TOKEN` are present.
+
+## Invariants
+
+- Existing verification behavior for WhatsApp, Telegram, Slack, and Discord must remain unchanged.
+- Signal should only count as configured when both bridge URL and bearer token are set.
+- The output shape of `emitStatus('VERIFY', ...)` must remain stable.

--- a/.claude/skills/add-signal/modify/src/channels/index.ts
+++ b/.claude/skills/add-signal/modify/src/channels/index.ts
@@ -1,0 +1,15 @@
+// Channel self-registration barrel file.
+// Each import triggers the channel module's registerChannel() call.
+
+// discord
+
+// gmail
+
+// slack
+
+// signal
+import './signal.js';
+
+// telegram
+
+// whatsapp

--- a/.claude/skills/add-signal/modify/src/channels/index.ts.intent.md
+++ b/.claude/skills/add-signal/modify/src/channels/index.ts.intent.md
@@ -1,0 +1,7 @@
+# Intent: Add Signal channel import
+
+Add `import './signal.js';` to the channel barrel file so the Signal module
+self-registers with the channel registry on startup.
+
+This is an append-only change. Existing imports or comment placeholders for
+other channels must be preserved.

--- a/.claude/skills/add-signal/tests/signal.test.ts
+++ b/.claude/skills/add-signal/tests/signal.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+describe('signal skill package', () => {
+  const skillDir = path.resolve(__dirname, '..');
+
+  it('has a valid manifest', () => {
+    const manifestPath = path.join(skillDir, 'manifest.yaml');
+    expect(fs.existsSync(manifestPath)).toBe(true);
+
+    const content = fs.readFileSync(manifestPath, 'utf-8');
+    expect(content).toContain('skill: signal');
+    expect(content).toContain('version: 1.0.0');
+    expect(content).toContain('SIGNAL_BRIDGE_URL');
+    expect(content).toContain('SIGNAL_BRIDGE_TOKEN');
+  });
+
+  it('has all files declared in adds', () => {
+    const channelFile = path.join(
+      skillDir,
+      'add',
+      'src',
+      'channels',
+      'signal.ts',
+    );
+    expect(fs.existsSync(channelFile)).toBe(true);
+
+    const content = fs.readFileSync(channelFile, 'utf-8');
+    expect(content).toContain('class SignalChannel');
+    expect(content).toContain('implements Channel');
+    expect(content).toContain("registerChannel('signal'");
+
+    const testFile = path.join(
+      skillDir,
+      'add',
+      'src',
+      'channels',
+      'signal.test.ts',
+    );
+    expect(fs.existsSync(testFile)).toBe(true);
+  });
+
+  it('has all files declared in modifies', () => {
+    const indexFile = path.join(
+      skillDir,
+      'modify',
+      'src',
+      'channels',
+      'index.ts',
+    );
+    expect(fs.existsSync(indexFile)).toBe(true);
+    expect(fs.readFileSync(indexFile, 'utf-8')).toContain(
+      "import './signal.js'",
+    );
+
+    const verifyFile = path.join(skillDir, 'modify', 'setup', 'verify.ts');
+    expect(fs.existsSync(verifyFile)).toBe(true);
+    expect(fs.readFileSync(verifyFile, 'utf-8')).toContain(
+      'SIGNAL_BRIDGE_URL',
+    );
+    expect(fs.readFileSync(verifyFile, 'utf-8')).toContain(
+      'channelAuth.signal',
+    );
+  });
+
+  it('includes intent and bridge protocol docs', () => {
+    expect(
+      fs.existsSync(
+        path.join(skillDir, 'modify', 'src', 'channels', 'index.ts.intent.md'),
+      ),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(skillDir, 'modify', 'setup', 'verify.ts.intent.md'),
+      ),
+    ).toBe(true);
+    expect(fs.existsSync(path.join(skillDir, 'SIGNAL_BRIDGE_API.md'))).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
# PR Description

## Summary

This PR adds a new `add-signal` skill package for NanoClaw.

The skill introduces a NanoClaw-side `SignalChannel` adapter that talks to an authenticated Android bridge instead of adding Signal runtime logic directly into the core repository. It also includes setup guidance, a documented bridge API contract, and verification support for Signal bridge credentials.

## What Changed

- Added `.claude/skills/add-signal/manifest.yaml`
- Added `.claude/skills/add-signal/SKILL.md`
- Added `.claude/skills/add-signal/SIGNAL_BRIDGE_API.md`
- Added `add/src/channels/signal.ts`
- Added `add/src/channels/signal.test.ts`
- Added modified skill files for:
  - `src/channels/index.ts`
  - `setup/verify.ts`
- Added a skill package test under `.claude/skills/add-signal/tests/signal.test.ts`

## Design

- Signal support is shipped as a skill, not as a built-in core feature.
- The channel adapter expects an external Android bridge with bearer-token authentication.
- The adapter:
  - validates bridge availability via `GET /health`
  - syncs thread metadata via `GET /threads`
  - polls message events via `GET /events`
  - sends replies via `POST /messages`
- Signal chats are registered as NanoClaw JIDs in the format `signal:<threadId>`.

## Why This Approach

This keeps NanoClaw aligned with the repo's skill-first philosophy:

- no new built-in channel in core
- no Android-specific runtime code in the base app
- clean separation between the NanoClaw adapter and the Signal bridge implementation

## Verification

The following checks were run:

- `npx vitest run --config vitest.skills.config.ts .claude/skills/add-signal/tests/signal.test.ts`
- `npm run build`

## Notes

- This PR does **not** include the Android bridge implementation itself.
- The expected bridge contract is documented in `SIGNAL_BRIDGE_API.md`.
- Signal is treated as configured only when both `SIGNAL_BRIDGE_URL` and `SIGNAL_BRIDGE_TOKEN` are present.
