### PR TITLE
feat: add Dokploy and Docker Compose deployment support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+logs
+store
+data
+.env
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM node:22-slim
+
+# Install system dependencies
+# - docker.io: To run docker commands from within the container
+# - build-essential, python3: To compile native modules like better-sqlite3
+RUN apt-get update && apt-get install -y \
+    docker.io \
+    build-essential \
+    python3 \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy project files
+COPY . .
+
+# Build the project
+RUN npm run build
+
+# Expose the credential proxy port
+EXPOSE 3001
+
+# Entry point
+CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.8'
+
+services:
+  nanoclaw:
+    build: .
+    container_name: nanoclaw
+    restart: unless-stopped
+    environment:
+      - HOST_PROJECT_PATH=${PWD}
+      # Pass through common env vars if they exist
+      - ASSISTANT_NAME
+      - ASSISTANT_HAS_OWN_NUMBER
+      - ANTHROPIC_API_KEY
+      - CLAUDE_CODE_OAUTH_TOKEN
+      - TZ
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./store:/app/store
+      - ./groups:/app/groups
+      - ./data:/app/data
+      - ./logs:/app/logs
+      # Mount .env so the orchestrator can read it
+      - ./.env:/app/.env:ro
+    ports:
+      - "3001:3001"

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,11 @@ export const SCHEDULER_POLL_INTERVAL = 60000;
 
 // Absolute paths needed for container mounts
 const PROJECT_ROOT = process.cwd();
+// Host paths for Docker-out-of-Docker mounts
+export const HOST_PROJECT_PATH = process.env.HOST_PROJECT_PATH || PROJECT_ROOT;
+export const HOST_GROUPS_DIR = path.resolve(HOST_PROJECT_PATH, "groups");
+export const HOST_DATA_DIR = path.resolve(HOST_PROJECT_PATH, "data");
+export const HOST_STORE_DIR = path.resolve(HOST_PROJECT_PATH, "store");
 const HOME_DIR = process.env.HOME || os.homedir();
 
 // Mount security: allowlist stored OUTSIDE project root, never mounted into containers

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -16,6 +16,10 @@ vi.mock('./config.js', () => ({
   GROUPS_DIR: '/tmp/nanoclaw-test-groups',
   IDLE_TIMEOUT: 1800000, // 30min
   TIMEZONE: 'America/Los_Angeles',
+  HOST_PROJECT_PATH: '/tmp/host/project',
+  HOST_GROUPS_DIR: '/tmp/host/groups',
+  HOST_DATA_DIR: '/tmp/host/data',
+  HOST_STORE_DIR: '/tmp/host/store',
 }));
 
 // Mock logger

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -15,6 +15,9 @@ import {
   GROUPS_DIR,
   IDLE_TIMEOUT,
   TIMEZONE,
+  HOST_DATA_DIR,
+  HOST_GROUPS_DIR,
+  HOST_PROJECT_PATH,
 } from './config.js';
 import { resolveGroupFolderPath, resolveGroupIpcPath } from './group-folder.js';
 import { logger } from './logger.js';
@@ -71,7 +74,7 @@ function buildVolumeMounts(
     // (src/, dist/, package.json, etc.) which would bypass the sandbox
     // entirely on next restart.
     mounts.push({
-      hostPath: projectRoot,
+      hostPath: HOST_PROJECT_PATH,
       containerPath: '/workspace/project',
       readonly: true,
     });
@@ -89,14 +92,14 @@ function buildVolumeMounts(
 
     // Main also gets its group folder as the working directory
     mounts.push({
-      hostPath: groupDir,
+      hostPath: path.join(HOST_GROUPS_DIR, group.folder),
       containerPath: '/workspace/group',
       readonly: false,
     });
   } else {
     // Other groups only get their own folder
     mounts.push({
-      hostPath: groupDir,
+      hostPath: path.join(HOST_GROUPS_DIR, group.folder),
       containerPath: '/workspace/group',
       readonly: false,
     });
@@ -106,7 +109,7 @@ function buildVolumeMounts(
     const globalDir = path.join(GROUPS_DIR, 'global');
     if (fs.existsSync(globalDir)) {
       mounts.push({
-        hostPath: globalDir,
+        hostPath: path.join(HOST_GROUPS_DIR, 'global'),
         containerPath: '/workspace/global',
         readonly: true,
       });
@@ -158,7 +161,7 @@ function buildVolumeMounts(
     }
   }
   mounts.push({
-    hostPath: groupSessionsDir,
+    hostPath: path.join(HOST_DATA_DIR, 'sessions', group.folder, '.claude'),
     containerPath: '/home/node/.claude',
     readonly: false,
   });
@@ -170,7 +173,7 @@ function buildVolumeMounts(
   fs.mkdirSync(path.join(groupIpcDir, 'tasks'), { recursive: true });
   fs.mkdirSync(path.join(groupIpcDir, 'input'), { recursive: true });
   mounts.push({
-    hostPath: groupIpcDir,
+    hostPath: path.join(HOST_DATA_DIR, 'ipc', group.folder),
     containerPath: '/workspace/ipc',
     readonly: false,
   });
@@ -194,7 +197,7 @@ function buildVolumeMounts(
     fs.cpSync(agentRunnerSrc, groupAgentRunnerDir, { recursive: true });
   }
   mounts.push({
-    hostPath: groupAgentRunnerDir,
+    hostPath: path.join(HOST_DATA_DIR, 'sessions', group.folder, 'agent-runner-src'),
     containerPath: '/app/src',
     readonly: false,
   });
@@ -325,6 +328,7 @@ export async function runContainerAgent(
     let parseBuffer = '';
     let newSessionId: string | undefined;
     let outputChain = Promise.resolve();
+    let hadStreamingOutput = false;
 
     container.stdout.on('data', (data) => {
       const chunk = data.toString();
@@ -401,7 +405,6 @@ export async function runContainerAgent(
     });
 
     let timedOut = false;
-    let hadStreamingOutput = false;
     const configTimeout = group.containerConfig?.timeout || CONTAINER_TIMEOUT;
     // Grace period: hard timeout must be at least IDLE_TIMEOUT + 30s so the
     // graceful _close sentinel has time to trigger before the hard kill fires.


### PR DESCRIPTION
- Added root Dockerfile and docker-compose.yml for production deployment.
- Implemented Docker-out-of-Docker (DooD) support for agent orchestration.
- Introduced HOST_PROJECT_PATH config to handle volume mounts from within a container.
- Updated container runner to use host-side paths for sibling containers.
- Updated test mocks to include new configuration variables.

## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description


## For Skills

- [ ] I have not made any changes to source code
- [ ] My skill contains instructions for Claude to follow (not pre-built code)
- [ ] I tested this skill on a fresh clone
