### PR TITLE
fix: add host.docker.internal mapping on all platforms

### DIFF
--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -42,11 +42,9 @@ function detectProxyBindHost(): string {
 
 /** CLI args needed for the container to resolve the host gateway. */
 export function hostGatewayArgs(): string[] {
-  // On Linux, host.docker.internal isn't built-in — add it explicitly
-  if (os.platform() === 'linux') {
-    return ['--add-host=host.docker.internal:host-gateway'];
-  }
-  return [];
+  // Always add host.docker.internal mapping — Docker Desktop doesn't
+  // always resolve it automatically (observed on Windows Docker Desktop).
+  return ['--add-host=host.docker.internal:host-gateway'];
 }
 
 /** Returns CLI args for a readonly bind mount. */


### PR DESCRIPTION
## Summary

- Always add `--add-host=host.docker.internal:host-gateway` regardless of platform
- Docker Desktop on Windows (and potentially macOS) doesn't always resolve `host.docker.internal` automatically
- Previously this was only added on Linux; this fix ensures consistent behavior across all platforms
- The flag is harmless on platforms where it's already resolved natively

## Test plan

- [x] Existing `container-runtime.test.ts` tests pass
- [x] Verified on Windows Docker Desktop: container can reach host services via `host.docker.internal`

?? Generated with [Claude Code](https://claude.com/claude-code)