### PR TITLE
feat: add optional APT_MIRROR build arg for Dockerfile

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -3,6 +3,13 @@
 
 FROM node:22-slim
 
+# Optional: override apt mirror for faster downloads in restricted networks
+# Usage: docker build --build-arg APT_MIRROR=http://mirrors.tuna.tsinghua.edu.cn ...
+ARG APT_MIRROR=
+RUN if [ -n "$APT_MIRROR" ]; then \
+      sed -i "s|http://deb.debian.org|${APT_MIRROR}|g" /etc/apt/sources.list.d/debian.sources; \
+    fi
+
 # Install system dependencies for Chromium
 RUN apt-get update && apt-get install -y \
     chromium \


### PR DESCRIPTION
## Summary

- Add APT_MIRROR build argument to the container Dockerfile
- Allows users in restricted networks to override the default Debian apt mirror at build time
- Default behavior is unchanged when APT_MIRROR is not set

## Usage

```bash
# Default (no change)
docker build .

# With custom mirror
docker build --build-arg APT_MIRROR=http://mirrors.tuna.tsinghua.edu.cn .
```

## Test plan

- [x] Build without APT_MIRROR: uses default deb.debian.org
- [x] Build with APT_MIRROR set: packages install from mirror