### PR TITLE
fix: remove broken .env shadow mount for Apple Container

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -76,16 +76,12 @@ function buildVolumeMounts(
       readonly: true,
     });
 
-    // Shadow .env so the agent cannot read secrets from the mounted project root.
-    // Credentials are injected by the credential proxy, never exposed to containers.
-    const envFile = path.join(projectRoot, '.env');
-    if (fs.existsSync(envFile)) {
-      mounts.push({
-        hostPath: '/dev/null',
-        containerPath: '/workspace/project/.env',
-        readonly: true,
-      });
-    }
+    // NOTE: .env shadow mount removed — Apple Container doesn't support
+    // overlaying a file mount on a path from a parent directory mount.
+    // The .env is visible read-only inside the container. API credentials
+    // use placeholders (injected by the credential proxy), but other secrets
+    // (e.g. GH_TOKEN) are exposed. Acceptable risk: project mount is read-only,
+    // and the agent already receives GH_TOKEN via env var for gh CLI access.
 
     // Main also gets its group folder as the working directory
     mounts.push({


### PR DESCRIPTION
## Summary
- Remove the `.env` shadow mount in `buildVolumeMounts()` that breaks on Apple Container
- `/dev/null` is rejected as a bind-mount source, and file-on-file overlays within a parent directory mount fail
- Replace with a comment documenting the acceptable-risk tradeoff (project mount is read-only, credentials use proxy placeholders)

Fixes #1104

## Test plan
- [ ] Manual verification: run `npm run build` to confirm no TypeScript errors
- [ ] Manual verification: spawn a main-group container on Apple Container and confirm it starts without bind-mount errors
- [ ] Verify `.env` is visible read-only inside the container (expected behavior after this change)
- [ ] Verify credential proxy still injects API credentials correctly (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)