### PR TITLE
feat: add Linux/Docker deployment support

### DIFF
--- a/Dockerfile.unraid
+++ b/Dockerfile.unraid
@@ -1,0 +1,46 @@
+FROM node:22-slim
+
+# Build tools for native modules (better-sqlite3)
+RUN apt-get update && apt-get install -y \
+    python3 \
+    make \
+    g++ \
+    curl \
+    ca-certificates \
+    gnupg \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Docker CLI (not daemon — uses host socket)
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] \
+    https://download.docker.com/linux/debian bookworm stable" \
+    > /etc/apt/sources.list.d/docker.list \
+    && apt-get update \
+    && apt-get install -y docker-ce-cli \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install dependencies
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Copy source and build
+COPY tsconfig.json ./
+COPY src/ ./src/
+RUN npm run build
+
+# Copy runtime assets
+COPY container/ ./container/
+COPY groups/ ./groups/
+COPY .claude/ ./.claude/
+COPY setup/ ./setup/
+
+# Startup script — builds agent image if missing, then starts NanoClaw
+COPY docker-entrypoint.sh ./
+RUN chmod +x docker-entrypoint.sh
+
+# Persistent data volumes
+VOLUME ["/app/data", "/app/groups", "/app/logs", "/app/store"]
+
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -e
+
+echo "=== NanoClaw startup ==="
+
+# Build agent image if not present on host
+if ! docker image inspect nanoclaw-agent:latest > /dev/null 2>&1; then
+    echo "Building nanoclaw-agent image..."
+    cd /app/container && sh build.sh
+    cd /app
+else
+    echo "nanoclaw-agent image found, skipping build."
+fi
+
+# Pre-create persistent data directory structure so volume mounts
+# don't start empty and cause runtime errors on first boot
+mkdir -p \
+    /app/data/sessions \
+    /app/data/env \
+    /app/data/ipc \
+    /app/logs \
+    /app/store
+
+echo "Starting NanoClaw..."
+exec node dist/index.js

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -21,5 +21,32 @@ mkdir -p \
     /app/logs \
     /app/store
 
+chown -R 1000:1000 /app/data/sessions
+
+# Seed a minimal .claude.json for each existing group session directory
+# so claude-code considers itself logged in without needing the host's real token file.
+for session_dir in /app/data/sessions/*/; do
+    [ -d "$session_dir" ] || continue
+    claude_json="$session_dir.claude.json"
+    if [ ! -f "$claude_json" ]; then
+        cat > "$claude_json" <<'EOF'
+{
+  "hasCompletedOnboarding": true,
+  "lastOnboardingVersion": "2.1.76",
+  "oauthAccount": {
+    "accountUuid": "00000000-0000-0000-0000-000000000000",
+    "emailAddress": "agent@nanoclaw.local",
+    "organizationUuid": "00000000-0000-0000-0000-000000000000",
+    "displayName": "NanoClaw Agent",
+    "organizationRole": "admin",
+    "organizationName": "NanoClaw"
+  }
+}
+EOF
+        chown 1000:1000 "$claude_json"
+        echo "Seeded .claude.json for $session_dir"
+    fi
+done
+
 echo "Starting NanoClaw..."
 exec node dist/index.js

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -231,6 +231,11 @@ function buildVolumeMounts(
       sessionDotClaudeJson,
       JSON.stringify(claudeJsonContent, null, 2) + '\n',
     );
+    try {
+      fs.chownSync(sessionDotClaudeJson, 1000, 1000);
+    } catch {
+      // ignore — chown may fail if not running as root (native install)
+    }
   }
   mounts.push({
     hostPath: toHostPath(sessionDotClaudeJson),

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -4,6 +4,7 @@
  */
 import { ChildProcess, spawn } from 'child_process';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
 import {
@@ -64,7 +65,16 @@ function buildVolumeMounts(
   isMain: boolean,
 ): VolumeMount[] {
   const mounts: VolumeMount[] = [];
-  const projectRoot = process.cwd();
+  const containerRoot = process.cwd();
+  const hostRoot = process.env.HOST_PROJECT_ROOT ?? containerRoot;
+  // Translate internal container paths to host paths for Docker volume mounts.
+  // File system operations (mkdirSync, cpSync) use the raw path; only hostPath
+  // values passed to `docker run -v` need to reference the host filesystem.
+  const toHostPath = (p: string) =>
+    hostRoot !== containerRoot && p.startsWith(containerRoot)
+      ? hostRoot + p.slice(containerRoot.length)
+      : p;
+  const projectRoot = hostRoot;
   const groupDir = resolveGroupFolderPath(group.folder);
 
   if (isMain) {
@@ -74,7 +84,7 @@ function buildVolumeMounts(
     // (src/, dist/, package.json, etc.) which would bypass the sandbox
     // entirely on next restart.
     mounts.push({
-      hostPath: projectRoot,
+      hostPath: toHostPath(projectRoot),
       containerPath: '/workspace/project',
       readonly: true,
     });
@@ -101,7 +111,7 @@ function buildVolumeMounts(
 
     // Main also gets its group folder as the working directory
     mounts.push({
-      hostPath: groupDir,
+      hostPath: toHostPath(groupDir),
       containerPath: '/workspace/group',
       readonly: false,
     });
@@ -118,7 +128,7 @@ function buildVolumeMounts(
   } else {
     // Other groups only get their own folder
     mounts.push({
-      hostPath: groupDir,
+      hostPath: toHostPath(groupDir),
       containerPath: '/workspace/group',
       readonly: false,
     });
@@ -128,7 +138,7 @@ function buildVolumeMounts(
     const globalDir = path.join(GROUPS_DIR, 'global');
     if (fs.existsSync(globalDir)) {
       mounts.push({
-        hostPath: globalDir,
+        hostPath: toHostPath(globalDir),
         containerPath: '/workspace/global',
         readonly: true,
       });
@@ -180,8 +190,51 @@ function buildVolumeMounts(
     }
   }
   mounts.push({
-    hostPath: groupSessionsDir,
+    hostPath: toHostPath(groupSessionsDir),
     containerPath: '/home/node/.claude',
+    readonly: false,
+  });
+
+  // Provide a .claude.json at the container home so claude-code considers
+  // itself logged in. Copy non-sensitive account metadata from the host's
+  // ~/.claude.json (oauthAccount, onboarding flags) — no tokens or API keys.
+  const sessionDotClaudeJson = path.join(
+    DATA_DIR,
+    'sessions',
+    group.folder,
+    '.claude.json',
+  );
+  const hostDotClaudeJson = path.join(os.homedir(), '.claude.json');
+  if (!fs.existsSync(sessionDotClaudeJson)) {
+    let claudeJsonContent: Record<string, unknown> = {
+      hasCompletedOnboarding: true,
+      lastOnboardingVersion: '2.1.76',
+    };
+    if (fs.existsSync(hostDotClaudeJson)) {
+      try {
+        const host = JSON.parse(fs.readFileSync(hostDotClaudeJson, 'utf-8'));
+        // Copy only non-sensitive identity/onboarding fields — never tokens
+        for (const key of [
+          'oauthAccount',
+          'hasCompletedOnboarding',
+          'lastOnboardingVersion',
+          'hasSeenTasksHint',
+          'userID',
+        ]) {
+          if (host[key] !== undefined) claudeJsonContent[key] = host[key];
+        }
+      } catch {
+        // ignore — use defaults
+      }
+    }
+    fs.writeFileSync(
+      sessionDotClaudeJson,
+      JSON.stringify(claudeJsonContent, null, 2) + '\n',
+    );
+  }
+  mounts.push({
+    hostPath: toHostPath(sessionDotClaudeJson),
+    containerPath: '/home/node/.claude.json',
     readonly: false,
   });
 
@@ -192,7 +245,7 @@ function buildVolumeMounts(
   fs.mkdirSync(path.join(groupIpcDir, 'tasks'), { recursive: true });
   fs.mkdirSync(path.join(groupIpcDir, 'input'), { recursive: true });
   mounts.push({
-    hostPath: groupIpcDir,
+    hostPath: toHostPath(groupIpcDir),
     containerPath: '/workspace/ipc',
     readonly: false,
   });
@@ -201,7 +254,7 @@ function buildVolumeMounts(
   // can customize it (add tools, change behavior) without affecting other
   // groups. Recompiled on container startup via entrypoint.sh.
   const agentRunnerSrc = path.join(
-    projectRoot,
+    containerRoot,
     'container',
     'agent-runner',
     'src',
@@ -225,7 +278,7 @@ function buildVolumeMounts(
     }
   }
   mounts.push({
-    hostPath: groupAgentRunnerDir,
+    hostPath: toHostPath(groupAgentRunnerDir),
     containerPath: '/app/src',
     readonly: false,
   });

--- a/src/env.ts
+++ b/src/env.ts
@@ -15,7 +15,7 @@ export function readEnvFile(keys: string[]): Record<string, string> {
     content = fs.readFileSync(envFile, 'utf-8');
   } catch (err) {
     logger.debug({ err }, '.env file not found, using defaults');
-    return {};
+    content = '';
   }
 
   const result: Record<string, string> = {};
@@ -37,6 +37,15 @@ export function readEnvFile(keys: string[]): Record<string, string> {
       value = value.slice(1, -1);
     }
     if (value) result[key] = value;
+  }
+
+  // Fall back to process.env for any keys not found in the file.
+  // This allows secrets to be injected via environment variables (e.g. --env-file)
+  // when no .env file is present on disk.
+  for (const key of wanted) {
+    if (!result[key] && process.env[key]) {
+      result[key] = process.env[key]!;
+    }
   }
 
   return result;


### PR DESCRIPTION
- Dockerfile.unraid: containerised NanoClaw for Linux/Unraid/Docker deployments
- docker-entrypoint.sh: builds agent image on first boot, pre-creates data dirs
- container-runner.ts: HOST_PROJECT_ROOT env var + toHostPath() for Docker-in-Docker volume mount path translation
- env.ts: fall back to process.env when .env file not present on disk
- config.ts: keep PROJECT_ROOT as process.cwd() (internal paths only)

Tested on Unraid 7 with Docker 27.5.1. Resolves silent agent spawn failures when NanoClaw itself runs inside a container.

## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description
Enables NanoClaw to run as a Docker container on Linux/Unraid systems. When NanoClaw itself runs inside a container and spawns agent containers via the host Docker socket, volume mount paths need to reference the host filesystem rather than the container's internal paths. This PR adds HOST_PROJECT_ROOT env var support and a toHostPath() helper to handle that translation. Also includes a Dockerfile.unraid and docker-entrypoint.sh for reproducible deployments.

## For Skills

- [ ] I have not made any changes to source code
- [ ] My skill contains instructions for Claude to follow (not pre-built code)
- [ ] I tested this skill on a fresh clone
