### PR TITLE
fix: use platform-appropriate browser ID for WhatsApp pairing

### DIFF
--- a/setup/groups.ts
+++ b/setup/groups.ts
@@ -140,7 +140,7 @@ const sock = makeWASocket({
   auth: { creds: state.creds, keys: makeCacheableSignalKeyStore(state.keys, logger) },
   printQRInTerminal: false,
   logger,
-  browser: Browsers.macOS('Chrome'),
+  browser: Browsers.appropriate('Chrome'),
 });
 
 const timeout = setTimeout(() => {


### PR DESCRIPTION
## Summary

- Change `Browsers.macOS('Chrome')` to `Browsers.appropriate('Chrome')` in `setup/groups.ts` (Discord triage #20)
- `Browsers.appropriate` is a Baileys built-in that auto-detects the host platform, so WhatsApp linked devices shows the correct OS instead of always showing "Chrome · macOS" on Linux/WSL

## Test plan

- [ ] Run `npx tsx setup/index.ts --step groups` on Linux — verify linked device doesn't show "macOS"
- [ ] Run on macOS — verify it still shows "macOS" correctly
- [ ] No behavioral change, cosmetic fix only

🤖 Generated with [Claude Code](https://claude.com/claude-code)