### PR TITLE
fix: refresh tasks snapshot immediately after IPC task mutations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -575,6 +575,21 @@ async function main(): Promise<void> {
     getAvailableGroups,
     writeGroupsSnapshot: (gf, im, ag, rj) =>
       writeGroupsSnapshot(gf, im, ag, rj),
+    onTasksChanged: () => {
+      const tasks = getAllTasks();
+      const taskRows = tasks.map((t) => ({
+        id: t.id,
+        groupFolder: t.group_folder,
+        prompt: t.prompt,
+        schedule_type: t.schedule_type,
+        schedule_value: t.schedule_value,
+        status: t.status,
+        next_run: t.next_run,
+      }));
+      for (const group of Object.values(registeredGroups)) {
+        writeTasksSnapshot(group.folder, group.isMain === true, taskRows);
+      }
+    },
   });
   queue.setProcessMessagesFn(processGroupMessages);
   recoverPendingMessages();

--- a/src/ipc-auth.test.ts
+++ b/src/ipc-auth.test.ts
@@ -62,6 +62,7 @@ beforeEach(() => {
     syncGroups: async () => {},
     getAvailableGroups: () => [],
     writeGroupsSnapshot: () => {},
+    onTasksChanged: () => {},
   };
 });
 

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -22,6 +22,7 @@ export interface IpcDeps {
     availableGroups: AvailableGroup[],
     registeredJids: Set<string>,
   ) => void;
+  onTasksChanged: () => void;
 }
 
 let ipcWatcherRunning = false;
@@ -270,6 +271,7 @@ export async function processTaskIpc(
           { taskId, sourceGroup, targetFolder, contextMode },
           'Task created via IPC',
         );
+        deps.onTasksChanged();
       }
       break;
 
@@ -282,6 +284,7 @@ export async function processTaskIpc(
             { taskId: data.taskId, sourceGroup },
             'Task paused via IPC',
           );
+          deps.onTasksChanged();
         } else {
           logger.warn(
             { taskId: data.taskId, sourceGroup },
@@ -300,6 +303,7 @@ export async function processTaskIpc(
             { taskId: data.taskId, sourceGroup },
             'Task resumed via IPC',
           );
+          deps.onTasksChanged();
         } else {
           logger.warn(
             { taskId: data.taskId, sourceGroup },
@@ -318,6 +322,7 @@ export async function processTaskIpc(
             { taskId: data.taskId, sourceGroup },
             'Task cancelled via IPC',
           );
+          deps.onTasksChanged();
         } else {
           logger.warn(
             { taskId: data.taskId, sourceGroup },
@@ -388,6 +393,7 @@ export async function processTaskIpc(
           { taskId: data.taskId, sourceGroup, updates },
           'Task updated via IPC',
         );
+        deps.onTasksChanged();
       }
       break;
 


### PR DESCRIPTION
## Problem

`current_tasks.json` (the snapshot read by `list_tasks` inside containers) is only written at container-start time. Tasks created, paused, cancelled, or updated during a session via IPC are invisible to `list_tasks` until the next invocation.

Concretely: if an agent schedules a new task and then immediately calls `list_tasks` in the same session, the new task does not appear.

## Solution

Add an `onTasksChanged` callback to `IpcDeps`. It is called after every successful mutation in `processTaskIpc`:

- `schedule_task` (create)
- `pause_task`
- `resume_task`
- `cancel_task` (delete)
- `update_task`

`index.ts` wires the callback to immediately write fresh snapshots for all registered groups using the existing `writeTasksSnapshot` helper.

## Design

The callback pattern keeps `ipc.ts` decoupled from the container layer — it has no knowledge of how or where snapshots are written. This mirrors the existing pattern used for `writeGroupsSnapshot` and `sendMessage` in `IpcDeps`.

## Test

Updated the `IpcDeps` fixture in `ipc-auth.test.ts` with a no-op `onTasksChanged`. All 251 existing tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)