### PR TITLE
fix: Apple Container networking (host gateway + proxy bind)

### DIFF
--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -12,11 +12,26 @@ import { logger } from './logger.js';
 export const CONTAINER_RUNTIME_BIN = 'docker';
 
 /** Hostname containers use to reach the host machine. */
-export const CONTAINER_HOST_GATEWAY = 'host.docker.internal';
+export const CONTAINER_HOST_GATEWAY = detectHostGateway();
+
+function detectHostGateway(): string {
+  if (process.env.CONTAINER_HOST_GATEWAY) return process.env.CONTAINER_HOST_GATEWAY;
+
+  // Apple Container uses a well-known bridge IP (192.168.64.1) instead of
+  // Docker Desktop's host.docker.internal magic hostname.  The bridge100
+  // interface doesn't exist until a container starts, so we hardcode the IP.
+  if (os.platform() === 'darwin' && (CONTAINER_RUNTIME_BIN as string) === 'container') {
+    return '192.168.64.1';
+  }
+
+  return 'host.docker.internal';
+}
 
 /**
  * Address the credential proxy binds to.
- * Docker Desktop (macOS): 127.0.0.1 — the VM routes host.docker.internal to loopback.
+ * macOS: 0.0.0.0 — Apple Container's bridge100 interface doesn't exist at
+ *   startup so we can't bind to it directly; binding all interfaces works for
+ *   both Apple Container and Docker Desktop.
  * Docker (Linux): bind to the docker0 bridge IP so only containers can reach it,
  *   falling back to 0.0.0.0 if the interface isn't found.
  */
@@ -24,7 +39,7 @@ export const PROXY_BIND_HOST =
   process.env.CREDENTIAL_PROXY_HOST || detectProxyBindHost();
 
 function detectProxyBindHost(): string {
-  if (os.platform() === 'darwin') return '127.0.0.1';
+  if (os.platform() === 'darwin') return '0.0.0.0';
 
   // WSL uses Docker Desktop (same VM routing as macOS) — loopback is correct.
   // Check /proc filesystem, not env vars — WSL_DISTRO_NAME isn't set under systemd.


### PR DESCRIPTION
## Summary
- Add `detectHostGateway()` function that returns `192.168.64.1` for Apple Container on macOS (its well-known bridge IP), with `CONTAINER_HOST_GATEWAY` env override support. Falls back to `host.docker.internal` for Docker Desktop / Linux.
- Change `detectProxyBindHost()` on macOS from `127.0.0.1` to `0.0.0.0` — Apple Container's `bridge100` interface doesn't exist at startup, so we bind all interfaces. This also works correctly for Docker Desktop.

Fixes #1103

## Test plan
- [ ] Manual verification with Apple Container: start a container and confirm it can reach the host via `192.168.64.1`
- [ ] Verify credential proxy is reachable from inside the container on the bound address
- [ ] Confirm Docker Desktop on macOS still works (host.docker.internal, 0.0.0.0 bind)
- [ ] Confirm `CONTAINER_HOST_GATEWAY` env override takes precedence when set
- [ ] `npm run build` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)