### PR TITLE
fix: include weekday in message timestamps so agent knows the correct…

### DIFF
--- a/src/timezone.test.ts
+++ b/src/timezone.test.ts
@@ -15,6 +15,7 @@ describe('formatLocalTime', () => {
       '2026-02-04T18:30:00.000Z',
       'America/New_York',
     );
+    expect(result).toContain('Wednesday');
     expect(result).toContain('1:30');
     expect(result).toContain('PM');
     expect(result).toContain('Feb');

--- a/src/timezone.ts
+++ b/src/timezone.ts
@@ -27,6 +27,7 @@ export function formatLocalTime(utcIso: string, timezone: string): string {
   const date = new Date(utcIso);
   return date.toLocaleString('en-US', {
     timeZone: resolveTimezone(timezone),
+    weekday: 'long',
     year: 'numeric',
     month: 'short',
     day: 'numeric',


### PR DESCRIPTION
## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description

formatLocalTime in src/timezone.ts produced timestamps like Mar 9,
2026, 11:59 AM with no weekday. The agent had to infer the day of the week
from the date string alone, and LLMs are unreliable at computing calendar
weekdays for arbitrary dates.

## Changes
- Added weekday: 'long' to the Intl.DateTimeFormat options in formatLocalTime,
so the output now includes the full weekday name

- Updated src/timezone.test.ts to assert the weekday name is present in the
output.

## Test plan

  - [x] Unit tests pass (`npx vitest run src/timezone.test.ts`)
  - [x] Built successfully (`npm run build`)
  - [x] Manually verified on live Telegram session — agent now correctly
  identifies the day of the week without inference errors
