### PR TITLE
docs: remove stale data/env refs, clarify folder vs display name, drop Signal RFS

### DIFF
--- a/.claude/skills/add-discord/SKILL.md
+++ b/.claude/skills/add-discord/SKILL.md
@@ -93,14 +93,6 @@ DISCORD_BOT_TOKEN=<their-token>
 
 Channels auto-enable when their credentials are present — no extra configuration needed.
 
-Sync to container environment:
-
-```bash
-mkdir -p data/env && cp .env data/env/env
-```
-
-The container reads environment from `data/env/env`, not `.env` directly.
-
 ### Build and restart
 
 ```bash
@@ -128,6 +120,8 @@ Wait for the user to provide the channel ID (format: `dc:1234567890123456`).
 
 Use the IPC register flow or register directly. The channel ID, name, and folder name are needed.
 
+**Important:** `name` is the human-readable display name (e.g. "My Server #general"). `folder` is a machine-friendly slug used for the filesystem directory under `groups/` — use only lowercase letters, numbers, and underscores (e.g. `discord_general`). Do NOT pass the display name as `folder`.
+
 For a main channel (responds to all messages):
 
 ```typescript
@@ -145,8 +139,8 @@ For additional channels (trigger-only):
 
 ```typescript
 registerGroup("dc:<channel-id>", {
-  name: "<server-name> #<channel-name>",
-  folder: "discord_<channel-name>",
+  name: "<server-name> #<channel-display-name>",
+  folder: "discord_<slug>",  // e.g. "discord_general", NOT "discord_#general"
   trigger: `@${ASSISTANT_NAME}`,
   added_at: new Date().toISOString(),
   requiresTrigger: true,
@@ -175,7 +169,7 @@ tail -f logs/nanoclaw.log
 
 ### Bot not responding
 
-1. Check `DISCORD_BOT_TOKEN` is set in `.env` AND synced to `data/env/env`
+1. Check `DISCORD_BOT_TOKEN` is set in `.env`
 2. Check channel is registered: `sqlite3 store/messages.db "SELECT * FROM registered_groups WHERE jid LIKE 'dc:%'"`
 3. For non-main channels: message must include trigger pattern (@mention the bot)
 4. Service is running: `launchctl list | grep nanoclaw`

--- a/.claude/skills/add-slack/SKILL.md
+++ b/.claude/skills/add-slack/SKILL.md
@@ -83,14 +83,6 @@ SLACK_APP_TOKEN=xapp-your-app-token
 
 Channels auto-enable when their credentials are present — no extra configuration needed.
 
-Sync to container environment:
-
-```bash
-mkdir -p data/env && cp .env data/env/env
-```
-
-The container reads environment from `data/env/env`, not `.env` directly.
-
 ### Build and restart
 
 ```bash
@@ -116,6 +108,8 @@ Wait for the user to provide the channel ID.
 
 Use the IPC register flow or register directly. The channel ID, name, and folder name are needed.
 
+**Important:** `name` is the human-readable display name (e.g. "#engineering"). `folder` is a machine-friendly slug used for the filesystem directory under `groups/` — use only lowercase letters, numbers, and underscores (e.g. `slack_engineering`). Do NOT pass the display name as `folder`.
+
 For a main channel (responds to all messages):
 
 ```typescript
@@ -133,8 +127,8 @@ For additional channels (trigger-only):
 
 ```typescript
 registerGroup("slack:<channel-id>", {
-  name: "<channel-name>",
-  folder: "slack_<channel-name>",
+  name: "<channel-display-name>",
+  folder: "slack_<slug>",  // e.g. "slack_engineering", NOT "slack_#engineering"
   trigger: `@${ASSISTANT_NAME}`,
   added_at: new Date().toISOString(),
   requiresTrigger: true,
@@ -163,7 +157,7 @@ tail -f logs/nanoclaw.log
 
 ### Bot not responding
 
-1. Check `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN` are set in `.env` AND synced to `data/env/env`
+1. Check `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN` are set in `.env`
 2. Check channel is registered: `sqlite3 store/messages.db "SELECT * FROM registered_groups WHERE jid LIKE 'slack:%'"`
 3. For non-main channels: message must include trigger pattern
 4. Service is running: `launchctl list | grep nanoclaw`
@@ -188,8 +182,7 @@ If the bot logs `missing_scope` errors:
 2. Add the missing scope listed in the error message
 3. **Reinstall the app** to your workspace — scope changes require reinstallation
 4. Copy the new Bot Token (it changes on reinstall) and update `.env`
-5. Sync: `mkdir -p data/env && cp .env data/env/env`
-6. Restart: `launchctl kickstart -k gui/$(id -u)/com.nanoclaw`
+5. Restart: `launchctl kickstart -k gui/$(id -u)/com.nanoclaw`
 
 ### Getting channel ID
 

--- a/.claude/skills/add-telegram-swarm/SKILL.md
+++ b/.claude/skills/add-telegram-swarm/SKILL.md
@@ -308,12 +308,6 @@ Add pool tokens to `.env`:
 TELEGRAM_BOT_POOL=TOKEN1,TOKEN2,TOKEN3,...
 ```
 
-**Important**: Sync to all required locations:
-
-```bash
-cp .env data/env/env
-```
-
 Also add `TELEGRAM_BOT_POOL` to the launchd plist (`~/Library/LaunchAgents/com.nanoclaw.plist`) in the `EnvironmentVariables` dict if using launchd.
 
 ### Step 7: Rebuild and Restart
@@ -380,5 +374,5 @@ To remove Agent Swarm support while keeping basic Telegram:
 4. Remove `initBotPool` call from `main()`
 5. Remove `sender` param from MCP tool in `container/agent-runner/src/ipc-mcp-stdio.ts`
 6. Remove Agent Teams section from group CLAUDE.md files
-7. Remove `TELEGRAM_BOT_POOL` from `.env`, `data/env/env`, and launchd plist/systemd unit
+7. Remove `TELEGRAM_BOT_POOL` from `.env` and launchd plist/systemd unit
 8. Rebuild: `npm run build && ./container/build.sh && launchctl unload ~/Library/LaunchAgents/com.nanoclaw.plist && launchctl load ~/Library/LaunchAgents/com.nanoclaw.plist` (macOS) or `npm run build && ./container/build.sh && systemctl --user restart nanoclaw` (Linux)

--- a/.claude/skills/add-telegram/SKILL.md
+++ b/.claude/skills/add-telegram/SKILL.md
@@ -87,14 +87,6 @@ TELEGRAM_BOT_TOKEN=<their-token>
 
 Channels auto-enable when their credentials are present — no extra configuration needed.
 
-Sync to container environment:
-
-```bash
-mkdir -p data/env && cp .env data/env/env
-```
-
-The container reads environment from `data/env/env`, not `.env` directly.
-
 ### Disable Group Privacy (for group chats)
 
 Tell the user:
@@ -131,6 +123,8 @@ Wait for the user to provide the chat ID (format: `tg:123456789` or `tg:-1001234
 
 Use the IPC register flow or register directly. The chat ID, name, and folder name are needed.
 
+**Important:** `name` is the human-readable display name (e.g. "Dev Team"). `folder` is a machine-friendly slug used for the filesystem directory under `groups/` — use only lowercase letters, numbers, and underscores (e.g. `telegram_dev_team`). Do NOT pass the display name as `folder`.
+
 For a main chat (responds to all messages):
 
 ```typescript
@@ -148,8 +142,8 @@ For additional chats (trigger-only):
 
 ```typescript
 registerGroup("tg:<chat-id>", {
-  name: "<chat-name>",
-  folder: "telegram_<group-name>",
+  name: "<chat-display-name>",
+  folder: "telegram_<slug>",  // e.g. "telegram_dev_team", NOT "telegram_Dev Team"
   trigger: `@${ASSISTANT_NAME}`,
   added_at: new Date().toISOString(),
   requiresTrigger: true,
@@ -179,7 +173,7 @@ tail -f logs/nanoclaw.log
 ### Bot not responding
 
 Check:
-1. `TELEGRAM_BOT_TOKEN` is set in `.env` AND synced to `data/env/env`
+1. `TELEGRAM_BOT_TOKEN` is set in `.env`
 2. Chat is registered in SQLite (check with: `sqlite3 store/messages.db "SELECT * FROM registered_groups WHERE jid LIKE 'tg:%'"`)
 3. For non-main chats: message includes trigger pattern
 4. Service is running: `launchctl list | grep nanoclaw` (macOS) or `systemctl --user status nanoclaw` (Linux)

--- a/.claude/skills/add-voice-transcription/SKILL.md
+++ b/.claude/skills/add-voice-transcription/SKILL.md
@@ -88,14 +88,6 @@ Add to `.env`:
 OPENAI_API_KEY=<their-key>
 ```
 
-Sync to container environment:
-
-```bash
-mkdir -p data/env && cp .env data/env/env
-```
-
-The container reads environment from `data/env/env`, not `.env` directly.
-
 ### Build and restart
 
 ```bash
@@ -128,7 +120,7 @@ Look for:
 
 ### Voice notes show "[Voice Message - transcription unavailable]"
 
-1. Check `OPENAI_API_KEY` is set in `.env` AND synced to `data/env/env`
+1. Check `OPENAI_API_KEY` is set in `.env`
 2. Verify key works: `curl -s https://api.openai.com/v1/models -H "Authorization: Bearer $OPENAI_API_KEY" | head -c 200`
 3. Check OpenAI billing — Whisper requires a funded account
 

--- a/.claude/skills/add-whatsapp/SKILL.md
+++ b/.claude/skills/add-whatsapp/SKILL.md
@@ -166,12 +166,6 @@ test -f store/auth/creds.json && echo "Authentication successful" || echo "Authe
 
 Channels auto-enable when their credentials are present — WhatsApp activates when `store/auth/creds.json` exists.
 
-Sync to container environment:
-
-```bash
-mkdir -p data/env && cp .env data/env/env
-```
-
 ## Phase 4: Registration
 
 ### Configure trigger and channel type
@@ -225,6 +219,8 @@ The output shows `JID|GroupName` pairs. Present candidates as AskUserQuestion (n
 
 ### Register the chat
 
+**Important:** `--name` is the human-readable display name (e.g. "Family Chat"). `--folder` is a machine-friendly slug used for the filesystem directory under `groups/` — use only lowercase letters, numbers, and underscores (e.g. `whatsapp_family_chat`). Do NOT pass the display name as `--folder`.
+
 ```bash
 npx tsx setup/index.ts --step register \
   --jid "<jid>" \
@@ -242,10 +238,11 @@ For additional groups (trigger-required):
 ```bash
 npx tsx setup/index.ts --step register \
   --jid "<group-jid>" \
-  --name "<group-name>" \
+  --name "<group-display-name>" \
   --trigger "@<trigger>" \
-  --folder "whatsapp_<group-name>" \
+  --folder "whatsapp_<slug>" \
   --channel whatsapp
+# Example: --name "Work Projects" --folder "whatsapp_work_projects"
 ```
 
 ## Phase 5: Verify
@@ -364,5 +361,4 @@ To remove WhatsApp integration:
 
 1. Delete auth credentials: `rm -rf store/auth/`
 2. Remove WhatsApp registrations: `sqlite3 store/messages.db "DELETE FROM registered_groups WHERE jid LIKE '%@g.us' OR jid LIKE '%@s.whatsapp.net'"`
-3. Sync env: `mkdir -p data/env && cp .env data/env/env`
-4. Rebuild and restart: `npm run build && launchctl kickstart -k gui/$(id -u)/com.nanoclaw` (macOS) or `npm run build && systemctl --user restart nanoclaw` (Linux)
+3. Rebuild and restart: `npm run build && launchctl kickstart -k gui/$(id -u)/com.nanoclaw` (macOS) or `npm run build && systemctl --user restart nanoclaw` (Linux)

--- a/.claude/skills/debug/SKILL.md
+++ b/.claude/skills/debug/SKILL.md
@@ -17,7 +17,7 @@ src/container-runner.ts               container/agent-runner/
     │ spawns container                      │ runs Claude Agent SDK
     │ with volume mounts                   │ with MCP servers
     │                                      │
-    ├── data/env/env ──────────────> /workspace/env-dir/env
+    ├── .env ─────────────────────> /dev/null (shadowed; credentials via proxy)
     ├── groups/{folder} ───────────> /workspace/group
     ├── data/ipc/{folder} ────────> /workspace/ipc
     ├── data/sessions/{folder}/.claude/ ──> /home/node/.claude/ (isolated per-group)
@@ -84,15 +84,7 @@ cat .env  # Should show one of:
 
 **Runtime note:** Environment variables passed via `-e` may be lost when using `-i` (interactive/piped stdin).
 
-**Workaround:** The system extracts only authentication variables (`CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`) from `.env` and mounts them for sourcing inside the container. Other env vars are not exposed.
-
-To verify env vars are reaching the container:
-```bash
-echo '{}' | docker run -i \
-  -v $(pwd)/data/env:/workspace/env-dir:ro \
-  --entrypoint /bin/bash nanoclaw-agent:latest \
-  -c 'export $(cat /workspace/env-dir/env | xargs); echo "OAuth: ${#CLAUDE_CODE_OAUTH_TOKEN} chars, API: ${#ANTHROPIC_API_KEY} chars"'
-```
+**How it works:** Credentials (`CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`) are injected into the container via the credential proxy. The `.env` file is shadowed with `/dev/null` so the agent cannot read secrets from the mounted project root.
 
 ### 3. Mount Issues
 
@@ -179,14 +171,13 @@ If an MCP server fails to start, the agent may exit. Check the container logs fo
 
 ### Test the full agent flow:
 ```bash
-# Set up env file
-mkdir -p data/env groups/test
-cp .env data/env/env
+mkdir -p groups/test
 
-# Run test query
+# Run test query (credentials are injected via credential proxy in production;
+# for manual testing, pass them as env vars)
 echo '{"prompt":"What is 2+2?","groupFolder":"test","chatJid":"test@g.us","isMain":false}' | \
   docker run -i \
-  -v $(pwd)/data/env:/workspace/env-dir:ro \
+  -e ANTHROPIC_API_KEY \
   -v $(pwd)/groups/test:/workspace/group \
   -v $(pwd)/data/ipc:/workspace/ipc \
   nanoclaw-agent:latest
@@ -195,9 +186,8 @@ echo '{"prompt":"What is 2+2?","groupFolder":"test","chatJid":"test@g.us","isMai
 ### Test Claude Code directly:
 ```bash
 docker run --rm --entrypoint /bin/bash \
-  -v $(pwd)/data/env:/workspace/env-dir:ro \
+  -e ANTHROPIC_API_KEY \
   nanoclaw-agent:latest -c '
-  export $(cat /workspace/env-dir/env | xargs)
   claude -p "Say hello" --dangerously-skip-permissions --allowedTools ""
 '
 ```
@@ -325,8 +315,8 @@ echo "=== Checking NanoClaw Container Setup ==="
 echo -e "\n1. Authentication configured?"
 [ -f .env ] && (grep -q "CLAUDE_CODE_OAUTH_TOKEN=sk-" .env || grep -q "ANTHROPIC_API_KEY=sk-" .env) && echo "OK" || echo "MISSING - add CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY to .env"
 
-echo -e "\n2. Env file copied for container?"
-[ -f data/env/env ] && echo "OK" || echo "MISSING - will be created on first run"
+echo -e "\n2. Credentials configured?"
+grep -q "CLAUDE_CODE_OAUTH_TOKEN\|ANTHROPIC_API_KEY" .env 2>/dev/null && echo "OK" || echo "MISSING - add CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY to .env"
 
 echo -e "\n3. Container runtime running?"
 docker info &>/dev/null && echo "OK" || echo "NOT RUNNING - start Docker Desktop (macOS) or sudo systemctl start docker (Linux)"

--- a/README.md
+++ b/README.md
@@ -116,9 +116,6 @@ Users then run `/add-telegram` on their fork and get clean code that does exactl
 
 Skills we'd like to see:
 
-**Communication Channels**
-- `/add-signal` - Add Signal as a channel
-
 **Session Management**
 - `/clear` - Add a `/clear` command that compacts the conversation (summarizes context while preserving critical information in the same session). Requires figuring out how to trigger compaction programmatically via the Claude Agent SDK.
 


### PR DESCRIPTION
## Summary

- Remove all `data/env` references from 7 skill docs — container runner now uses credential proxy, `.env` is shadowed with `/dev/null` (Discord triage #17)
- Clarify that `--folder`/`folder` takes a machine-friendly slug (e.g. `whatsapp_main`), not the chat display name, in all 4 channel skill docs (Discord triage #16, #375)
- Remove `/add-signal` from README RFS section — Signal support doesn't exist (Discord triage #21, #29)

## Files changed

- `README.md`
- `.claude/skills/add-whatsapp/SKILL.md`
- `.claude/skills/add-telegram/SKILL.md`
- `.claude/skills/add-slack/SKILL.md`
- `.claude/skills/add-discord/SKILL.md`
- `.claude/skills/add-voice-transcription/SKILL.md`
- `.claude/skills/add-telegram-swarm/SKILL.md`
- `.claude/skills/debug/SKILL.md`

## Test plan

- [ ] Verify no remaining `data/env` references in SKILL.md files
- [ ] Confirm folder vs name guidance is clear in each channel skill
- [ ] Confirm `/add-signal` no longer appears in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)