### PR TITLE
fix: Apple Container networking and mount compatibility

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -76,16 +76,8 @@ function buildVolumeMounts(
       readonly: true,
     });
 
-    // Shadow .env so the agent cannot read secrets from the mounted project root.
-    // Credentials are injected by the credential proxy, never exposed to containers.
-    const envFile = path.join(projectRoot, '.env');
-    if (fs.existsSync(envFile)) {
-      mounts.push({
-        hostPath: '/dev/null',
-        containerPath: '/workspace/project/.env',
-        readonly: true,
-      });
-    }
+    // .env shadowing is handled inside the container entrypoint via mount --bind
+    // (Apple Container only supports directory mounts, not file mounts like /dev/null)
 
     // Main also gets its group folder as the working directory
     mounts.push({

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -11,8 +11,11 @@ import { logger } from './logger.js';
 /** The container runtime binary name. */
 export const CONTAINER_RUNTIME_BIN = 'container';
 
-/** Hostname containers use to reach the host machine. */
-export const CONTAINER_HOST_GATEWAY = 'host.docker.internal';
+/** Hostname/IP containers use to reach the host machine. */
+export const CONTAINER_HOST_GATEWAY =
+  CONTAINER_RUNTIME_BIN === 'container'
+    ? '192.168.64.1' // Apple Container: VM gateway IP (host.docker.internal not available)
+    : 'host.docker.internal';
 
 /**
  * Address the credential proxy binds to.
@@ -24,6 +27,9 @@ export const PROXY_BIND_HOST =
   process.env.CREDENTIAL_PROXY_HOST || detectProxyBindHost();
 
 function detectProxyBindHost(): string {
+  // Apple Container VMs reach the host via the bridge network, not loopback.
+  // The proxy must bind to 0.0.0.0 so the VM gateway (192.168.64.1) can connect.
+  if (os.platform() === 'darwin' && CONTAINER_RUNTIME_BIN === 'container') return '0.0.0.0';
   if (os.platform() === 'darwin') return '127.0.0.1';
 
   // WSL uses Docker Desktop (same VM routing as macOS) — loopback is correct.


### PR DESCRIPTION
## Summary

- **Remove `/dev/null` file mount** from `container-runner.ts` — Apple Container only supports directory mounts. The Dockerfile entrypoint already shadows `.env` via `mount --bind` inside the container, so the host-side mount was redundant and broke container startup.
- **Bind credential proxy to `0.0.0.0`** on macOS with Apple Container so the VM's bridge network can reach it (`127.0.0.1` is not accessible from the container).
- **Use gateway IP `192.168.64.1`** as the container host address instead of `host.docker.internal`, which doesn't resolve in Apple Container VMs.

## Test plan

- [x] All 243 tests pass
- [x] Container builds and starts successfully
- [x] Agent responds to WhatsApp messages end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)