### PR TITLE
fix: skip .env shadow mount on Apple Container (non-Docker runtimes)

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -78,8 +78,9 @@ function buildVolumeMounts(
 
     // Shadow .env so the agent cannot read secrets from the mounted project root.
     // Credentials are injected by the credential proxy, never exposed to containers.
+    // Only apply for Docker — Apple Container doesn't support file mounts.
     const envFile = path.join(projectRoot, '.env');
-    if (fs.existsSync(envFile)) {
+    if (fs.existsSync(envFile) && CONTAINER_RUNTIME_BIN === 'docker') {
       mounts.push({
         hostPath: '/dev/null',
         containerPath: '/workspace/project/.env',


### PR DESCRIPTION
## Summary
Fixes #834

The .env shadow mount introduced in v1.2.6 breaks NanoClaw on Apple Container with:
```
Error: invalidArgument: "path '/dev/null' is not a directory"
```

## Root Cause
Apple Container only supports directory bind mounts — it rejects `/dev/null` (character device) and any file sources.

## Changes
- Made .env shadow mount conditional on Docker runtime only
- Added comment explaining Apple Container limitation
- Secrets are already injected via stdin by `readSecrets()`, so the agent doesn't need to read .env directly

## Impact
- Fixes container startup on Apple Container
- No behavior change for Docker users (shadow mount still applied)
- Defense-in-depth measure remains for Docker users