### PR TITLE
fix: inject GH_TOKEN into containers for macOS Keychain

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -26,6 +26,7 @@ import {
   stopContainer,
 } from './container-runtime.js';
 import { detectAuthMode } from './credential-proxy.js';
+import { readEnvFile } from './env.js';
 import { validateAdditionalMounts } from './mount-security.js';
 import { RegisteredGroup } from './types.js';
 
@@ -236,6 +237,13 @@ function buildContainerArgs(
     args.push('-e', 'ANTHROPIC_API_KEY=placeholder');
   } else {
     args.push('-e', 'CLAUDE_CODE_OAUTH_TOKEN=placeholder');
+  }
+
+  // GitHub CLI token — gh stores tokens in macOS Keychain, which containers
+  // can't access. Inject GH_TOKEN so the gh CLI works inside the container.
+  const secrets = readEnvFile(['GH_TOKEN']);
+  if (secrets.GH_TOKEN) {
+    args.push('-e', `GH_TOKEN=${secrets.GH_TOKEN}`);
   }
 
   // Runtime-specific args for host gateway resolution


### PR DESCRIPTION
## Summary
- Inject `GH_TOKEN` from `.env` into containers so the `gh` CLI works inside them
- macOS Keychain is inaccessible from containers, so tokens must be passed explicitly as environment variables
- Reads `GH_TOKEN` via the existing `readEnvFile()` helper and adds it to the container args

Fixes #1105

## Test plan
- [ ] Add `GH_TOKEN=ghp_...` to `.env`
- [ ] Trigger a container run and verify `GH_TOKEN` is present inside (`env | grep GH_TOKEN`)
- [ ] Run `gh auth status` inside the container and confirm it authenticates successfully
- [ ] Verify that when `GH_TOKEN` is absent from `.env`, no extra env var is injected

🤖 Generated with [Claude Code](https://claude.com/claude-code)