### PR TITLE
fix(container): sanitize lone surrogates in JSONL session transcripts

### DIFF
--- a/scripts/validate-surrogate-fix.mjs
+++ b/scripts/validate-surrogate-fix.mjs
@@ -1,0 +1,191 @@
+/**
+ * validate-surrogate-fix.mjs
+ *
+ * End-to-end validation that lone surrogates in JSONL session transcripts are
+ * sanitised before the container is spawned, preventing HTTP 400 from the API.
+ *
+ * Usage (run from the NanoClaw project root):
+ *   node scripts/validate-surrogate-fix.mjs <group-folder>
+ *
+ * The script:
+ *   1. Finds the most-recently-modified .jsonl session file for the group.
+ *   2. Injects a lone surrogate into one of the string values in the last line
+ *      (simulating what happens after a Bash tool returns binary/mojibake output).
+ *   3. Verifies that NanoClaw's sanitizeSessionTranscripts logic cleans it back up.
+ *   4. Restores the original file so no permanent damage is done.
+ *
+ * To test the full round-trip (HTTP 400 without fix, success with fix):
+ *   - Run this script to inject the surrogate, then send a message to the group
+ *     WITHOUT applying the fix first; watch the container log for HTTP 400.
+ *   - Apply the fix, restart NanoClaw, inject again, send the same message;
+ *     the agent should respond normally.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+
+// ── config ────────────────────────────────────────────────────────────────────
+
+const DATA_DIR = path.resolve(process.cwd(), 'data');
+
+const group = process.argv[2];
+if (!group) {
+  const available = fs.readdirSync(path.join(DATA_DIR, 'sessions'))
+    .filter(d => fs.existsSync(path.join(DATA_DIR, 'sessions', d, '.claude')));
+  console.error('Usage: node scripts/validate-surrogate-fix.mjs <group-folder>');
+  console.error('\nAvailable groups:');
+  available.forEach(g => console.error('  ', g));
+  process.exit(1);
+}
+
+const sessionDir = path.join(DATA_DIR, 'sessions', group, '.claude');
+if (!fs.existsSync(sessionDir)) {
+  console.error(`No session directory found: ${sessionDir}`);
+  console.error('Send at least one message to the group first.');
+  process.exit(1);
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function sanitizeSurrogates(s) {
+  return s.replace(
+    /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g,
+    '\uFFFD',
+  );
+}
+
+function sanitizeTranscript(content) {
+  return content
+    .split('\n')
+    .map(line => {
+      if (!line.trim()) return line;
+      try {
+        return JSON.stringify(JSON.parse(line), (_, v) =>
+          typeof v === 'string' ? sanitizeSurrogates(v) : v
+        );
+      } catch {
+        return line;
+      }
+    })
+    .join('\n');
+}
+
+function hasLoneSurrogate(s) {
+  // Match the JSON-escaped form \udXXX (lone surrogates produce \ud800–\udfff)
+  return /\\ud[89ab][0-9a-f]{2}(?!\\ud[c-f][0-9a-f]{2})/i.test(s)
+      || /(?<!\\ud[89ab][0-9a-f]{2})\\ud[c-f][0-9a-f]{2}/i.test(s);
+}
+
+// ── find most-recently-modified .jsonl ───────────────────────────────────────
+
+function walkJsonl(dir) {
+  const results = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) results.push(...walkJsonl(full));
+    else if (entry.name.endsWith('.jsonl')) results.push(full);
+  }
+  return results;
+}
+
+const jsonlFiles = walkJsonl(sessionDir)
+  .map(f => ({ f, mtime: fs.statSync(f).mtimeMs }))
+  .sort((a, b) => b.mtime - a.mtime);
+
+if (jsonlFiles.length === 0) {
+  console.error('No .jsonl session files found for this group.');
+  console.error('Send at least one message to the group first.');
+  process.exit(1);
+}
+
+const targetFile = jsonlFiles[0].f;
+console.log(`\nTarget file: ${path.relative(process.cwd(), targetFile)}`);
+
+// ── inject a lone surrogate ───────────────────────────────────────────────────
+
+const original = fs.readFileSync(targetFile, 'utf-8');
+const lines = original.split('\n');
+
+// Find the last non-empty line and inject a surrogate into a string value
+let injectedLineIdx = -1;
+let injectedLine = '';
+for (let i = lines.length - 1; i >= 0; i--) {
+  if (!lines[i].trim()) continue;
+  try {
+    const obj = JSON.parse(lines[i]);
+    // Inject into the first string value we can find anywhere in the object
+    const patched = JSON.stringify(obj, (_, v) =>
+      typeof v === 'string' && injectedLineIdx === -1
+        ? (injectedLineIdx = i, v + '\uD800injected-surrogate')
+        : v
+    );
+    if (injectedLineIdx === i) {
+      injectedLine = patched;
+      break;
+    }
+  } catch {
+    continue;
+  }
+}
+
+if (injectedLineIdx === -1) {
+  console.error('Could not find a string field in the session to inject into.');
+  process.exit(1);
+}
+
+// Write the corrupted file
+const corruptedLines = [...lines];
+corruptedLines[injectedLineIdx] = injectedLine;
+const corrupted = corruptedLines.join('\n');
+fs.writeFileSync(targetFile, corrupted, 'utf-8');
+
+const corruptConfirmed = hasLoneSurrogate(injectedLine);
+console.log('\n── Step 1: Injected lone surrogate ─────────────────────────────────────');
+console.log(`  Line ${injectedLineIdx + 1} now contains lone surrogate: ${corruptConfirmed ? '✗ YES (bug reproduced)' : '? could not confirm'}`);
+if (process.env.VERBOSE) {
+  console.log('\n  Corrupted line (truncated to 200 chars):');
+  console.log(' ', injectedLine.slice(0, 200) + (injectedLine.length > 200 ? '…' : ''));
+}
+
+// ── run the sanitizer ─────────────────────────────────────────────────────────
+
+console.log('\n── Step 2: Run sanitizer ────────────────────────────────────────────────');
+const sanitized = sanitizeTranscript(corrupted);
+const stillCorrupt = hasLoneSurrogate(sanitized.split('\n')[injectedLineIdx] ?? '');
+console.log(`  After sanitizeSessionTranscripts: ${stillCorrupt ? '✗ STILL CORRUPT (fix not working)' : '✓ Surrogate replaced with \\uFFFD (fix works)'}`);
+
+// ── restore original ──────────────────────────────────────────────────────────
+
+fs.writeFileSync(targetFile, original, 'utf-8');
+console.log('\n── Step 3: Original file restored ──────────────────────────────────────');
+console.log('  No permanent changes made to the session transcript.\n');
+
+// ── full round-trip instructions ──────────────────────────────────────────────
+
+console.log('── Full round-trip test (manual) ────────────────────────────────────────');
+console.log(`
+  To observe HTTP 400 without the fix / success with the fix:
+
+  WITHOUT fix (reproduce the bug):
+    1. Check out a commit before this fix:
+         git stash && git checkout HEAD~1
+         npm run build
+    2. Inject a surrogate:
+         node scripts/validate-surrogate-fix.mjs ${group}
+       Then immediately send a message to the group — before NanoClaw sanitizes.
+       (The injection happens here; NanoClaw reads the corrupted file on next spawn.)
+    3. Watch the container log:
+         tail -f data/sessions/${group}/logs/container-*.log
+       Look for: HTTP 400 / Bad Request / invalid_request_error
+
+  WITH fix (confirm it's resolved):
+    1. Return to the fix branch:
+         git checkout - && npm run build && npm run dev
+    2. Inject and send again:
+         node scripts/validate-surrogate-fix.mjs ${group}
+       Then send a message.  NanoClaw sanitizes before spawning the container.
+    3. Agent responds normally; no HTTP 400 in logs.
+`);
+
+process.exit(corruptConfirmed && !stillCorrupt ? 0 : 1);

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -27,6 +27,7 @@ import {
 } from './container-runtime.js';
 import { detectAuthMode } from './credential-proxy.js';
 import { validateAdditionalMounts } from './mount-security.js';
+import { sanitizeSurrogates } from './router.js';
 import { RegisteredGroup } from './types.js';
 
 // Sentinel markers for robust output parsing (must match agent-runner)
@@ -264,6 +265,33 @@ function buildContainerArgs(
   return args;
 }
 
+function sanitizeSessionTranscripts(sessionDir: string): void {
+  if (!fs.existsSync(sessionDir)) return;
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) { walk(full); continue; }
+      if (!entry.name.endsWith('.jsonl')) continue;
+      const original = fs.readFileSync(full, 'utf-8');
+      const sanitized = original
+        .split('\n')
+        .map((line) => {
+          if (!line.trim()) return line;
+          try {
+            return JSON.stringify(JSON.parse(line), (_, v) =>
+              typeof v === 'string' ? sanitizeSurrogates(v) : v
+            );
+          } catch {
+            return line;
+          }
+        })
+        .join('\n');
+      if (sanitized !== original) fs.writeFileSync(full, sanitized, 'utf-8');
+    }
+  };
+  walk(sessionDir);
+}
+
 export async function runContainerAgent(
   group: RegisteredGroup,
   input: ContainerInput,
@@ -306,6 +334,9 @@ export async function runContainerAgent(
   const logsDir = path.join(groupDir, 'logs');
   fs.mkdirSync(logsDir, { recursive: true });
 
+  const sessionDir = path.join(DATA_DIR, 'sessions', group.folder, '.claude');
+  sanitizeSessionTranscripts(sessionDir);
+
   return new Promise((resolve) => {
     const container = spawn(CONTAINER_RUNTIME_BIN, containerArgs, {
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -318,7 +349,8 @@ export async function runContainerAgent(
     let stdoutTruncated = false;
     let stderrTruncated = false;
 
-    container.stdin.write(JSON.stringify(input));
+    const safeInput = { ...input, prompt: sanitizeSurrogates(input.prompt) };
+    container.stdin.write(JSON.stringify(safeInput));
     container.stdin.end();
 
     // Streaming output: parse OUTPUT_START/END marker pairs as they arrive

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,9 +1,16 @@
 import { Channel, NewMessage } from './types.js';
 import { formatLocalTime } from './timezone.js';
 
+export function sanitizeSurrogates(s: string): string {
+  return s.replace(
+    /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g,
+    '\uFFFD',
+  );
+}
+
 export function escapeXml(s: string): string {
   if (!s) return '';
-  return s
+  return sanitizeSurrogates(s)
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')


### PR DESCRIPTION
## Summary

Lone surrogates in Bash tool output survive `JSON.stringify` and end up stored verbatim in `.jsonl` session transcripts. When NanoClaw re-reads those transcripts to build the conversation history for the next agent spawn, the API rejects the payload with **HTTP 400** (`invalid_request_error` / bad encoding).

### What breaks

1. Agent runs a Bash command whose stdout contains binary data or mojibake (e.g. `strings`, `xxd`, raw file cat).
2. The lone surrogate (e.g. `\uD800`) survives `JSON.stringify` — V8 encodes it as `\ud800`, which is technically invalid JSON per RFC 8259 but accepted by most runtimes.
3. The surrogate is written into the `.jsonl` session transcript.
4. On the **next** message to the group, `container-runner.ts` reads the transcript, re-serialises it, and the API rejects the request.

### What the fix does

Two targeted changes:

| File | Change |
|---|---|
| `src/container-runner.ts` | Adds `sanitizeSessionTranscripts()` — walks all `.jsonl` files under the group's session dir and runs a `JSON.stringify` replacer that calls `sanitizeSurrogates()` on every string value before the container is spawned. |
| `src/router.ts` | Wires `sanitizeSurrogates` into `escapeXml` so the inbound prompt is also clean. |

The `sanitizeSurrogates` helper uses a targeted regex to match lone high surrogates (`\uD800–\uDBFF` not followed by a low surrogate) and lone low surrogates (`\uDC00–\uDFFF` not preceded by a high surrogate), replacing each with the Unicode replacement character `\uFFFD`.

## Validation

A self-contained script is included:

```sh
node scripts/validate-surrogate-fix.mjs <group-folder>
```

It:
1. Finds the most-recently-modified `.jsonl` for the group.
2. Injects a lone surrogate into a string value in the last line (reproducing the bug).
3. Runs the same `sanitizeSessionTranscripts` logic from the fix.
4. Confirms the surrogate is replaced with `\uFFFD`.
5. Restores the original file — no permanent changes.

Expected output:

```
Target file: data/sessions/<group>/.claude/projects/…/abc123.jsonl

── Step 1: Injected lone surrogate ─────────────────────────────────────
  Line 47 now contains lone surrogate: ✗ YES (bug reproduced)

── Step 2: Run sanitizer ────────────────────────────────────────────────
  After sanitizeSessionTranscripts: ✓ Surrogate replaced with \uFFFD (fix works)

── Step 3: Original file restored ──────────────────────────────────────
  No permanent changes made to the session transcript.
```

### Full round-trip test (manual)

**Without the fix (reproduce HTTP 400):**
1. Check out a commit before this fix: `git stash && git checkout HEAD~1 && npm run build`
2. Run `node scripts/validate-surrogate-fix.mjs <group>` to inject the surrogate, then send a message to the group.
3. Watch `tail -f data/sessions/<group>/logs/container-*.log` — look for `HTTP 400` / `invalid_request_error`.

**With the fix (confirm resolved):**
1. Return to this branch: `git checkout - && npm run build && npm run dev`
2. Inject and send again — `sanitizeSessionTranscripts` runs before container spawn.
3. Agent responds normally; no HTTP 400 in logs.

## References

Closes #889