### PR TITLE
fix(skill/apple-container): credential proxy support + dynamic gateway

### DIFF
--- a/.claude/skills/convert-to-apple-container/modify/src/container-runtime.ts
+++ b/.claude/skills/convert-to-apple-container/modify/src/container-runtime.ts
@@ -11,9 +11,44 @@ export const CONTAINER_RUNTIME_BIN = 'container';
 
 /**
  * Hostname containers use to reach the host machine.
- * Apple Container VMs access the host via the default gateway (192.168.64.1).
+ * Apple Container's default network subnet varies across machines (e.g. 192.168.64.0/24,
+ * 192.168.65.0/24). Detect the gateway (.1) from `container network ls` at startup.
  */
-export const CONTAINER_HOST_GATEWAY = '192.168.64.1';
+export const CONTAINER_HOST_GATEWAY = detectHostGateway();
+
+function detectHostGateway(): string {
+  try {
+    const output = execSync('container network ls --format json', {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      encoding: 'utf-8',
+      timeout: 5000,
+    });
+    const networks: {
+      id: string;
+      state: string;
+      status?: { ipv4Gateway?: string; ipv4Subnet?: string };
+    }[] = JSON.parse(output || '[]');
+    const defaultNet = networks.find((n) => n.id === 'default');
+    if (defaultNet?.status?.ipv4Gateway) {
+      logger.debug(
+        { gateway: defaultNet.status.ipv4Gateway, subnet: defaultNet.status.ipv4Subnet },
+        'Detected Apple Container gateway',
+      );
+      return defaultNet.status.ipv4Gateway;
+    }
+  } catch (err) {
+    logger.warn({ err }, 'Failed to detect Apple Container gateway, using fallback');
+  }
+  return '192.168.64.1';
+}
+
+/**
+ * Address the credential proxy binds to.
+ * Apple Container VMs reach the host via the bridge gateway (detected above),
+ * so the proxy must listen on all interfaces to be reachable from the VM.
+ */
+export const PROXY_BIND_HOST =
+  process.env.CREDENTIAL_PROXY_HOST || '0.0.0.0';
 
 /**
  * CLI args needed for the container to resolve the host gateway.

--- a/.claude/skills/convert-to-apple-container/modify/src/container-runtime.ts.intent.md
+++ b/.claude/skills/convert-to-apple-container/modify/src/container-runtime.ts.intent.md
@@ -21,15 +21,23 @@ Replaced Docker runtime with Apple Container runtime. This is a full file replac
 - Apple Container returns JSON with `{ status, configuration: { id } }` structure
 
 ### CONTAINER_HOST_GATEWAY
-- Set to `'192.168.64.1'` — the default gateway for Apple Container VMs to reach the host
+- Dynamically detected at startup via `container network ls --format json`
+- Reads `status.ipv4Gateway` from the `default` network (e.g. `192.168.65.1`)
+- The subnet varies across machines — cannot be hardcoded
+- Falls back to `192.168.64.1` if detection fails
 - Docker uses `'host.docker.internal'` which is resolved differently
+
+### PROXY_BIND_HOST
+- Set to `'0.0.0.0'` — Apple Container VMs reach the host via the bridge gateway, so the proxy must listen on all interfaces
+- Docker (macOS) uses `'127.0.0.1'` because Docker Desktop routes `host.docker.internal` to loopback
+- Overridable via `CREDENTIAL_PROXY_HOST` env var
 
 ### hostGatewayArgs
 - Returns `[]` — Apple Container provides host networking natively on macOS
 - Docker version returns `['--add-host=host.docker.internal:host-gateway']` on Linux
 
 ## Invariants
-- All exports remain identical: `CONTAINER_RUNTIME_BIN`, `CONTAINER_HOST_GATEWAY`, `readonlyMountArgs`, `stopContainer`, `hostGatewayArgs`, `ensureContainerRuntimeRunning`, `cleanupOrphans`
+- All exports remain identical: `CONTAINER_RUNTIME_BIN`, `CONTAINER_HOST_GATEWAY`, `PROXY_BIND_HOST`, `readonlyMountArgs`, `stopContainer`, `hostGatewayArgs`, `ensureContainerRuntimeRunning`, `cleanupOrphans`
 - `stopContainer` implementation is unchanged (`<bin> stop <name>`)
 - Logger usage pattern is unchanged
 - Error handling pattern is unchanged


### PR DESCRIPTION
## Summary

- **Dynamic gateway detection**: `CONTAINER_HOST_GATEWAY` was hardcoded to `192.168.64.1` but Apple Container's default network subnet varies across machines. Now detected at startup via `container network ls --format json` reading `status.ipv4Gateway` from the `default` network.
- **Add `PROXY_BIND_HOST`**: The credential proxy feature (#798) added this to the Docker `container-runtime.ts` but the Apple Container skill variant was not updated. Apple Container VMs reach the host via a bridge interface, so the proxy must bind to `0.0.0.0` (Docker binds to `127.0.0.1` since it routes via loopback).

Without this fix, containers on Apple Container cannot reach the credential proxy, causing all agent API calls to time out silently.

## Test plan

- [x] Verified on machine where Apple Container uses `192.168.65.0/24` (not the assumed `192.168.64.0/24`)
- [x] Confirmed container can reach proxy at detected gateway
- [x] `npm run build` and `npm test` pass (404/404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)