### PR TITLE
fix: self-heal stale sessions and fix IPC file permissions

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -511,7 +511,20 @@ async function main(): Promise<void> {
     while (true) {
       log(`Starting query (session: ${sessionId || 'new'}, resumeAt: ${resumeAt || 'latest'})...`);
 
-      const queryResult = await runQuery(prompt, sessionId, mcpServerPath, containerInput, sdkEnv, resumeAt);
+      let queryResult: Awaited<ReturnType<typeof runQuery>>;
+      try {
+        queryResult = await runQuery(prompt, sessionId, mcpServerPath, containerInput, sdkEnv, resumeAt);
+      } catch (resumeErr) {
+        const msg = resumeErr instanceof Error ? resumeErr.message : String(resumeErr);
+        if (sessionId && msg.includes('No conversation found with session ID')) {
+          log(`Session ${sessionId} not found on disk — retrying as new session`);
+          sessionId = undefined;
+          resumeAt = undefined;
+          queryResult = await runQuery(prompt, sessionId, mcpServerPath, containerInput, sdkEnv, resumeAt);
+        } else {
+          throw resumeErr;
+        }
+      }
       if (queryResult.newSessionId) {
         sessionId = queryResult.newSessionId;
       }

--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -165,11 +165,11 @@ export class GroupQueue {
 
     const inputDir = path.join(DATA_DIR, 'ipc', state.groupFolder, 'input');
     try {
-      fs.mkdirSync(inputDir, { recursive: true });
+      fs.mkdirSync(inputDir, { recursive: true, mode: 0o777 });
       const filename = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}.json`;
       const filepath = path.join(inputDir, filename);
       const tempPath = `${filepath}.tmp`;
-      fs.writeFileSync(tempPath, JSON.stringify({ type: 'message', text }));
+      fs.writeFileSync(tempPath, JSON.stringify({ type: 'message', text }), { mode: 0o666 });
       fs.renameSync(tempPath, filepath);
       return true;
     } catch {
@@ -186,8 +186,8 @@ export class GroupQueue {
 
     const inputDir = path.join(DATA_DIR, 'ipc', state.groupFolder, 'input');
     try {
-      fs.mkdirSync(inputDir, { recursive: true });
-      fs.writeFileSync(path.join(inputDir, '_close'), '');
+      fs.mkdirSync(inputDir, { recursive: true, mode: 0o777 });
+      fs.writeFileSync(path.join(inputDir, '_close'), '', { mode: 0o666 });
     } catch {
       // ignore
     }


### PR DESCRIPTION
Two bugs that cause silent failures when the host runs as root and containers run as a non-root user (the default Docker setup).

**Stale session self-healing** (`container/agent-runner/src/index.ts`): When Claude Code session transcript files are missing (after a container rebuild, first-run mount timing, or any disruption to the .claude directory), the SDK throws "No conversation found with session ID: ...". Previously this caused the agent-runner to crash, the host to retry up to 6 times with the same dead session ID, and then drop the message entirely — the user never received a response.

The fix catches this specific error and immediately retries without a session ID, starting a fresh session. The new session ID is then stored and used on subsequent runs.

**IPC file permissions** (`src/group-queue.ts`):
IPC input files and directories were created with default umask permissions (typically 644/755), owned by root. The container's node user could read them but not delete them, producing repeated "EACCES: permission denied, unlink" errors. Files accumulated in the IPC directory and were re-processed on every poll cycle.

The fix creates IPC directories with mode 0o777 and files with mode 0o666 so the container user can clean up after itself.

## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description


## For Skills

- [ ] I have not made any changes to source code
- [ ] My skill contains instructions for Claude to follow (not pre-built code)
- [ ] I tested this skill on a fresh clone
