### PR TITLE
feat: Apple Container support + image vision + emoji reactions

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -27,7 +27,19 @@ interface ContainerInput {
   isMain: boolean;
   isScheduledTask?: boolean;
   assistantName?: string;
+  imageAttachments?: Array<{ relativePath: string; mediaType: string }>;
+
 }
+
+interface ImageContentBlock {
+  type: 'image';
+  source: { type: 'base64'; media_type: string; data: string };
+}
+interface TextContentBlock {
+  type: 'text';
+  text: string;
+}
+type ContentBlock = ImageContentBlock | TextContentBlock;
 
 interface ContainerOutput {
   status: 'success' | 'error';
@@ -49,7 +61,7 @@ interface SessionsIndex {
 
 interface SDKUserMessage {
   type: 'user';
-  message: { role: 'user'; content: string };
+  message: { role: 'user'; content: string | ContentBlock[] };
   parent_tool_use_id: null;
   session_id: string;
 }
@@ -71,6 +83,16 @@ class MessageStream {
     this.queue.push({
       type: 'user',
       message: { role: 'user', content: text },
+      parent_tool_use_id: null,
+      session_id: '',
+    });
+    this.waiting?.();
+  }
+
+  pushMultimodal(content: ContentBlock[]): void {
+    this.queue.push({
+      type: 'user',
+      message: { role: 'user', content },
       parent_tool_use_id: null,
       session_id: '',
     });
@@ -339,6 +361,23 @@ async function runQuery(
 ): Promise<{ newSessionId?: string; lastAssistantUuid?: string; closedDuringQuery: boolean }> {
   const stream = new MessageStream();
   stream.push(prompt);
+
+  // Load image attachments and send as multimodal content blocks
+  if (containerInput.imageAttachments?.length) {
+    const blocks: ContentBlock[] = [];
+    for (const img of containerInput.imageAttachments) {
+      const imgPath = path.join('/workspace/group', img.relativePath);
+      try {
+        const data = fs.readFileSync(imgPath).toString('base64');
+        blocks.push({ type: 'image', source: { type: 'base64', media_type: img.mediaType, data } });
+      } catch (err) {
+        log(`Failed to load image: ${imgPath}`);
+      }
+    }
+    if (blocks.length > 0) {
+      stream.pushMultimodal(blocks);
+    }
+  }
 
   // Poll IPC for follow-up messages and _close sentinel during the query
   let ipcPolling = true;

--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -41,10 +41,15 @@ const server = new McpServer({
 
 server.tool(
   'send_message',
-  "Send a message to the user or group immediately while you're still running. Use this for progress updates or to send multiple messages. You can call this multiple times.",
+  "Send a message to the user or group immediately while you're still running. Use this for progress updates or to send multiple messages. You can call this multiple times. Note: when running as a scheduled task, your final output is NOT sent to the user — use this tool if you need to communicate with the user or group.",
   {
     text: z.string().describe('The message text to send'),
-    sender: z.string().optional().describe('Your role/identity name (e.g. "Researcher"). When set, messages appear from a dedicated bot in Telegram.'),
+    sender: z
+      .string()
+      .optional()
+      .describe(
+        'Your role/identity name (e.g. "Researcher"). When set, messages appear from a dedicated bot in Telegram.',
+      ),
   },
   async (args) => {
     const data: Record<string, string | undefined> = {
@@ -63,8 +68,42 @@ server.tool(
 );
 
 server.tool(
+  'react_to_message',
+  'React to a message with an emoji. Omit message_id to react to the most recent message in the chat.',
+  {
+    emoji: z
+      .string()
+      .describe('The emoji to react with (e.g. "👍", "❤️", "🔥")'),
+    message_id: z
+      .string()
+      .optional()
+      .describe(
+        'The message ID to react to. If omitted, reacts to the latest message in the chat.',
+      ),
+  },
+  async (args) => {
+    const data: Record<string, string | undefined> = {
+      type: 'reaction',
+      chatJid,
+      emoji: args.emoji,
+      messageId: args.message_id || undefined,
+      groupFolder,
+      timestamp: new Date().toISOString(),
+    };
+
+    writeIpcFile(MESSAGES_DIR, data);
+
+    return {
+      content: [
+        { type: 'text' as const, text: `Reaction ${args.emoji} sent.` },
+      ],
+    };
+  },
+);
+
+server.tool(
   'schedule_task',
-  `Schedule a recurring or one-time task. The task will run as a full agent with access to all tools. Returns the task ID for future reference. To modify an existing task, use update_task instead.
+  `Schedule a recurring or one-time task. The task will run as a full agent with access to all tools.
 
 CONTEXT MODE - Choose based on task type:
 \u2022 "group": Task runs in the group's conversation context, with access to chat history. Use for tasks that need context about ongoing discussions, user preferences, or recent interactions.
@@ -86,11 +125,33 @@ SCHEDULE VALUE FORMAT (all times are LOCAL timezone):
 \u2022 interval: Milliseconds between runs (e.g., "300000" for 5 minutes, "3600000" for 1 hour)
 \u2022 once: Local time WITHOUT "Z" suffix (e.g., "2026-02-01T15:30:00"). Do NOT use UTC/Z suffix.`,
   {
-    prompt: z.string().describe('What the agent should do when the task runs. For isolated mode, include all necessary context here.'),
-    schedule_type: z.enum(['cron', 'interval', 'once']).describe('cron=recurring at specific times, interval=recurring every N ms, once=run once at specific time'),
-    schedule_value: z.string().describe('cron: "*/5 * * * *" | interval: milliseconds like "300000" | once: local timestamp like "2026-02-01T15:30:00" (no Z suffix!)'),
-    context_mode: z.enum(['group', 'isolated']).default('group').describe('group=runs with chat history and memory, isolated=fresh session (include context in prompt)'),
-    target_group_jid: z.string().optional().describe('(Main group only) JID of the group to schedule the task for. Defaults to the current group.'),
+    prompt: z
+      .string()
+      .describe(
+        'What the agent should do when the task runs. For isolated mode, include all necessary context here.',
+      ),
+    schedule_type: z
+      .enum(['cron', 'interval', 'once'])
+      .describe(
+        'cron=recurring at specific times, interval=recurring every N ms, once=run once at specific time',
+      ),
+    schedule_value: z
+      .string()
+      .describe(
+        'cron: "*/5 * * * *" | interval: milliseconds like "300000" | once: local timestamp like "2026-02-01T15:30:00" (no Z suffix!)',
+      ),
+    context_mode: z
+      .enum(['group', 'isolated'])
+      .default('group')
+      .describe(
+        'group=runs with chat history and memory, isolated=fresh session (include context in prompt)',
+      ),
+    target_group_jid: z
+      .string()
+      .optional()
+      .describe(
+        '(Main group only) JID of the group to schedule the task for. Defaults to the current group.',
+      ),
   },
   async (args) => {
     // Validate schedule_value before writing IPC
@@ -99,7 +160,12 @@ SCHEDULE VALUE FORMAT (all times are LOCAL timezone):
         CronExpressionParser.parse(args.schedule_value);
       } catch {
         return {
-          content: [{ type: 'text' as const, text: `Invalid cron: "${args.schedule_value}". Use format like "0 9 * * *" (daily 9am) or "*/5 * * * *" (every 5 min).` }],
+          content: [
+            {
+              type: 'text' as const,
+              text: `Invalid cron: "${args.schedule_value}". Use format like "0 9 * * *" (daily 9am) or "*/5 * * * *" (every 5 min).`,
+            },
+          ],
           isError: true,
         };
       }
@@ -107,34 +173,50 @@ SCHEDULE VALUE FORMAT (all times are LOCAL timezone):
       const ms = parseInt(args.schedule_value, 10);
       if (isNaN(ms) || ms <= 0) {
         return {
-          content: [{ type: 'text' as const, text: `Invalid interval: "${args.schedule_value}". Must be positive milliseconds (e.g., "300000" for 5 min).` }],
+          content: [
+            {
+              type: 'text' as const,
+              text: `Invalid interval: "${args.schedule_value}". Must be positive milliseconds (e.g., "300000" for 5 min).`,
+            },
+          ],
           isError: true,
         };
       }
     } else if (args.schedule_type === 'once') {
-      if (/[Zz]$/.test(args.schedule_value) || /[+-]\d{2}:\d{2}$/.test(args.schedule_value)) {
+      if (
+        /[Zz]$/.test(args.schedule_value) ||
+        /[+-]\d{2}:\d{2}$/.test(args.schedule_value)
+      ) {
         return {
-          content: [{ type: 'text' as const, text: `Timestamp must be local time without timezone suffix. Got "${args.schedule_value}" — use format like "2026-02-01T15:30:00".` }],
+          content: [
+            {
+              type: 'text' as const,
+              text: `Timestamp must be local time without timezone suffix. Got "${args.schedule_value}" — use format like "2026-02-01T15:30:00".`,
+            },
+          ],
           isError: true,
         };
       }
       const date = new Date(args.schedule_value);
       if (isNaN(date.getTime())) {
         return {
-          content: [{ type: 'text' as const, text: `Invalid timestamp: "${args.schedule_value}". Use local time format like "2026-02-01T15:30:00".` }],
+          content: [
+            {
+              type: 'text' as const,
+              text: `Invalid timestamp: "${args.schedule_value}". Use local time format like "2026-02-01T15:30:00".`,
+            },
+          ],
           isError: true,
         };
       }
     }
 
     // Non-main groups can only schedule for themselves
-    const targetJid = isMain && args.target_group_jid ? args.target_group_jid : chatJid;
-
-    const taskId = `task-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const targetJid =
+      isMain && args.target_group_jid ? args.target_group_jid : chatJid;
 
     const data = {
       type: 'schedule_task',
-      taskId,
       prompt: args.prompt,
       schedule_type: args.schedule_type,
       schedule_value: args.schedule_value,
@@ -144,10 +226,15 @@ SCHEDULE VALUE FORMAT (all times are LOCAL timezone):
       timestamp: new Date().toISOString(),
     };
 
-    writeIpcFile(TASKS_DIR, data);
+    const filename = writeIpcFile(TASKS_DIR, data);
 
     return {
-      content: [{ type: 'text' as const, text: `Task ${taskId} scheduled: ${args.schedule_type} - ${args.schedule_value}` }],
+      content: [
+        {
+          type: 'text' as const,
+          text: `Task scheduled (${filename}): ${args.schedule_type} - ${args.schedule_value}`,
+        },
+      ],
     };
   },
 );
@@ -161,30 +248,56 @@ server.tool(
 
     try {
       if (!fs.existsSync(tasksFile)) {
-        return { content: [{ type: 'text' as const, text: 'No scheduled tasks found.' }] };
+        return {
+          content: [
+            { type: 'text' as const, text: 'No scheduled tasks found.' },
+          ],
+        };
       }
 
       const allTasks = JSON.parse(fs.readFileSync(tasksFile, 'utf-8'));
 
       const tasks = isMain
         ? allTasks
-        : allTasks.filter((t: { groupFolder: string }) => t.groupFolder === groupFolder);
+        : allTasks.filter(
+            (t: { groupFolder: string }) => t.groupFolder === groupFolder,
+          );
 
       if (tasks.length === 0) {
-        return { content: [{ type: 'text' as const, text: 'No scheduled tasks found.' }] };
+        return {
+          content: [
+            { type: 'text' as const, text: 'No scheduled tasks found.' },
+          ],
+        };
       }
 
       const formatted = tasks
         .map(
-          (t: { id: string; prompt: string; schedule_type: string; schedule_value: string; status: string; next_run: string }) =>
+          (t: {
+            id: string;
+            prompt: string;
+            schedule_type: string;
+            schedule_value: string;
+            status: string;
+            next_run: string;
+          }) =>
             `- [${t.id}] ${t.prompt.slice(0, 50)}... (${t.schedule_type}: ${t.schedule_value}) - ${t.status}, next: ${t.next_run || 'N/A'}`,
         )
         .join('\n');
 
-      return { content: [{ type: 'text' as const, text: `Scheduled tasks:\n${formatted}` }] };
+      return {
+        content: [
+          { type: 'text' as const, text: `Scheduled tasks:\n${formatted}` },
+        ],
+      };
     } catch (err) {
       return {
-        content: [{ type: 'text' as const, text: `Error reading tasks: ${err instanceof Error ? err.message : String(err)}` }],
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error reading tasks: ${err instanceof Error ? err.message : String(err)}`,
+          },
+        ],
       };
     }
   },
@@ -205,7 +318,14 @@ server.tool(
 
     writeIpcFile(TASKS_DIR, data);
 
-    return { content: [{ type: 'text' as const, text: `Task ${args.task_id} pause requested.` }] };
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: `Task ${args.task_id} pause requested.`,
+        },
+      ],
+    };
   },
 );
 
@@ -224,7 +344,14 @@ server.tool(
 
     writeIpcFile(TASKS_DIR, data);
 
-    return { content: [{ type: 'text' as const, text: `Task ${args.task_id} resume requested.` }] };
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: `Task ${args.task_id} resume requested.`,
+        },
+      ],
+    };
   },
 );
 
@@ -243,57 +370,14 @@ server.tool(
 
     writeIpcFile(TASKS_DIR, data);
 
-    return { content: [{ type: 'text' as const, text: `Task ${args.task_id} cancellation requested.` }] };
-  },
-);
-
-server.tool(
-  'update_task',
-  'Update an existing scheduled task. Only provided fields are changed; omitted fields stay the same.',
-  {
-    task_id: z.string().describe('The task ID to update'),
-    prompt: z.string().optional().describe('New prompt for the task'),
-    schedule_type: z.enum(['cron', 'interval', 'once']).optional().describe('New schedule type'),
-    schedule_value: z.string().optional().describe('New schedule value (see schedule_task for format)'),
-  },
-  async (args) => {
-    // Validate schedule_value if provided
-    if (args.schedule_type === 'cron' || (!args.schedule_type && args.schedule_value)) {
-      if (args.schedule_value) {
-        try {
-          CronExpressionParser.parse(args.schedule_value);
-        } catch {
-          return {
-            content: [{ type: 'text' as const, text: `Invalid cron: "${args.schedule_value}".` }],
-            isError: true,
-          };
-        }
-      }
-    }
-    if (args.schedule_type === 'interval' && args.schedule_value) {
-      const ms = parseInt(args.schedule_value, 10);
-      if (isNaN(ms) || ms <= 0) {
-        return {
-          content: [{ type: 'text' as const, text: `Invalid interval: "${args.schedule_value}".` }],
-          isError: true,
-        };
-      }
-    }
-
-    const data: Record<string, string | undefined> = {
-      type: 'update_task',
-      taskId: args.task_id,
-      groupFolder,
-      isMain: String(isMain),
-      timestamp: new Date().toISOString(),
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: `Task ${args.task_id} cancellation requested.`,
+        },
+      ],
     };
-    if (args.prompt !== undefined) data.prompt = args.prompt;
-    if (args.schedule_type !== undefined) data.schedule_type = args.schedule_type;
-    if (args.schedule_value !== undefined) data.schedule_value = args.schedule_value;
-
-    writeIpcFile(TASKS_DIR, data);
-
-    return { content: [{ type: 'text' as const, text: `Task ${args.task_id} update requested.` }] };
   },
 );
 
@@ -303,15 +387,28 @@ server.tool(
 
 Use available_groups.json to find the JID for a group. The folder name must be channel-prefixed: "{channel}_{group-name}" (e.g., "whatsapp_family-chat", "telegram_dev-team", "discord_general"). Use lowercase with hyphens for the group name part.`,
   {
-    jid: z.string().describe('The chat JID (e.g., "120363336345536173@g.us", "tg:-1001234567890", "dc:1234567890123456")'),
+    jid: z
+      .string()
+      .describe(
+        'The chat JID (e.g., "120363336345536173@g.us", "tg:-1001234567890", "dc:1234567890123456")',
+      ),
     name: z.string().describe('Display name for the group'),
-    folder: z.string().describe('Channel-prefixed folder name (e.g., "whatsapp_family-chat", "telegram_dev-team")'),
+    folder: z
+      .string()
+      .describe(
+        'Channel-prefixed folder name (e.g., "whatsapp_family-chat", "telegram_dev-team")',
+      ),
     trigger: z.string().describe('Trigger word (e.g., "@Andy")'),
   },
   async (args) => {
     if (!isMain) {
       return {
-        content: [{ type: 'text' as const, text: 'Only the main group can register new groups.' }],
+        content: [
+          {
+            type: 'text' as const,
+            text: 'Only the main group can register new groups.',
+          },
+        ],
         isError: true,
       };
     }
@@ -328,7 +425,12 @@ Use available_groups.json to find the JID for a group. The folder name must be c
     writeIpcFile(TASKS_DIR, data);
 
     return {
-      content: [{ type: 'text' as const, text: `Group "${args.name}" registered. It will start receiving messages immediately.` }],
+      content: [
+        {
+          type: 'text' as const,
+          text: `Group "${args.name}" registered. It will start receiving messages immediately.`,
+        },
+      ],
     };
   },
 );

--- a/container/skills/reactions/SKILL.md
+++ b/container/skills/reactions/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: reactions
+description: React to WhatsApp messages with emoji. Use when the user asks you to react, when acknowledging a message with a reaction makes sense, or when you want to express a quick response without sending a full message.
+---
+
+# Reactions
+
+React to messages with emoji using the `mcp__nanoclaw__react_to_message` tool.
+
+## When to use
+
+- User explicitly asks you to react ("react with a thumbs up", "heart that message")
+- Quick acknowledgment is more appropriate than a full text reply
+- Expressing agreement, approval, or emotion about a specific message
+
+## How to use
+
+### React to the latest message
+
+```
+mcp__nanoclaw__react_to_message(emoji: "👍")
+```
+
+Omitting `message_id` reacts to the most recent message in the chat.
+
+### React to a specific message
+
+```
+mcp__nanoclaw__react_to_message(emoji: "❤️", message_id: "3EB0F4C9E7...")
+```
+
+Pass a `message_id` to react to a specific message. You can find message IDs by querying the messages database:
+
+```bash
+sqlite3 /workspace/project/store/messages.db "
+  SELECT id, sender_name, substr(content, 1, 80), timestamp
+  FROM messages
+  WHERE chat_jid = '<chat_jid>'
+  ORDER BY timestamp DESC
+  LIMIT 5;
+"
+```
+
+### Remove a reaction
+
+Send an empty string to remove your reaction:
+
+```
+mcp__nanoclaw__react_to_message(emoji: "")
+```
+
+## Common emoji
+
+| Emoji | When to use |
+|-------|-------------|
+| 👍 | Acknowledgment, approval |
+| ❤️ | Appreciation, love |
+| 😂 | Something funny |
+| 🔥 | Impressive, exciting |
+| 🎉 | Celebration, congrats |
+| 🙏 | Thanks, prayer |
+| ✅ | Task done, confirmed |
+| ❓ | Needs clarification |

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,16 +8,22 @@
       "name": "nanoclaw",
       "version": "1.2.14",
       "dependencies": {
+        "@whiskeysockets/baileys": "^7.0.0-rc.9",
         "better-sqlite3": "^11.8.1",
         "cron-parser": "^5.5.0",
+        "grammy": "^1.39.3",
         "pino": "^9.6.0",
         "pino-pretty": "^13.0.0",
+        "qrcode": "^1.5.4",
+        "qrcode-terminal": "^0.12.0",
+        "sharp": "^0.34.5",
         "yaml": "^2.8.2",
         "zod": "^4.3.6"
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.12",
         "@types/node": "^22.10.0",
+        "@types/qrcode-terminal": "^0.12.0",
         "@vitest/coverage-v8": "^4.0.18",
         "husky": "^9.1.7",
         "prettier": "^3.8.1",
@@ -87,6 +93,62 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@cacheable/memory": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.8.tgz",
+      "integrity": "sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/utils": "^2.4.0",
+        "@keyv/bigmap": "^1.3.1",
+        "hookified": "^1.15.1",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/node-cache": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@cacheable/node-cache/-/node-cache-1.7.6.tgz",
+      "integrity": "sha512-6Omk2SgNnjtxB5f/E6bTIWIt5xhdpx39fGNRQgU9lojvRxU68v+qY+SXXLsp3ZGukqoPjsK21wZ6XABFr/Ge3A==",
+      "license": "MIT",
+      "dependencies": {
+        "cacheable": "^2.3.1",
+        "hookified": "^1.14.0",
+        "keyv": "^5.5.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cacheable/utils": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.4.0.tgz",
+      "integrity": "sha512-PeMMsqjVq+bF0WBsxFBxr/WozBJiZKY0rUojuaCoIaKnEl3Ju1wfEwS+SV1DU/cSe8fqHIPiYJFif8T3MVt4cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.5.0",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
+      "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -531,6 +593,492 @@
         "node": ">=18"
       }
     },
+    "node_modules/@grammyjs/types": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@grammyjs/types/-/types-3.25.0.tgz",
+      "integrity": "sha512-iN9i5p+8ZOu9OMxWNcguojQfz4K/PDyMPOnL7PPCON+SoA/F8OKMH3uR7CVUkYfdNe0GCz8QOzAWrnqusQYFOg==",
+      "license": "MIT"
+    },
+    "node_modules/@hapi/boom": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
+      "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -559,11 +1107,97 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@keyv/bigmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+      "integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.4.0",
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+      "license": "MIT"
+    },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
       "license": "MIT"
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.57.1",
@@ -922,6 +1556,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
@@ -957,15 +1614,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
       "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/qrcode-terminal": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/qrcode-terminal/-/qrcode-terminal-0.12.2.tgz",
+      "integrity": "sha512-v+RcIEJ+Uhd6ygSQ0u5YYY7ZM+la7GgPbs0V/7l/kFs2uO4S8BcIUEMoP7za4DNIqNnUD5npf0A/7kBhrCKG5Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.0.18",
@@ -1109,6 +1778,81 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@whiskeysockets/baileys": {
+      "version": "7.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@whiskeysockets/baileys/-/baileys-7.0.0-rc.9.tgz",
+      "integrity": "sha512-YFm5gKXfDP9byCXCW3OPHKXLzrAKzolzgVUlRosHHgwbnf2YOO3XknkMm6J7+F0ns8OA0uuSBhgkRHTDtqkacw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/node-cache": "^1.4.0",
+        "@hapi/boom": "^9.1.3",
+        "async-mutex": "^0.5.0",
+        "libsignal": "git+https://github.com/whiskeysockets/libsignal-node.git",
+        "lru-cache": "^11.1.0",
+        "music-metadata": "^11.7.0",
+        "p-queue": "^9.0.0",
+        "pino": "^9.6",
+        "protobufjs": "^7.2.4",
+        "ws": "^8.13.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "audio-decode": "^2.1.3",
+        "jimp": "^1.6.0",
+        "link-preview-js": "^3.0.0",
+        "sharp": "*"
+      },
+      "peerDependenciesMeta": {
+        "audio-decode": {
+          "optional": true
+        },
+        "jimp": {
+          "optional": true
+        },
+        "link-preview-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1129,6 +1873,15 @@
         "@jridgewell/trace-mapping": "^0.3.31",
         "estree-walker": "^3.0.3",
         "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/atomic-sleep": {
@@ -1215,6 +1968,28 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/cacheable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.3.tgz",
+      "integrity": "sha512-iffYMX4zxKp54evOH27fm92hs+DeC1DhXmNVN8Tr94M/iZIV42dqTHSR2Ik4TOSPyOAwKr7Yu3rN9ALoLkbWyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/memory": "^2.0.8",
+        "@cacheable/utils": "^2.4.0",
+        "hookified": "^1.15.0",
+        "keyv": "^5.6.0",
+        "qified": "^0.6.0"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -1231,11 +2006,49 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
     },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
     "node_modules/colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "license": "MIT"
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/cron-parser": {
       "version": "5.5.0",
@@ -1249,6 +2062,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/curve25519-js": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/curve25519-js/-/curve25519-js-0.0.4.tgz",
+      "integrity": "sha512-axn2UMEnkhyDUPWOwVKBMVIzSQy2ejH2xRGy1wq81dqRwApXfIzfbE3hIX0ZRFBIihf/KDqK158DLwESu4AK1w==",
+      "license": "MIT"
+    },
     "node_modules/dateformat": {
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
@@ -1256,6 +2075,32 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/decompress-response": {
@@ -1290,6 +2135,18 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -1359,6 +2216,21 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -1408,11 +2280,42 @@
         }
       }
     },
+    "node_modules/file-type": {
+      "version": "21.3.2",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.2.tgz",
+      "integrity": "sha512-DLkUvGwep3poOV2wpzbHCOnSKGk1LzyXTv+aHFgN2VFl96wnp8YA9YjO2qPzg5PuL8q/SW9Pdi6WTkYOIh995w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "license": "MIT"
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/fs-constants": {
       "version": "1.0.0",
@@ -1435,6 +2338,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
@@ -1454,6 +2366,21 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
     },
+    "node_modules/grammy": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/grammy/-/grammy-1.41.1.tgz",
+      "integrity": "sha512-wcHAQ1e7svL3fJMpDchcQVcWUmywhuepOOjHUHmMmWAwUJEIyK5ea5sbSjZd+Gy1aMpZeP8VYJa+4tP+j1YptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@grammyjs/types": "3.25.0",
+        "abort-controller": "^3.0.0",
+        "debug": "^4.4.3",
+        "node-fetch": "^2.7.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || >=14.13.1"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1464,10 +2391,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/hashery": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.0.tgz",
+      "integrity": "sha512-nhQ6ExaOIqti2FDWoEMWARUqIKyjr2VcZzXShrI+A3zpeiuPWzx6iPftt44LhP74E5sW36B75N6VHbvRtpvO6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.14.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/help-me": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
       "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "license": "MIT"
+    },
+    "node_modules/hookified": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+      "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
       "license": "MIT"
     },
     "node_modules/html-escaper": {
@@ -1525,6 +2470,15 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
@@ -1580,6 +2534,91 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/libsignal": {
+      "name": "@whiskeysockets/libsignal-node",
+      "version": "2.0.1",
+      "resolved": "git+ssh://git@github.com/whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67",
+      "license": "GPL-3.0",
+      "dependencies": {
+        "curve25519-js": "^0.0.4",
+        "protobufjs": "6.8.8"
+      }
+    },
+    "node_modules/libsignal/node_modules/@types/node": {
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "license": "MIT"
+    },
+    "node_modules/libsignal/node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/libsignal/node_modules/protobufjs": {
+      "version": "6.8.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
+      "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.0",
+        "@types/node": "^10.1.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/luxon": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
@@ -1627,6 +2666,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/mimic-response": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
@@ -1653,6 +2701,43 @@
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/music-metadata": {
+      "version": "11.12.3",
+      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-11.12.3.tgz",
+      "integrity": "sha512-n6hSTZkuD59qWgHh6IP5dtDlDZQXoxk/bcA85Jywg8Z1iFrlNgl2+GTFgjZyn52W5UgQpV42V4XqrQZZAMbZTQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/Borewit"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://buymeacoffee.com/borewit"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.2",
+        "@tokenizer/token": "^0.3.0",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "file-type": "^21.3.1",
+        "media-typer": "^1.1.0",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.2",
+        "uint8array-extras": "^1.5.0",
+        "win-guid": "^0.2.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -1691,6 +2776,26 @@
         "node": ">=10"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -1720,6 +2825,79 @@
         "wrappy": "1"
       }
     },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.1.0.tgz",
+      "integrity": "sha512-O/ZPaXuQV29uSLbxWBGGZO1mCQXV2BLIwUr59JUU9SoH76mnYvtms7aafH/isNSNGwuEfP6W/4xD0/TJXxrizw==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -1740,6 +2918,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1816,6 +2995,15 @@
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "license": "MIT"
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.6",
@@ -1904,6 +3092,30 @@
       ],
       "license": "MIT"
     },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
@@ -1912,6 +3124,43 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/qified": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/qified/-/qified-0.6.0.tgz",
+      "integrity": "sha512-tsSGN1x3h569ZSU1u6diwhltLyfUWDp3YbFHedapTmpBl0B3P6U3+Qptg7xu+v+1io1EwhdPyyRHYbEw0KN2FA==",
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.14.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode-terminal": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
+      "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
+      "bin": {
+        "qrcode-terminal": "bin/qrcode-terminal.js"
       }
     },
     "node_modules/quick-format-unescaped": {
@@ -1966,6 +3215,21 @@
       "engines": {
         "node": ">= 12.13.0"
       }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
@@ -2079,6 +3343,57 @@
         "node": ">=10"
       }
     },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -2182,6 +3497,32 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
@@ -2192,6 +3533,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strtok3": {
+      "version": "10.3.4",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz",
+      "integrity": "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/supports-color": {
@@ -2288,12 +3645,43 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/tsx": {
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -2334,11 +3722,22 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/util-deprecate": {
@@ -2353,6 +3752,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -2428,6 +3828,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -2500,6 +3901,28 @@
         }
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -2517,10 +3940,57 @@
         "node": ">=8"
       }
     },
+    "node_modules/win-guid": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/win-guid/-/win-guid-0.2.1.tgz",
+      "integrity": "sha512-gEIQU4mkgl2OPeoNrWflcJFJ3Ae2BPd4eCsHHA/XikslkIVms/nHhvnvzIZV7VLmBvtFlDOzLt9rrZT+n6D67A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "license": "ISC"
     },
     "node_modules/yaml": {
@@ -2528,6 +3998,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -2536,6 +4007,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -20,14 +20,20 @@
   },
   "dependencies": {
     "better-sqlite3": "^11.8.1",
+    "grammy": "^1.39.3",
     "cron-parser": "^5.5.0",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",
     "yaml": "^2.8.2",
+    "@whiskeysockets/baileys": "^7.0.0-rc.9",
+    "qrcode": "^1.5.4",
+    "qrcode-terminal": "^0.12.0",
+    "sharp": "^0.34.5",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.12",
+    "@types/qrcode-terminal": "^0.12.0",
     "@types/node": "^22.10.0",
     "@vitest/coverage-v8": "^4.0.18",
     "husky": "^9.1.7",

--- a/scripts/migrate-reactions.ts
+++ b/scripts/migrate-reactions.ts
@@ -1,0 +1,57 @@
+// Database migration script for reactions table
+// Run: npx tsx scripts/migrate-reactions.ts
+
+import Database from 'better-sqlite3';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const STORE_DIR = process.env.STORE_DIR || path.join(process.cwd(), 'store');
+const dbPath = path.join(STORE_DIR, 'messages.db');
+
+console.log(`Migrating database at: ${dbPath}`);
+
+const db = new Database(dbPath);
+
+try {
+  db.transaction(() => {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS reactions (
+        message_id TEXT NOT NULL,
+        message_chat_jid TEXT NOT NULL,
+        reactor_jid TEXT NOT NULL,
+        reactor_name TEXT,
+        emoji TEXT NOT NULL,
+        timestamp TEXT NOT NULL,
+        PRIMARY KEY (message_id, message_chat_jid, reactor_jid)
+      );
+    `);
+
+    console.log('Created reactions table');
+
+    db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_reactions_message ON reactions(message_id, message_chat_jid);
+      CREATE INDEX IF NOT EXISTS idx_reactions_reactor ON reactions(reactor_jid);
+      CREATE INDEX IF NOT EXISTS idx_reactions_emoji ON reactions(emoji);
+      CREATE INDEX IF NOT EXISTS idx_reactions_timestamp ON reactions(timestamp);
+    `);
+
+    console.log('Created indexes');
+  })();
+
+  const tableInfo = db.prepare(`PRAGMA table_info(reactions)`).all();
+  console.log('\nReactions table schema:');
+  console.table(tableInfo);
+
+  const count = db.prepare(`SELECT COUNT(*) as count FROM reactions`).get() as {
+    count: number;
+  };
+  console.log(`\nCurrent reaction count: ${count.count}`);
+
+  console.log('\nMigration complete!');
+} catch (err) {
+  console.error('Migration failed:', err);
+  process.exit(1);
+} finally {
+  db.close();
+}

--- a/setup/service.ts
+++ b/setup/service.ts
@@ -101,7 +101,7 @@ function setupLaunchd(
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/usr/local/bin:/usr/bin:/bin:${homeDir}/.local/bin</string>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${homeDir}/.local/bin</string>
         <key>HOME</key>
         <string>${homeDir}</string>
     </dict>

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -8,5 +8,7 @@
 // slack
 
 // telegram
+import './telegram.js';
 
 // whatsapp
+import './whatsapp.js';

--- a/src/channels/telegram.test.ts
+++ b/src/channels/telegram.test.ts
@@ -1,0 +1,936 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+// --- Mocks ---
+
+// Mock registry (registerChannel runs at import time)
+vi.mock('./registry.js', () => ({ registerChannel: vi.fn() }));
+
+// Mock env reader (used by the factory, not needed in unit tests)
+vi.mock('../env.js', () => ({ readEnvFile: vi.fn(() => ({})) }));
+
+// Mock config
+vi.mock('../config.js', () => ({
+  ASSISTANT_NAME: 'Andy',
+  TRIGGER_PATTERN: /^@Andy\b/i,
+}));
+
+// Mock logger
+vi.mock('../logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// --- Grammy mock ---
+
+type Handler = (...args: any[]) => any;
+
+const botRef = vi.hoisted(() => ({ current: null as any }));
+
+vi.mock('grammy', () => ({
+  Bot: class MockBot {
+    token: string;
+    commandHandlers = new Map<string, Handler>();
+    filterHandlers = new Map<string, Handler[]>();
+    errorHandler: Handler | null = null;
+
+    api = {
+      sendMessage: vi.fn().mockResolvedValue(undefined),
+      sendChatAction: vi.fn().mockResolvedValue(undefined),
+    };
+
+    constructor(token: string) {
+      this.token = token;
+      botRef.current = this;
+    }
+
+    command(name: string, handler: Handler) {
+      this.commandHandlers.set(name, handler);
+    }
+
+    on(filter: string, handler: Handler) {
+      const existing = this.filterHandlers.get(filter) || [];
+      existing.push(handler);
+      this.filterHandlers.set(filter, existing);
+    }
+
+    catch(handler: Handler) {
+      this.errorHandler = handler;
+    }
+
+    start(opts: { onStart: (botInfo: any) => void }) {
+      opts.onStart({ username: 'andy_ai_bot', id: 12345 });
+    }
+
+    stop() {}
+  },
+}));
+
+import { TelegramChannel, TelegramChannelOpts } from './telegram.js';
+
+// --- Test helpers ---
+
+function createTestOpts(
+  overrides?: Partial<TelegramChannelOpts>,
+): TelegramChannelOpts {
+  return {
+    onMessage: vi.fn(),
+    onChatMetadata: vi.fn(),
+    registeredGroups: vi.fn(() => ({
+      'tg:100200300': {
+        name: 'Test Group',
+        folder: 'test-group',
+        trigger: '@Andy',
+        added_at: '2024-01-01T00:00:00.000Z',
+      },
+    })),
+    ...overrides,
+  };
+}
+
+function createTextCtx(overrides: {
+  chatId?: number;
+  chatType?: string;
+  chatTitle?: string;
+  text: string;
+  fromId?: number;
+  firstName?: string;
+  username?: string;
+  messageId?: number;
+  date?: number;
+  entities?: any[];
+}) {
+  const chatId = overrides.chatId ?? 100200300;
+  const chatType = overrides.chatType ?? 'group';
+  return {
+    chat: {
+      id: chatId,
+      type: chatType,
+      title: overrides.chatTitle ?? 'Test Group',
+    },
+    from: {
+      id: overrides.fromId ?? 99001,
+      first_name: overrides.firstName ?? 'Alice',
+      username: overrides.username ?? 'alice_user',
+    },
+    message: {
+      text: overrides.text,
+      date: overrides.date ?? Math.floor(Date.now() / 1000),
+      message_id: overrides.messageId ?? 1,
+      entities: overrides.entities ?? [],
+    },
+    me: { username: 'andy_ai_bot' },
+    reply: vi.fn(),
+  };
+}
+
+function createMediaCtx(overrides: {
+  chatId?: number;
+  chatType?: string;
+  fromId?: number;
+  firstName?: string;
+  date?: number;
+  messageId?: number;
+  caption?: string;
+  extra?: Record<string, any>;
+}) {
+  const chatId = overrides.chatId ?? 100200300;
+  return {
+    chat: {
+      id: chatId,
+      type: overrides.chatType ?? 'group',
+      title: 'Test Group',
+    },
+    from: {
+      id: overrides.fromId ?? 99001,
+      first_name: overrides.firstName ?? 'Alice',
+      username: 'alice_user',
+    },
+    message: {
+      date: overrides.date ?? Math.floor(Date.now() / 1000),
+      message_id: overrides.messageId ?? 1,
+      caption: overrides.caption,
+      ...(overrides.extra || {}),
+    },
+    me: { username: 'andy_ai_bot' },
+  };
+}
+
+function currentBot() {
+  return botRef.current;
+}
+
+async function triggerTextMessage(ctx: ReturnType<typeof createTextCtx>) {
+  const handlers = currentBot().filterHandlers.get('message:text') || [];
+  for (const h of handlers) await h(ctx);
+}
+
+async function triggerMediaMessage(
+  filter: string,
+  ctx: ReturnType<typeof createMediaCtx>,
+) {
+  const handlers = currentBot().filterHandlers.get(filter) || [];
+  for (const h of handlers) await h(ctx);
+}
+
+// --- Tests ---
+
+describe('TelegramChannel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // --- Connection lifecycle ---
+
+  describe('connection lifecycle', () => {
+    it('resolves connect() when bot starts', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+
+      await channel.connect();
+
+      expect(channel.isConnected()).toBe(true);
+    });
+
+    it('registers command and message handlers on connect', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+
+      await channel.connect();
+
+      expect(currentBot().commandHandlers.has('chatid')).toBe(true);
+      expect(currentBot().commandHandlers.has('ping')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:text')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:photo')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:video')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:voice')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:audio')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:document')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:sticker')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:location')).toBe(true);
+      expect(currentBot().filterHandlers.has('message:contact')).toBe(true);
+    });
+
+    it('registers error handler on connect', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+
+      await channel.connect();
+
+      expect(currentBot().errorHandler).not.toBeNull();
+    });
+
+    it('disconnects cleanly', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+
+      await channel.connect();
+      expect(channel.isConnected()).toBe(true);
+
+      await channel.disconnect();
+      expect(channel.isConnected()).toBe(false);
+    });
+
+    it('isConnected() returns false before connect', () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+
+      expect(channel.isConnected()).toBe(false);
+    });
+  });
+
+  // --- Text message handling ---
+
+  describe('text message handling', () => {
+    it('delivers message for registered group', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ text: 'Hello everyone' });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.any(String),
+        'Test Group',
+        'telegram',
+        true,
+      );
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          id: '1',
+          chat_jid: 'tg:100200300',
+          sender: '99001',
+          sender_name: 'Alice',
+          content: 'Hello everyone',
+          is_from_me: false,
+        }),
+      );
+    });
+
+    it('only emits metadata for unregistered chats', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ chatId: 999999, text: 'Unknown chat' });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        'tg:999999',
+        expect.any(String),
+        'Test Group',
+        'telegram',
+        true,
+      );
+      expect(opts.onMessage).not.toHaveBeenCalled();
+    });
+
+    it('skips command messages (starting with /)', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ text: '/start' });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).not.toHaveBeenCalled();
+      expect(opts.onChatMetadata).not.toHaveBeenCalled();
+    });
+
+    it('extracts sender name from first_name', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ text: 'Hi', firstName: 'Bob' });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ sender_name: 'Bob' }),
+      );
+    });
+
+    it('falls back to username when first_name missing', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ text: 'Hi' });
+      ctx.from.first_name = undefined as any;
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ sender_name: 'alice_user' }),
+      );
+    });
+
+    it('falls back to user ID when name and username missing', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ text: 'Hi', fromId: 42 });
+      ctx.from.first_name = undefined as any;
+      ctx.from.username = undefined as any;
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ sender_name: '42' }),
+      );
+    });
+
+    it('uses sender name as chat name for private chats', async () => {
+      const opts = createTestOpts({
+        registeredGroups: vi.fn(() => ({
+          'tg:100200300': {
+            name: 'Private',
+            folder: 'private',
+            trigger: '@Andy',
+            added_at: '2024-01-01T00:00:00.000Z',
+          },
+        })),
+      });
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: 'Hello',
+        chatType: 'private',
+        firstName: 'Alice',
+      });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.any(String),
+        'Alice', // Private chats use sender name
+        'telegram',
+        false,
+      );
+    });
+
+    it('uses chat title as name for group chats', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: 'Hello',
+        chatType: 'supergroup',
+        chatTitle: 'Project Team',
+      });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.any(String),
+        'Project Team',
+        'telegram',
+        true,
+      );
+    });
+
+    it('converts message.date to ISO timestamp', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const unixTime = 1704067200; // 2024-01-01T00:00:00.000Z
+      const ctx = createTextCtx({ text: 'Hello', date: unixTime });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          timestamp: '2024-01-01T00:00:00.000Z',
+        }),
+      );
+    });
+  });
+
+  // --- @mention translation ---
+
+  describe('@mention translation', () => {
+    it('translates @bot_username mention to trigger format', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: '@andy_ai_bot what time is it?',
+        entities: [{ type: 'mention', offset: 0, length: 12 }],
+      });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '@Andy @andy_ai_bot what time is it?',
+        }),
+      );
+    });
+
+    it('does not translate if message already matches trigger', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: '@Andy @andy_ai_bot hello',
+        entities: [{ type: 'mention', offset: 6, length: 12 }],
+      });
+      await triggerTextMessage(ctx);
+
+      // Should NOT double-prepend — already starts with @Andy
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '@Andy @andy_ai_bot hello',
+        }),
+      );
+    });
+
+    it('does not translate mentions of other bots', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: '@some_other_bot hi',
+        entities: [{ type: 'mention', offset: 0, length: 15 }],
+      });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '@some_other_bot hi', // No translation
+        }),
+      );
+    });
+
+    it('handles mention in middle of message', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: 'hey @andy_ai_bot check this',
+        entities: [{ type: 'mention', offset: 4, length: 12 }],
+      });
+      await triggerTextMessage(ctx);
+
+      // Bot is mentioned, message doesn't match trigger → prepend trigger
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '@Andy hey @andy_ai_bot check this',
+        }),
+      );
+    });
+
+    it('handles message with no entities', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ text: 'plain message' });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: 'plain message',
+        }),
+      );
+    });
+
+    it('ignores non-mention entities', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: 'check https://example.com',
+        entities: [{ type: 'url', offset: 6, length: 19 }],
+      });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: 'check https://example.com',
+        }),
+      );
+    });
+  });
+
+  // --- Non-text messages ---
+
+  describe('non-text messages', () => {
+    it('stores photo with placeholder', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({});
+      await triggerMediaMessage('message:photo', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Photo]' }),
+      );
+    });
+
+    it('stores photo with caption', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({ caption: 'Look at this' });
+      await triggerMediaMessage('message:photo', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Photo] Look at this' }),
+      );
+    });
+
+    it('stores video with placeholder', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({});
+      await triggerMediaMessage('message:video', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Video]' }),
+      );
+    });
+
+    it('stores voice message with placeholder', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({});
+      await triggerMediaMessage('message:voice', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Voice message]' }),
+      );
+    });
+
+    it('stores audio with placeholder', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({});
+      await triggerMediaMessage('message:audio', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Audio]' }),
+      );
+    });
+
+    it('stores document with filename', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({
+        extra: { document: { file_name: 'report.pdf' } },
+      });
+      await triggerMediaMessage('message:document', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Document: report.pdf]' }),
+      );
+    });
+
+    it('stores document with fallback name when filename missing', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({ extra: { document: {} } });
+      await triggerMediaMessage('message:document', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Document: file]' }),
+      );
+    });
+
+    it('stores sticker with emoji', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({
+        extra: { sticker: { emoji: '😂' } },
+      });
+      await triggerMediaMessage('message:sticker', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Sticker 😂]' }),
+      );
+    });
+
+    it('stores location with placeholder', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({});
+      await triggerMediaMessage('message:location', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Location]' }),
+      );
+    });
+
+    it('stores contact with placeholder', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({});
+      await triggerMediaMessage('message:contact', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Contact]' }),
+      );
+    });
+
+    it('ignores non-text messages from unregistered chats', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({ chatId: 999999 });
+      await triggerMediaMessage('message:photo', ctx);
+
+      expect(opts.onMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- sendMessage ---
+
+  describe('sendMessage', () => {
+    it('sends message via bot API', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      await channel.sendMessage('tg:100200300', 'Hello');
+
+      expect(currentBot().api.sendMessage).toHaveBeenCalledWith(
+        '100200300',
+        'Hello',
+        { parse_mode: 'Markdown' },
+      );
+    });
+
+    it('strips tg: prefix from JID', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      await channel.sendMessage('tg:-1001234567890', 'Group message');
+
+      expect(currentBot().api.sendMessage).toHaveBeenCalledWith(
+        '-1001234567890',
+        'Group message',
+        { parse_mode: 'Markdown' },
+      );
+    });
+
+    it('splits messages exceeding 4096 characters', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const longText = 'x'.repeat(5000);
+      await channel.sendMessage('tg:100200300', longText);
+
+      expect(currentBot().api.sendMessage).toHaveBeenCalledTimes(2);
+      expect(currentBot().api.sendMessage).toHaveBeenNthCalledWith(
+        1,
+        '100200300',
+        'x'.repeat(4096),
+        { parse_mode: 'Markdown' },
+      );
+      expect(currentBot().api.sendMessage).toHaveBeenNthCalledWith(
+        2,
+        '100200300',
+        'x'.repeat(904),
+        { parse_mode: 'Markdown' },
+      );
+    });
+
+    it('sends exactly one message at 4096 characters', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const exactText = 'y'.repeat(4096);
+      await channel.sendMessage('tg:100200300', exactText);
+
+      expect(currentBot().api.sendMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles send failure gracefully', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      currentBot().api.sendMessage.mockRejectedValueOnce(
+        new Error('Network error'),
+      );
+
+      // Should not throw
+      await expect(
+        channel.sendMessage('tg:100200300', 'Will fail'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('does nothing when bot is not initialized', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+
+      // Don't connect — bot is null
+      await channel.sendMessage('tg:100200300', 'No bot');
+
+      // No error, no API call
+    });
+  });
+
+  // --- ownsJid ---
+
+  describe('ownsJid', () => {
+    it('owns tg: JIDs', () => {
+      const channel = new TelegramChannel('test-token', createTestOpts());
+      expect(channel.ownsJid('tg:123456')).toBe(true);
+    });
+
+    it('owns tg: JIDs with negative IDs (groups)', () => {
+      const channel = new TelegramChannel('test-token', createTestOpts());
+      expect(channel.ownsJid('tg:-1001234567890')).toBe(true);
+    });
+
+    it('does not own WhatsApp group JIDs', () => {
+      const channel = new TelegramChannel('test-token', createTestOpts());
+      expect(channel.ownsJid('12345@g.us')).toBe(false);
+    });
+
+    it('does not own WhatsApp DM JIDs', () => {
+      const channel = new TelegramChannel('test-token', createTestOpts());
+      expect(channel.ownsJid('12345@s.whatsapp.net')).toBe(false);
+    });
+
+    it('does not own unknown JID formats', () => {
+      const channel = new TelegramChannel('test-token', createTestOpts());
+      expect(channel.ownsJid('random-string')).toBe(false);
+    });
+  });
+
+  // --- setTyping ---
+
+  describe('setTyping', () => {
+    it('sends typing action when isTyping is true', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      await channel.setTyping('tg:100200300', true);
+
+      expect(currentBot().api.sendChatAction).toHaveBeenCalledWith(
+        '100200300',
+        'typing',
+      );
+    });
+
+    it('does nothing when isTyping is false', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      await channel.setTyping('tg:100200300', false);
+
+      expect(currentBot().api.sendChatAction).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when bot is not initialized', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+
+      // Don't connect
+      await channel.setTyping('tg:100200300', true);
+
+      // No error, no API call
+    });
+
+    it('handles typing indicator failure gracefully', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      currentBot().api.sendChatAction.mockRejectedValueOnce(
+        new Error('Rate limited'),
+      );
+
+      await expect(
+        channel.setTyping('tg:100200300', true),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  // --- Bot commands ---
+
+  describe('bot commands', () => {
+    it('/chatid replies with chat ID and metadata', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const handler = currentBot().commandHandlers.get('chatid')!;
+      const ctx = {
+        chat: { id: 100200300, type: 'group' as const },
+        from: { first_name: 'Alice' },
+        reply: vi.fn(),
+      };
+
+      await handler(ctx);
+
+      expect(ctx.reply).toHaveBeenCalledWith(
+        expect.stringContaining('tg:100200300'),
+        expect.objectContaining({ parse_mode: 'Markdown' }),
+      );
+    });
+
+    it('/chatid shows chat type', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const handler = currentBot().commandHandlers.get('chatid')!;
+      const ctx = {
+        chat: { id: 555, type: 'private' as const },
+        from: { first_name: 'Bob' },
+        reply: vi.fn(),
+      };
+
+      await handler(ctx);
+
+      expect(ctx.reply).toHaveBeenCalledWith(
+        expect.stringContaining('private'),
+        expect.any(Object),
+      );
+    });
+
+    it('/ping replies with bot status', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const handler = currentBot().commandHandlers.get('ping')!;
+      const ctx = { reply: vi.fn() };
+
+      await handler(ctx);
+
+      expect(ctx.reply).toHaveBeenCalledWith('Andy is online.');
+    });
+  });
+
+  // --- Channel properties ---
+
+  describe('channel properties', () => {
+    it('has name "telegram"', () => {
+      const channel = new TelegramChannel('test-token', createTestOpts());
+      expect(channel.name).toBe('telegram');
+    });
+  });
+});

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -1,0 +1,298 @@
+import https from 'https';
+import { Api, Bot } from 'grammy';
+
+import { ASSISTANT_NAME, TRIGGER_PATTERN } from '../config.js';
+import { readEnvFile } from '../env.js';
+import { logger } from '../logger.js';
+import { registerChannel, ChannelOpts } from './registry.js';
+import {
+  Channel,
+  OnChatMetadata,
+  OnInboundMessage,
+  RegisteredGroup,
+} from '../types.js';
+
+export interface TelegramChannelOpts {
+  onMessage: OnInboundMessage;
+  onChatMetadata: OnChatMetadata;
+  registeredGroups: () => Record<string, RegisteredGroup>;
+}
+
+/**
+ * Send a message with Telegram Markdown parse mode, falling back to plain text.
+ * Claude's output naturally matches Telegram's Markdown v1 format:
+ *   *bold*, _italic_, `code`, ```code blocks```, [links](url)
+ */
+async function sendTelegramMessage(
+  api: { sendMessage: Api['sendMessage'] },
+  chatId: string | number,
+  text: string,
+  options: { message_thread_id?: number } = {},
+): Promise<void> {
+  try {
+    await api.sendMessage(chatId, text, {
+      ...options,
+      parse_mode: 'Markdown',
+    });
+  } catch (err) {
+    // Fallback: send as plain text if Markdown parsing fails
+    logger.debug({ err }, 'Markdown send failed, falling back to plain text');
+    await api.sendMessage(chatId, text, options);
+  }
+}
+
+export class TelegramChannel implements Channel {
+  name = 'telegram';
+
+  private bot: Bot | null = null;
+  private opts: TelegramChannelOpts;
+  private botToken: string;
+
+  constructor(botToken: string, opts: TelegramChannelOpts) {
+    this.botToken = botToken;
+    this.opts = opts;
+  }
+
+  async connect(): Promise<void> {
+    this.bot = new Bot(this.botToken, {
+      client: {
+        baseFetchConfig: { agent: https.globalAgent, compress: true },
+      },
+    });
+
+    // Command to get chat ID (useful for registration)
+    this.bot.command('chatid', (ctx) => {
+      const chatId = ctx.chat.id;
+      const chatType = ctx.chat.type;
+      const chatName =
+        chatType === 'private'
+          ? ctx.from?.first_name || 'Private'
+          : (ctx.chat as any).title || 'Unknown';
+
+      ctx.reply(
+        `Chat ID: \`tg:${chatId}\`\nName: ${chatName}\nType: ${chatType}`,
+        { parse_mode: 'Markdown' },
+      );
+    });
+
+    // Command to check bot status
+    this.bot.command('ping', (ctx) => {
+      ctx.reply(`${ASSISTANT_NAME} is online.`);
+    });
+
+    this.bot.on('message:text', async (ctx) => {
+      // Skip commands
+      if (ctx.message.text.startsWith('/')) return;
+
+      const chatJid = `tg:${ctx.chat.id}`;
+      let content = ctx.message.text;
+      const timestamp = new Date(ctx.message.date * 1000).toISOString();
+      const senderName =
+        ctx.from?.first_name ||
+        ctx.from?.username ||
+        ctx.from?.id.toString() ||
+        'Unknown';
+      const sender = ctx.from?.id.toString() || '';
+      const msgId = ctx.message.message_id.toString();
+
+      // Determine chat name
+      const chatName =
+        ctx.chat.type === 'private'
+          ? senderName
+          : (ctx.chat as any).title || chatJid;
+
+      // Translate Telegram @bot_username mentions into TRIGGER_PATTERN format.
+      // Telegram @mentions (e.g., @andy_ai_bot) won't match TRIGGER_PATTERN
+      // (e.g., ^@Andy\b), so we prepend the trigger when the bot is @mentioned.
+      const botUsername = ctx.me?.username?.toLowerCase();
+      if (botUsername) {
+        const entities = ctx.message.entities || [];
+        const isBotMentioned = entities.some((entity) => {
+          if (entity.type === 'mention') {
+            const mentionText = content
+              .substring(entity.offset, entity.offset + entity.length)
+              .toLowerCase();
+            return mentionText === `@${botUsername}`;
+          }
+          return false;
+        });
+        if (isBotMentioned && !TRIGGER_PATTERN.test(content)) {
+          content = `@${ASSISTANT_NAME} ${content}`;
+        }
+      }
+
+      // Store chat metadata for discovery
+      const isGroup =
+        ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
+      this.opts.onChatMetadata(
+        chatJid,
+        timestamp,
+        chatName,
+        'telegram',
+        isGroup,
+      );
+
+      // Only deliver full message for registered groups
+      const group = this.opts.registeredGroups()[chatJid];
+      if (!group) {
+        logger.debug(
+          { chatJid, chatName },
+          'Message from unregistered Telegram chat',
+        );
+        return;
+      }
+
+      // Deliver message — startMessageLoop() will pick it up
+      this.opts.onMessage(chatJid, {
+        id: msgId,
+        chat_jid: chatJid,
+        sender,
+        sender_name: senderName,
+        content,
+        timestamp,
+        is_from_me: false,
+      });
+
+      logger.info(
+        { chatJid, chatName, sender: senderName },
+        'Telegram message stored',
+      );
+    });
+
+    // Handle non-text messages with placeholders so the agent knows something was sent
+    const storeNonText = (ctx: any, placeholder: string) => {
+      const chatJid = `tg:${ctx.chat.id}`;
+      const group = this.opts.registeredGroups()[chatJid];
+      if (!group) return;
+
+      const timestamp = new Date(ctx.message.date * 1000).toISOString();
+      const senderName =
+        ctx.from?.first_name ||
+        ctx.from?.username ||
+        ctx.from?.id?.toString() ||
+        'Unknown';
+      const caption = ctx.message.caption ? ` ${ctx.message.caption}` : '';
+
+      const isGroup =
+        ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
+      this.opts.onChatMetadata(
+        chatJid,
+        timestamp,
+        undefined,
+        'telegram',
+        isGroup,
+      );
+      this.opts.onMessage(chatJid, {
+        id: ctx.message.message_id.toString(),
+        chat_jid: chatJid,
+        sender: ctx.from?.id?.toString() || '',
+        sender_name: senderName,
+        content: `${placeholder}${caption}`,
+        timestamp,
+        is_from_me: false,
+      });
+    };
+
+    this.bot.on('message:photo', (ctx) => storeNonText(ctx, '[Photo]'));
+    this.bot.on('message:video', (ctx) => storeNonText(ctx, '[Video]'));
+    this.bot.on('message:voice', (ctx) => storeNonText(ctx, '[Voice message]'));
+    this.bot.on('message:audio', (ctx) => storeNonText(ctx, '[Audio]'));
+    this.bot.on('message:document', (ctx) => {
+      const name = ctx.message.document?.file_name || 'file';
+      storeNonText(ctx, `[Document: ${name}]`);
+    });
+    this.bot.on('message:sticker', (ctx) => {
+      const emoji = ctx.message.sticker?.emoji || '';
+      storeNonText(ctx, `[Sticker ${emoji}]`);
+    });
+    this.bot.on('message:location', (ctx) => storeNonText(ctx, '[Location]'));
+    this.bot.on('message:contact', (ctx) => storeNonText(ctx, '[Contact]'));
+
+    // Handle errors gracefully
+    this.bot.catch((err) => {
+      logger.error({ err: err.message }, 'Telegram bot error');
+    });
+
+    // Start polling — returns a Promise that resolves when started
+    return new Promise<void>((resolve) => {
+      this.bot!.start({
+        onStart: (botInfo) => {
+          logger.info(
+            { username: botInfo.username, id: botInfo.id },
+            'Telegram bot connected',
+          );
+          console.log(`\n  Telegram bot: @${botInfo.username}`);
+          console.log(
+            `  Send /chatid to the bot to get a chat's registration ID\n`,
+          );
+          resolve();
+        },
+      });
+    });
+  }
+
+  async sendMessage(jid: string, text: string): Promise<void> {
+    if (!this.bot) {
+      logger.warn('Telegram bot not initialized');
+      return;
+    }
+
+    try {
+      const numericId = jid.replace(/^tg:/, '');
+
+      // Telegram has a 4096 character limit per message — split if needed
+      const MAX_LENGTH = 4096;
+      if (text.length <= MAX_LENGTH) {
+        await sendTelegramMessage(this.bot.api, numericId, text);
+      } else {
+        for (let i = 0; i < text.length; i += MAX_LENGTH) {
+          await sendTelegramMessage(
+            this.bot.api,
+            numericId,
+            text.slice(i, i + MAX_LENGTH),
+          );
+        }
+      }
+      logger.info({ jid, length: text.length }, 'Telegram message sent');
+    } catch (err) {
+      logger.error({ jid, err }, 'Failed to send Telegram message');
+    }
+  }
+
+  isConnected(): boolean {
+    return this.bot !== null;
+  }
+
+  ownsJid(jid: string): boolean {
+    return jid.startsWith('tg:');
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.bot) {
+      this.bot.stop();
+      this.bot = null;
+      logger.info('Telegram bot stopped');
+    }
+  }
+
+  async setTyping(jid: string, isTyping: boolean): Promise<void> {
+    if (!this.bot || !isTyping) return;
+    try {
+      const numericId = jid.replace(/^tg:/, '');
+      await this.bot.api.sendChatAction(numericId, 'typing');
+    } catch (err) {
+      logger.debug({ jid, err }, 'Failed to send Telegram typing indicator');
+    }
+  }
+}
+
+registerChannel('telegram', (opts: ChannelOpts) => {
+  const envVars = readEnvFile(['TELEGRAM_BOT_TOKEN']);
+  const token =
+    process.env.TELEGRAM_BOT_TOKEN || envVars.TELEGRAM_BOT_TOKEN || '';
+  if (!token) {
+    logger.warn('Telegram: TELEGRAM_BOT_TOKEN not set');
+    return null;
+  }
+  return new TelegramChannel(token, opts);
+});

--- a/src/channels/whatsapp.test.ts
+++ b/src/channels/whatsapp.test.ts
@@ -1,0 +1,1125 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+// --- Mocks ---
+
+// Mock config
+vi.mock('../config.js', () => ({
+  STORE_DIR: '/tmp/nanoclaw-test-store',
+  ASSISTANT_NAME: 'Andy',
+  ASSISTANT_HAS_OWN_NUMBER: false,
+  GROUPS_DIR: '/tmp/test-groups',
+}));
+
+// Mock logger
+vi.mock('../logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Mock db
+vi.mock('../db.js', () => ({
+  getLastGroupSync: vi.fn(() => null),
+  getLatestMessage: vi.fn(() => undefined),
+  getMessageFromMe: vi.fn(() => false),
+  setLastGroupSync: vi.fn(),
+  storeReaction: vi.fn(),
+  updateChatName: vi.fn(),
+}));
+
+// Mock image module
+vi.mock('../image.js', () => ({
+  isImageMessage: vi.fn().mockReturnValue(false),
+  processImage: vi
+    .fn()
+    .mockResolvedValue({
+      content: '[Image: attachments/test.jpg]',
+      relativePath: 'attachments/test.jpg',
+    }),
+}));
+
+// Mock fs
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      existsSync: vi.fn(() => true),
+      mkdirSync: vi.fn(),
+    },
+  };
+});
+
+// Mock child_process (used for osascript notification)
+vi.mock('child_process', () => ({
+  exec: vi.fn(),
+}));
+
+// Build a fake WASocket that's an EventEmitter with the methods we need
+function createFakeSocket() {
+  const ev = new EventEmitter();
+  const sock = {
+    ev: {
+      on: (event: string, handler: (...args: unknown[]) => void) => {
+        ev.on(event, handler);
+      },
+    },
+    user: {
+      id: '1234567890:1@s.whatsapp.net',
+      lid: '9876543210:1@lid',
+    },
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+    sendPresenceUpdate: vi.fn().mockResolvedValue(undefined),
+    groupFetchAllParticipating: vi.fn().mockResolvedValue({}),
+    updateMediaMessage: vi.fn().mockResolvedValue(undefined),
+    end: vi.fn(),
+    // Expose the event emitter for triggering events in tests
+    _ev: ev,
+  };
+  return sock;
+}
+
+let fakeSocket: ReturnType<typeof createFakeSocket>;
+
+// Mock Baileys
+vi.mock('@whiskeysockets/baileys', () => {
+  return {
+    default: vi.fn(() => fakeSocket),
+    Browsers: { macOS: vi.fn(() => ['macOS', 'Chrome', '']) },
+    DisconnectReason: {
+      loggedOut: 401,
+      badSession: 500,
+      connectionClosed: 428,
+      connectionLost: 408,
+      connectionReplaced: 440,
+      timedOut: 408,
+      restartRequired: 515,
+    },
+    fetchLatestWaWebVersion: vi
+      .fn()
+      .mockResolvedValue({ version: [2, 3000, 0] }),
+    downloadMediaMessage: vi.fn().mockResolvedValue(Buffer.from('image-data')),
+    normalizeMessageContent: vi.fn((content: unknown) => content),
+    makeCacheableSignalKeyStore: vi.fn((keys: unknown) => keys),
+    useMultiFileAuthState: vi.fn().mockResolvedValue({
+      state: {
+        creds: {},
+        keys: {},
+      },
+      saveCreds: vi.fn(),
+    }),
+  };
+});
+
+import { WhatsAppChannel, WhatsAppChannelOpts } from './whatsapp.js';
+import { downloadMediaMessage } from '@whiskeysockets/baileys';
+import { getLastGroupSync, updateChatName, setLastGroupSync } from '../db.js';
+import { isImageMessage, processImage } from '../image.js';
+
+// --- Test helpers ---
+
+function createTestOpts(
+  overrides?: Partial<WhatsAppChannelOpts>,
+): WhatsAppChannelOpts {
+  return {
+    onMessage: vi.fn(),
+    onChatMetadata: vi.fn(),
+    registeredGroups: vi.fn(() => ({
+      'registered@g.us': {
+        name: 'Test Group',
+        folder: 'test-group',
+        trigger: '@Andy',
+        added_at: '2024-01-01T00:00:00.000Z',
+      },
+    })),
+    ...overrides,
+  };
+}
+
+function triggerConnection(state: string, extra?: Record<string, unknown>) {
+  fakeSocket._ev.emit('connection.update', { connection: state, ...extra });
+}
+
+function triggerDisconnect(statusCode: number) {
+  fakeSocket._ev.emit('connection.update', {
+    connection: 'close',
+    lastDisconnect: {
+      error: { output: { statusCode } },
+    },
+  });
+}
+
+async function triggerMessages(messages: unknown[]) {
+  fakeSocket._ev.emit('messages.upsert', { messages });
+  // Flush microtasks so the async messages.upsert handler completes
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+// --- Tests ---
+
+describe('WhatsAppChannel', () => {
+  beforeEach(() => {
+    fakeSocket = createFakeSocket();
+    vi.mocked(getLastGroupSync).mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /**
+   * Helper: start connect, flush microtasks so event handlers are registered,
+   * then trigger the connection open event. Returns the resolved promise.
+   */
+  async function connectChannel(channel: WhatsAppChannel): Promise<void> {
+    const p = channel.connect();
+    // Flush microtasks so connectInternal completes its await and registers handlers
+    await new Promise((r) => setTimeout(r, 0));
+    triggerConnection('open');
+    return p;
+  }
+
+  // --- Version fetch ---
+
+  describe('version fetch', () => {
+    it('connects with fetched version', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+      await connectChannel(channel);
+
+      const { fetchLatestWaWebVersion } =
+        await import('@whiskeysockets/baileys');
+      expect(fetchLatestWaWebVersion).toHaveBeenCalledWith({});
+    });
+
+    it('falls back gracefully when version fetch fails', async () => {
+      const { fetchLatestWaWebVersion } =
+        await import('@whiskeysockets/baileys');
+      vi.mocked(fetchLatestWaWebVersion).mockRejectedValueOnce(
+        new Error('network error'),
+      );
+
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+      await connectChannel(channel);
+
+      // Should still connect successfully despite fetch failure
+      expect(channel.isConnected()).toBe(true);
+    });
+  });
+
+  // --- Connection lifecycle ---
+
+  describe('connection lifecycle', () => {
+    it('resolves connect() when connection opens', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      expect(channel.isConnected()).toBe(true);
+    });
+
+    it('sets up LID to phone mapping on open', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      // The channel should have mapped the LID from sock.user
+      // We can verify by sending a message from a LID JID
+      // and checking the translated JID in the callback
+    });
+
+    it('flushes outgoing queue on reconnect', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      // Disconnect
+      (channel as any).connected = false;
+
+      // Queue a message while disconnected
+      await channel.sendMessage('test@g.us', 'Queued message');
+      expect(fakeSocket.sendMessage).not.toHaveBeenCalled();
+
+      // Reconnect
+      (channel as any).connected = true;
+      await (channel as any).flushOutgoingQueue();
+
+      // Group messages get prefixed when flushed
+      expect(fakeSocket.sendMessage).toHaveBeenCalledWith('test@g.us', {
+        text: 'Andy: Queued message',
+      });
+    });
+
+    it('disconnects cleanly', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await channel.disconnect();
+      expect(channel.isConnected()).toBe(false);
+      expect(fakeSocket.end).toHaveBeenCalled();
+    });
+  });
+
+  // --- QR code and auth ---
+
+  describe('authentication', () => {
+    it('exits process when QR code is emitted (no auth state)', async () => {
+      vi.useFakeTimers();
+      const mockExit = vi
+        .spyOn(process, 'exit')
+        .mockImplementation(() => undefined as never);
+
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      // Start connect but don't await (it won't resolve - process exits)
+      channel.connect().catch(() => {});
+
+      // Flush microtasks so connectInternal registers handlers
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Emit QR code event
+      fakeSocket._ev.emit('connection.update', { qr: 'some-qr-data' });
+
+      // Advance timer past the 1000ms setTimeout before exit
+      await vi.advanceTimersByTimeAsync(1500);
+
+      expect(mockExit).toHaveBeenCalledWith(1);
+      mockExit.mockRestore();
+      vi.useRealTimers();
+    });
+  });
+
+  // --- Reconnection behavior ---
+
+  describe('reconnection', () => {
+    it('reconnects on non-loggedOut disconnect', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      expect(channel.isConnected()).toBe(true);
+
+      // Disconnect with a non-loggedOut reason (e.g., connectionClosed = 428)
+      triggerDisconnect(428);
+
+      expect(channel.isConnected()).toBe(false);
+      // The channel should attempt to reconnect (calls connectInternal again)
+    });
+
+    it('exits on loggedOut disconnect', async () => {
+      const mockExit = vi
+        .spyOn(process, 'exit')
+        .mockImplementation(() => undefined as never);
+
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      // Disconnect with loggedOut reason (401)
+      triggerDisconnect(401);
+
+      expect(channel.isConnected()).toBe(false);
+      expect(mockExit).toHaveBeenCalledWith(0);
+      mockExit.mockRestore();
+    });
+
+    it('retries reconnection after 5s on failure', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      // Disconnect with stream error 515
+      triggerDisconnect(515);
+
+      // The channel sets a 5s retry — just verify it doesn't crash
+      await new Promise((r) => setTimeout(r, 100));
+    });
+  });
+
+  // --- Message handling ---
+
+  describe('message handling', () => {
+    it('delivers message for registered group', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-1',
+            remoteJid: 'registered@g.us',
+            participant: '5551234@s.whatsapp.net',
+            fromMe: false,
+          },
+          message: { conversation: 'Hello Andy' },
+          pushName: 'Alice',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        'registered@g.us',
+        expect.any(String),
+        undefined,
+        'whatsapp',
+        true,
+      );
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'registered@g.us',
+        expect.objectContaining({
+          id: 'msg-1',
+          content: 'Hello Andy',
+          sender_name: 'Alice',
+          is_from_me: false,
+        }),
+      );
+    });
+
+    it('only emits metadata for unregistered groups', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-2',
+            remoteJid: 'unregistered@g.us',
+            participant: '5551234@s.whatsapp.net',
+            fromMe: false,
+          },
+          message: { conversation: 'Hello' },
+          pushName: 'Bob',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        'unregistered@g.us',
+        expect.any(String),
+        undefined,
+        'whatsapp',
+        true,
+      );
+      expect(opts.onMessage).not.toHaveBeenCalled();
+    });
+
+    it('ignores status@broadcast messages', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-3',
+            remoteJid: 'status@broadcast',
+            fromMe: false,
+          },
+          message: { conversation: 'Status update' },
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      expect(opts.onChatMetadata).not.toHaveBeenCalled();
+      expect(opts.onMessage).not.toHaveBeenCalled();
+    });
+
+    it('ignores messages with no content', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-4',
+            remoteJid: 'registered@g.us',
+            fromMe: false,
+          },
+          message: null,
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      expect(opts.onMessage).not.toHaveBeenCalled();
+    });
+
+    it('extracts text from extendedTextMessage', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-5',
+            remoteJid: 'registered@g.us',
+            participant: '5551234@s.whatsapp.net',
+            fromMe: false,
+          },
+          message: {
+            extendedTextMessage: { text: 'A reply message' },
+          },
+          pushName: 'Charlie',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'registered@g.us',
+        expect.objectContaining({ content: 'A reply message' }),
+      );
+    });
+
+    it('extracts caption from imageMessage', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-6',
+            remoteJid: 'registered@g.us',
+            participant: '5551234@s.whatsapp.net',
+            fromMe: false,
+          },
+          message: {
+            imageMessage: {
+              caption: 'Check this photo',
+              mimetype: 'image/jpeg',
+            },
+          },
+          pushName: 'Diana',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'registered@g.us',
+        expect.objectContaining({ content: 'Check this photo' }),
+      );
+    });
+
+    it('extracts caption from videoMessage', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-7',
+            remoteJid: 'registered@g.us',
+            participant: '5551234@s.whatsapp.net',
+            fromMe: false,
+          },
+          message: {
+            videoMessage: { caption: 'Watch this', mimetype: 'video/mp4' },
+          },
+          pushName: 'Eve',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'registered@g.us',
+        expect.objectContaining({ content: 'Watch this' }),
+      );
+    });
+
+    it('handles message with no extractable text (e.g. voice note without caption)', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-8',
+            remoteJid: 'registered@g.us',
+            participant: '5551234@s.whatsapp.net',
+            fromMe: false,
+          },
+          message: {
+            audioMessage: { mimetype: 'audio/ogg; codecs=opus', ptt: true },
+          },
+          pushName: 'Frank',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      // Skipped — no text content to process
+      expect(opts.onMessage).not.toHaveBeenCalled();
+    });
+
+    it('uses sender JID when pushName is absent', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-9',
+            remoteJid: 'registered@g.us',
+            participant: '5551234@s.whatsapp.net',
+            fromMe: false,
+          },
+          message: { conversation: 'No push name' },
+          // pushName is undefined
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'registered@g.us',
+        expect.objectContaining({ sender_name: '5551234' }),
+      );
+    });
+
+    it('downloads and processes image attachments', async () => {
+      vi.mocked(isImageMessage).mockReturnValue(true);
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-img-1',
+            remoteJid: 'registered@g.us',
+            participant: '5551234@s.whatsapp.net',
+            fromMe: false,
+          },
+          message: {
+            imageMessage: {
+              caption: 'Check this',
+              mimetype: 'image/jpeg',
+            },
+          },
+          pushName: 'Alice',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      expect(downloadMediaMessage).toHaveBeenCalled();
+      expect(processImage).toHaveBeenCalled();
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'registered@g.us',
+        expect.objectContaining({
+          content: '[Image: attachments/test.jpg]',
+        }),
+      );
+
+      vi.mocked(isImageMessage).mockReturnValue(false);
+    });
+
+    it('handles image without caption', async () => {
+      vi.mocked(isImageMessage).mockReturnValue(true);
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-img-2',
+            remoteJid: 'registered@g.us',
+            participant: '5551234@s.whatsapp.net',
+            fromMe: false,
+          },
+          message: {
+            imageMessage: {
+              mimetype: 'image/jpeg',
+            },
+          },
+          pushName: 'Bob',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      expect(processImage).toHaveBeenCalledWith(
+        expect.any(Buffer),
+        expect.any(String),
+        '',
+      );
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'registered@g.us',
+        expect.objectContaining({
+          content: '[Image: attachments/test.jpg]',
+        }),
+      );
+
+      vi.mocked(isImageMessage).mockReturnValue(false);
+    });
+
+    it('handles image download failure gracefully', async () => {
+      vi.mocked(isImageMessage).mockReturnValue(true);
+      vi.mocked(downloadMediaMessage).mockRejectedValueOnce(
+        new Error('Download failed'),
+      );
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-img-3',
+            remoteJid: 'registered@g.us',
+            participant: '5551234@s.whatsapp.net',
+            fromMe: false,
+          },
+          message: {
+            imageMessage: {
+              caption: 'Will fail',
+              mimetype: 'image/jpeg',
+            },
+          },
+          pushName: 'Charlie',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      // Image download failed but caption is still there as content
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'registered@g.us',
+        expect.objectContaining({
+          content: 'Will fail',
+        }),
+      );
+
+      vi.mocked(isImageMessage).mockReturnValue(false);
+    });
+
+    it('falls back to caption when processImage returns null', async () => {
+      vi.mocked(isImageMessage).mockReturnValue(true);
+      vi.mocked(processImage).mockResolvedValueOnce(null);
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-img-4',
+            remoteJid: 'registered@g.us',
+            participant: '5551234@s.whatsapp.net',
+            fromMe: false,
+          },
+          message: {
+            imageMessage: {
+              caption: 'Fallback caption',
+              mimetype: 'image/jpeg',
+            },
+          },
+          pushName: 'Diana',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      // processImage returned null, so original caption content is used
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'registered@g.us',
+        expect.objectContaining({
+          content: 'Fallback caption',
+        }),
+      );
+
+      vi.mocked(isImageMessage).mockReturnValue(false);
+    });
+  });
+
+  // --- LID ↔ JID translation ---
+
+  describe('LID to JID translation', () => {
+    it('translates known LID to phone JID', async () => {
+      const opts = createTestOpts({
+        registeredGroups: vi.fn(() => ({
+          '1234567890@s.whatsapp.net': {
+            name: 'Self Chat',
+            folder: 'self-chat',
+            trigger: '@Andy',
+            added_at: '2024-01-01T00:00:00.000Z',
+          },
+        })),
+      });
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      // The socket has lid '9876543210:1@lid' → phone '1234567890@s.whatsapp.net'
+      // Send a message from the LID
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-lid',
+            remoteJid: '9876543210@lid',
+            fromMe: false,
+          },
+          message: { conversation: 'From LID' },
+          pushName: 'Self',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      // Should be translated to phone JID
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        '1234567890@s.whatsapp.net',
+        expect.any(String),
+        undefined,
+        'whatsapp',
+        false,
+      );
+    });
+
+    it('passes through non-LID JIDs unchanged', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-normal',
+            remoteJid: 'registered@g.us',
+            participant: '5551234@s.whatsapp.net',
+            fromMe: false,
+          },
+          message: { conversation: 'Normal JID' },
+          pushName: 'Grace',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        'registered@g.us',
+        expect.any(String),
+        undefined,
+        'whatsapp',
+        true,
+      );
+    });
+
+    it('passes through unknown LID JIDs unchanged', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await triggerMessages([
+        {
+          key: {
+            id: 'msg-unknown-lid',
+            remoteJid: '0000000000@lid',
+            fromMe: false,
+          },
+          message: { conversation: 'Unknown LID' },
+          pushName: 'Unknown',
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+
+      // Unknown LID passes through unchanged
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        '0000000000@lid',
+        expect.any(String),
+        undefined,
+        'whatsapp',
+        false,
+      );
+    });
+  });
+
+  // --- Outgoing message queue ---
+
+  describe('outgoing message queue', () => {
+    it('sends message directly when connected', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await channel.sendMessage('test@g.us', 'Hello');
+      // Group messages get prefixed with assistant name
+      expect(fakeSocket.sendMessage).toHaveBeenCalledWith('test@g.us', {
+        text: 'Andy: Hello',
+      });
+    });
+
+    it('prefixes direct chat messages on shared number', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await channel.sendMessage('123@s.whatsapp.net', 'Hello');
+      // Shared number: DMs also get prefixed (needed for self-chat distinction)
+      expect(fakeSocket.sendMessage).toHaveBeenCalledWith(
+        '123@s.whatsapp.net',
+        { text: 'Andy: Hello' },
+      );
+    });
+
+    it('queues message when disconnected', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      // Don't connect — channel starts disconnected
+      await channel.sendMessage('test@g.us', 'Queued');
+      expect(fakeSocket.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('queues message on send failure', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      // Make sendMessage fail
+      fakeSocket.sendMessage.mockRejectedValueOnce(new Error('Network error'));
+
+      await channel.sendMessage('test@g.us', 'Will fail');
+
+      // Should not throw, message queued for retry
+      // The queue should have the message
+    });
+
+    it('flushes multiple queued messages in order', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      // Queue messages while disconnected
+      await channel.sendMessage('test@g.us', 'First');
+      await channel.sendMessage('test@g.us', 'Second');
+      await channel.sendMessage('test@g.us', 'Third');
+
+      // Connect — flush happens automatically on open
+      await connectChannel(channel);
+
+      // Give the async flush time to complete
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(fakeSocket.sendMessage).toHaveBeenCalledTimes(3);
+      // Group messages get prefixed
+      expect(fakeSocket.sendMessage).toHaveBeenNthCalledWith(1, 'test@g.us', {
+        text: 'Andy: First',
+      });
+      expect(fakeSocket.sendMessage).toHaveBeenNthCalledWith(2, 'test@g.us', {
+        text: 'Andy: Second',
+      });
+      expect(fakeSocket.sendMessage).toHaveBeenNthCalledWith(3, 'test@g.us', {
+        text: 'Andy: Third',
+      });
+    });
+  });
+
+  // --- Group metadata sync ---
+
+  describe('group metadata sync', () => {
+    it('syncs group metadata on first connection', async () => {
+      fakeSocket.groupFetchAllParticipating.mockResolvedValue({
+        'group1@g.us': { subject: 'Group One' },
+        'group2@g.us': { subject: 'Group Two' },
+      });
+
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      // Wait for async sync to complete
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(fakeSocket.groupFetchAllParticipating).toHaveBeenCalled();
+      expect(updateChatName).toHaveBeenCalledWith('group1@g.us', 'Group One');
+      expect(updateChatName).toHaveBeenCalledWith('group2@g.us', 'Group Two');
+      expect(setLastGroupSync).toHaveBeenCalled();
+    });
+
+    it('skips sync when synced recently', async () => {
+      // Last sync was 1 hour ago (within 24h threshold)
+      vi.mocked(getLastGroupSync).mockReturnValue(
+        new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      );
+
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(fakeSocket.groupFetchAllParticipating).not.toHaveBeenCalled();
+    });
+
+    it('forces sync regardless of cache', async () => {
+      vi.mocked(getLastGroupSync).mockReturnValue(
+        new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      );
+
+      fakeSocket.groupFetchAllParticipating.mockResolvedValue({
+        'group@g.us': { subject: 'Forced Group' },
+      });
+
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await channel.syncGroupMetadata(true);
+
+      expect(fakeSocket.groupFetchAllParticipating).toHaveBeenCalled();
+      expect(updateChatName).toHaveBeenCalledWith('group@g.us', 'Forced Group');
+    });
+
+    it('handles group sync failure gracefully', async () => {
+      fakeSocket.groupFetchAllParticipating.mockRejectedValue(
+        new Error('Network timeout'),
+      );
+
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      // Should not throw
+      await expect(channel.syncGroupMetadata(true)).resolves.toBeUndefined();
+    });
+
+    it('skips groups with no subject', async () => {
+      fakeSocket.groupFetchAllParticipating.mockResolvedValue({
+        'group1@g.us': { subject: 'Has Subject' },
+        'group2@g.us': { subject: '' },
+        'group3@g.us': {},
+      });
+
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      // Clear any calls from the automatic sync on connect
+      vi.mocked(updateChatName).mockClear();
+
+      await channel.syncGroupMetadata(true);
+
+      expect(updateChatName).toHaveBeenCalledTimes(1);
+      expect(updateChatName).toHaveBeenCalledWith('group1@g.us', 'Has Subject');
+    });
+  });
+
+  // --- JID ownership ---
+
+  describe('ownsJid', () => {
+    it('owns @g.us JIDs (WhatsApp groups)', () => {
+      const channel = new WhatsAppChannel(createTestOpts());
+      expect(channel.ownsJid('12345@g.us')).toBe(true);
+    });
+
+    it('owns @s.whatsapp.net JIDs (WhatsApp DMs)', () => {
+      const channel = new WhatsAppChannel(createTestOpts());
+      expect(channel.ownsJid('12345@s.whatsapp.net')).toBe(true);
+    });
+
+    it('does not own Telegram JIDs', () => {
+      const channel = new WhatsAppChannel(createTestOpts());
+      expect(channel.ownsJid('tg:12345')).toBe(false);
+    });
+
+    it('does not own unknown JID formats', () => {
+      const channel = new WhatsAppChannel(createTestOpts());
+      expect(channel.ownsJid('random-string')).toBe(false);
+    });
+  });
+
+  // --- Typing indicator ---
+
+  describe('setTyping', () => {
+    it('sends composing presence when typing', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await channel.setTyping('test@g.us', true);
+      expect(fakeSocket.sendPresenceUpdate).toHaveBeenCalledWith(
+        'composing',
+        'test@g.us',
+      );
+    });
+
+    it('sends paused presence when stopping', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      await channel.setTyping('test@g.us', false);
+      expect(fakeSocket.sendPresenceUpdate).toHaveBeenCalledWith(
+        'paused',
+        'test@g.us',
+      );
+    });
+
+    it('handles typing indicator failure gracefully', async () => {
+      const opts = createTestOpts();
+      const channel = new WhatsAppChannel(opts);
+
+      await connectChannel(channel);
+
+      fakeSocket.sendPresenceUpdate.mockRejectedValueOnce(new Error('Failed'));
+
+      // Should not throw
+      await expect(
+        channel.setTyping('test@g.us', true),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  // --- Channel properties ---
+
+  describe('channel properties', () => {
+    it('has name "whatsapp"', () => {
+      const channel = new WhatsAppChannel(createTestOpts());
+      expect(channel.name).toBe('whatsapp');
+    });
+
+    it('does not expose prefixAssistantName (prefix handled internally)', () => {
+      const channel = new WhatsAppChannel(createTestOpts());
+      expect('prefixAssistantName' in channel).toBe(false);
+    });
+  });
+});

--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -1,0 +1,493 @@
+import { exec } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+import makeWASocket, {
+  Browsers,
+  DisconnectReason,
+  downloadMediaMessage,
+  WASocket,
+  fetchLatestWaWebVersion,
+  makeCacheableSignalKeyStore,
+  useMultiFileAuthState,
+} from '@whiskeysockets/baileys';
+
+import {
+  ASSISTANT_HAS_OWN_NUMBER,
+  ASSISTANT_NAME,
+  GROUPS_DIR,
+  STORE_DIR,
+} from '../config.js';
+import {
+  getLastGroupSync,
+  getLatestMessage,
+  setLastGroupSync,
+  storeReaction,
+  updateChatName,
+} from '../db.js';
+import { isImageMessage, processImage } from '../image.js';
+import { logger } from '../logger.js';
+import { registerChannel, ChannelOpts } from './registry.js';
+import {
+  Channel,
+  OnInboundMessage,
+  OnChatMetadata,
+  RegisteredGroup,
+} from '../types.js';
+
+const GROUP_SYNC_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+export interface WhatsAppChannelOpts {
+  onMessage: OnInboundMessage;
+  onChatMetadata: OnChatMetadata;
+  registeredGroups: () => Record<string, RegisteredGroup>;
+}
+
+export class WhatsAppChannel implements Channel {
+  name = 'whatsapp';
+
+  private sock!: WASocket;
+  private connected = false;
+  private lidToPhoneMap: Record<string, string> = {};
+  private outgoingQueue: Array<{ jid: string; text: string }> = [];
+  private flushing = false;
+  private groupSyncTimerStarted = false;
+
+  private opts: WhatsAppChannelOpts;
+
+  constructor(opts: WhatsAppChannelOpts) {
+    this.opts = opts;
+  }
+
+  async connect(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      this.connectInternal(resolve).catch(reject);
+    });
+  }
+
+  private async connectInternal(onFirstOpen?: () => void): Promise<void> {
+    const authDir = path.join(STORE_DIR, 'auth');
+    fs.mkdirSync(authDir, { recursive: true });
+
+    const { state, saveCreds } = await useMultiFileAuthState(authDir);
+
+    const { version } = await fetchLatestWaWebVersion({}).catch((err) => {
+      logger.warn(
+        { err },
+        'Failed to fetch latest WA Web version, using default',
+      );
+      return { version: undefined };
+    });
+    this.sock = makeWASocket({
+      version,
+      auth: {
+        creds: state.creds,
+        keys: makeCacheableSignalKeyStore(state.keys, logger),
+      },
+      printQRInTerminal: false,
+      logger,
+      browser: Browsers.macOS('Chrome'),
+    });
+
+    this.sock.ev.on('connection.update', (update) => {
+      const { connection, lastDisconnect, qr } = update;
+
+      if (qr) {
+        const msg =
+          'WhatsApp authentication required. Run /setup in Claude Code.';
+        logger.error(msg);
+        exec(
+          `osascript -e 'display notification "${msg}" with title "NanoClaw" sound name "Basso"'`,
+        );
+        setTimeout(() => process.exit(1), 1000);
+      }
+
+      if (connection === 'close') {
+        this.connected = false;
+        const reason = (
+          lastDisconnect?.error as { output?: { statusCode?: number } }
+        )?.output?.statusCode;
+        const shouldReconnect = reason !== DisconnectReason.loggedOut;
+        logger.info(
+          {
+            reason,
+            shouldReconnect,
+            queuedMessages: this.outgoingQueue.length,
+          },
+          'Connection closed',
+        );
+
+        if (shouldReconnect) {
+          this.scheduleReconnect(1);
+        } else {
+          logger.info('Logged out. Run /setup to re-authenticate.');
+          process.exit(0);
+        }
+      } else if (connection === 'open') {
+        this.connected = true;
+        logger.info('Connected to WhatsApp');
+
+        // Announce availability so WhatsApp relays subsequent presence updates (typing indicators)
+        this.sock.sendPresenceUpdate('available').catch((err) => {
+          logger.warn({ err }, 'Failed to send presence update');
+        });
+
+        // Build LID to phone mapping from auth state for self-chat translation
+        if (this.sock.user) {
+          const phoneUser = this.sock.user.id.split(':')[0];
+          const lidUser = this.sock.user.lid?.split(':')[0];
+          if (lidUser && phoneUser) {
+            this.lidToPhoneMap[lidUser] = `${phoneUser}@s.whatsapp.net`;
+            logger.debug({ lidUser, phoneUser }, 'LID to phone mapping set');
+          }
+        }
+
+        // Flush any messages queued while disconnected
+        this.flushOutgoingQueue().catch((err) =>
+          logger.error({ err }, 'Failed to flush outgoing queue'),
+        );
+
+        // Sync group metadata on startup (respects 24h cache)
+        this.syncGroupMetadata().catch((err) =>
+          logger.error({ err }, 'Initial group sync failed'),
+        );
+        // Set up daily sync timer (only once)
+        if (!this.groupSyncTimerStarted) {
+          this.groupSyncTimerStarted = true;
+          setInterval(() => {
+            this.syncGroupMetadata().catch((err) =>
+              logger.error({ err }, 'Periodic group sync failed'),
+            );
+          }, GROUP_SYNC_INTERVAL_MS);
+        }
+
+        // Signal first connection to caller
+        if (onFirstOpen) {
+          onFirstOpen();
+          onFirstOpen = undefined;
+        }
+      }
+    });
+
+    this.sock.ev.on('creds.update', saveCreds);
+
+    this.sock.ev.on('messages.upsert', async ({ messages }) => {
+      for (const msg of messages) {
+        if (!msg.message) continue;
+        const rawJid = msg.key.remoteJid;
+        if (!rawJid || rawJid === 'status@broadcast') continue;
+
+        // Translate LID JID to phone JID if applicable
+        const chatJid = await this.translateJid(rawJid);
+
+        const timestamp = new Date(
+          Number(msg.messageTimestamp) * 1000,
+        ).toISOString();
+
+        // Always notify about chat metadata for group discovery
+        const isGroup = chatJid.endsWith('@g.us');
+        this.opts.onChatMetadata(
+          chatJid,
+          timestamp,
+          undefined,
+          'whatsapp',
+          isGroup,
+        );
+
+        // Only deliver full message for registered groups
+        const groups = this.opts.registeredGroups();
+        if (groups[chatJid]) {
+          let content =
+            msg.message?.conversation ||
+            msg.message?.extendedTextMessage?.text ||
+            msg.message?.imageMessage?.caption ||
+            msg.message?.videoMessage?.caption ||
+            '';
+
+          // Image attachment handling
+          if (isImageMessage(msg)) {
+            try {
+              const buffer = await downloadMediaMessage(msg, 'buffer', {});
+              const groupDir = path.join(GROUPS_DIR, groups[chatJid].folder);
+              const caption = msg.message?.imageMessage?.caption ?? '';
+              const result = await processImage(buffer as Buffer, groupDir, caption);
+              if (result) {
+                content = result.content;
+              }
+            } catch (err) {
+              logger.warn({ err, jid: chatJid }, 'Image - download failed');
+            }
+          }
+
+          // Skip protocol messages with no text content (encryption keys, read receipts, etc.)
+          if (!content) continue;
+
+          const sender = msg.key.participant || msg.key.remoteJid || '';
+          const senderName = msg.pushName || sender.split('@')[0];
+
+          const fromMe = msg.key.fromMe || false;
+          // Detect bot messages: with own number, fromMe is reliable
+          // since only the bot sends from that number.
+          // With shared number, bot messages carry the assistant name prefix
+          // (even in DMs/self-chat) so we check for that.
+          const isBotMessage = ASSISTANT_HAS_OWN_NUMBER
+            ? fromMe
+            : content.startsWith(`${ASSISTANT_NAME}:`);
+
+          this.opts.onMessage(chatJid, {
+            id: msg.key.id || '',
+            chat_jid: chatJid,
+            sender,
+            sender_name: senderName,
+            content,
+            timestamp,
+            is_from_me: fromMe,
+            is_bot_message: isBotMessage,
+          });
+        }
+      }
+    });
+
+    // Listen for message reactions
+    this.sock.ev.on('messages.reaction', async (reactions) => {
+      for (const { key, reaction } of reactions) {
+        try {
+          const messageId = key.id;
+          if (!messageId) continue;
+          const rawChatJid = key.remoteJid;
+          if (!rawChatJid || rawChatJid === 'status@broadcast') continue;
+          const chatJid = await this.translateJid(rawChatJid);
+          const groups = this.opts.registeredGroups();
+          if (!groups[chatJid]) continue;
+          const reactorJid =
+            reaction.key?.participant || reaction.key?.remoteJid || '';
+          const emoji = reaction.text || '';
+          const timestamp = reaction.senderTimestampMs
+            ? new Date(Number(reaction.senderTimestampMs)).toISOString()
+            : new Date().toISOString();
+          storeReaction({
+            message_id: messageId,
+            message_chat_jid: chatJid,
+            reactor_jid: reactorJid,
+            reactor_name: reactorJid.split('@')[0],
+            emoji,
+            timestamp,
+          });
+          logger.info(
+            {
+              chatJid,
+              messageId: messageId.slice(0, 10) + '...',
+              reactor: reactorJid.split('@')[0],
+              emoji: emoji || '(removed)',
+            },
+            emoji ? 'Reaction added' : 'Reaction removed',
+          );
+        } catch (err) {
+          logger.error({ err }, 'Failed to process reaction');
+        }
+      }
+    });
+  }
+
+  async sendMessage(jid: string, text: string): Promise<void> {
+    // Prefix bot messages with assistant name so users know who's speaking.
+    // On a shared number, prefix is also needed in DMs (including self-chat)
+    // to distinguish bot output from user messages.
+    // Skip only when the assistant has its own dedicated phone number.
+    const prefixed = ASSISTANT_HAS_OWN_NUMBER
+      ? text
+      : `${ASSISTANT_NAME}: ${text}`;
+
+    if (!this.connected) {
+      this.outgoingQueue.push({ jid, text: prefixed });
+      logger.info(
+        { jid, length: prefixed.length, queueSize: this.outgoingQueue.length },
+        'WA disconnected, message queued',
+      );
+      return;
+    }
+    try {
+      await this.sock.sendMessage(jid, { text: prefixed });
+      logger.info({ jid, length: prefixed.length }, 'Message sent');
+    } catch (err) {
+      // If send fails, queue it for retry on reconnect
+      this.outgoingQueue.push({ jid, text: prefixed });
+      logger.warn(
+        { jid, err, queueSize: this.outgoingQueue.length },
+        'Failed to send, message queued',
+      );
+    }
+  }
+
+  async sendReaction(
+    chatJid: string,
+    messageKey: {
+      id: string;
+      remoteJid: string;
+      fromMe?: boolean;
+      participant?: string;
+    },
+    emoji: string,
+  ): Promise<void> {
+    if (!this.connected) {
+      logger.warn({ chatJid, emoji }, 'Cannot send reaction - not connected');
+      throw new Error('Not connected to WhatsApp');
+    }
+    try {
+      await this.sock.sendMessage(chatJid, {
+        react: { text: emoji, key: messageKey },
+      });
+      logger.info(
+        {
+          chatJid,
+          messageId: messageKey.id?.slice(0, 10) + '...',
+          emoji: emoji || '(removed)',
+        },
+        emoji ? 'Reaction sent' : 'Reaction removed',
+      );
+    } catch (err) {
+      logger.error({ chatJid, emoji, err }, 'Failed to send reaction');
+      throw err;
+    }
+  }
+
+  async reactToLatestMessage(chatJid: string, emoji: string): Promise<void> {
+    const latest = getLatestMessage(chatJid);
+    if (!latest) {
+      throw new Error(`No messages found for chat ${chatJid}`);
+    }
+    const messageKey = {
+      id: latest.id,
+      remoteJid: chatJid,
+      fromMe: latest.fromMe,
+    };
+    await this.sendReaction(chatJid, messageKey, emoji);
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  ownsJid(jid: string): boolean {
+    return jid.endsWith('@g.us') || jid.endsWith('@s.whatsapp.net');
+  }
+
+  async disconnect(): Promise<void> {
+    this.connected = false;
+    this.sock?.end(undefined);
+  }
+
+  async setTyping(jid: string, isTyping: boolean): Promise<void> {
+    try {
+      const status = isTyping ? 'composing' : 'paused';
+      logger.debug({ jid, status }, 'Sending presence update');
+      await this.sock.sendPresenceUpdate(status, jid);
+    } catch (err) {
+      logger.debug({ jid, err }, 'Failed to update typing status');
+    }
+  }
+
+  /**
+   * Sync group metadata from WhatsApp.
+   * Fetches all participating groups and stores their names in the database.
+   * Called on startup, daily, and on-demand via IPC.
+   */
+  async syncGroupMetadata(force = false): Promise<void> {
+    if (!force) {
+      const lastSync = getLastGroupSync();
+      if (lastSync) {
+        const lastSyncTime = new Date(lastSync).getTime();
+        if (Date.now() - lastSyncTime < GROUP_SYNC_INTERVAL_MS) {
+          logger.debug({ lastSync }, 'Skipping group sync - synced recently');
+          return;
+        }
+      }
+    }
+
+    try {
+      logger.info('Syncing group metadata from WhatsApp...');
+      const groups = await this.sock.groupFetchAllParticipating();
+
+      let count = 0;
+      for (const [jid, metadata] of Object.entries(groups)) {
+        if (metadata.subject) {
+          updateChatName(jid, metadata.subject);
+          count++;
+        }
+      }
+
+      setLastGroupSync();
+      logger.info({ count }, 'Group metadata synced');
+    } catch (err) {
+      logger.error({ err }, 'Failed to sync group metadata');
+    }
+  }
+
+  private scheduleReconnect(attempt: number): void {
+    const delayMs = Math.min(5000 * Math.pow(2, attempt - 1), 300000);
+    logger.info({ attempt, delayMs }, 'Reconnecting...');
+    setTimeout(() => {
+      this.connectInternal().catch((err) => {
+        logger.error({ err, attempt }, 'Reconnection attempt failed');
+        this.scheduleReconnect(attempt + 1);
+      });
+    }, delayMs);
+  }
+
+  private async translateJid(jid: string): Promise<string> {
+    if (!jid.endsWith('@lid')) return jid;
+    const lidUser = jid.split('@')[0].split(':')[0];
+
+    // Check local cache first
+    const cached = this.lidToPhoneMap[lidUser];
+    if (cached) {
+      logger.debug(
+        { lidJid: jid, phoneJid: cached },
+        'Translated LID to phone JID (cached)',
+      );
+      return cached;
+    }
+
+    // Query Baileys' signal repository for the mapping
+    try {
+      const pn = await this.sock.signalRepository?.lidMapping?.getPNForLID(jid);
+      if (pn) {
+        const phoneJid = `${pn.split('@')[0].split(':')[0]}@s.whatsapp.net`;
+        this.lidToPhoneMap[lidUser] = phoneJid;
+        logger.info(
+          { lidJid: jid, phoneJid },
+          'Translated LID to phone JID (signalRepository)',
+        );
+        return phoneJid;
+      }
+    } catch (err) {
+      logger.debug({ err, jid }, 'Failed to resolve LID via signalRepository');
+    }
+
+    return jid;
+  }
+
+  private async flushOutgoingQueue(): Promise<void> {
+    if (this.flushing || this.outgoingQueue.length === 0) return;
+    this.flushing = true;
+    try {
+      logger.info(
+        { count: this.outgoingQueue.length },
+        'Flushing outgoing message queue',
+      );
+      while (this.outgoingQueue.length > 0) {
+        const item = this.outgoingQueue.shift()!;
+        // Send directly — queued items are already prefixed by sendMessage
+        await this.sock.sendMessage(item.jid, { text: item.text });
+        logger.info(
+          { jid: item.jid, length: item.text.length },
+          'Queued message sent',
+        );
+      }
+    } finally {
+      this.flushing = false;
+    }
+  }
+}
+
+registerChannel('whatsapp', (opts: ChannelOpts) => new WhatsAppChannel(opts));

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -26,6 +26,7 @@ import {
   stopContainer,
 } from './container-runtime.js';
 import { detectAuthMode } from './credential-proxy.js';
+import { readEnvFile } from './env.js';
 import { validateAdditionalMounts } from './mount-security.js';
 import { RegisteredGroup } from './types.js';
 
@@ -41,6 +42,7 @@ export interface ContainerInput {
   isMain: boolean;
   isScheduledTask?: boolean;
   assistantName?: string;
+  imageAttachments?: Array<{ relativePath: string; mediaType: string }>;
 }
 
 export interface ContainerOutput {
@@ -75,17 +77,6 @@ function buildVolumeMounts(
       containerPath: '/workspace/project',
       readonly: true,
     });
-
-    // Shadow .env so the agent cannot read secrets from the mounted project root.
-    // Credentials are injected by the credential proxy, never exposed to containers.
-    const envFile = path.join(projectRoot, '.env');
-    if (fs.existsSync(envFile)) {
-      mounts.push({
-        hostPath: '/dev/null',
-        containerPath: '/workspace/project/.env',
-        readonly: true,
-      });
-    }
 
     // Main also gets its group folder as the working directory
     mounts.push({
@@ -215,6 +206,7 @@ function buildVolumeMounts(
 function buildContainerArgs(
   mounts: VolumeMount[],
   containerName: string,
+  isMain: boolean,
 ): string[] {
   const args: string[] = ['run', '-i', '--rm', '--name', containerName];
 
@@ -238,6 +230,12 @@ function buildContainerArgs(
     args.push('-e', 'CLAUDE_CODE_OAUTH_TOKEN=placeholder');
   }
 
+  // Forward model selection to the container (supports LiteLLM / custom endpoints)
+  const { ANTHROPIC_MODEL: model } = readEnvFile(['ANTHROPIC_MODEL']);
+  if (model) {
+    args.push('-e', `ANTHROPIC_MODEL=${model}`);
+  }
+
   // Runtime-specific args for host gateway resolution
   args.push(...hostGatewayArgs());
 
@@ -247,7 +245,14 @@ function buildContainerArgs(
   const hostUid = process.getuid?.();
   const hostGid = process.getgid?.();
   if (hostUid != null && hostUid !== 0 && hostUid !== 1000) {
-    args.push('--user', `${hostUid}:${hostGid}`);
+    if (isMain) {
+      // Main containers start as root so the entrypoint can mount --bind
+      // to shadow .env. Privileges are dropped via setpriv in entrypoint.sh.
+      args.push('-e', `RUN_UID=${hostUid}`);
+      args.push('-e', `RUN_GID=${hostGid}`);
+    } else {
+      args.push('--user', `${hostUid}:${hostGid}`);
+    }
     args.push('-e', 'HOME=/home/node');
   }
 
@@ -278,7 +283,7 @@ export async function runContainerAgent(
   const mounts = buildVolumeMounts(group, input.isMain);
   const safeName = group.folder.replace(/[^a-zA-Z0-9-]/g, '-');
   const containerName = `nanoclaw-${safeName}-${Date.now()}`;
-  const containerArgs = buildContainerArgs(mounts, containerName);
+  const containerArgs = buildContainerArgs(mounts, containerName, input.isMain);
 
   logger.debug(
     {

--- a/src/container-runtime.test.ts
+++ b/src/container-runtime.test.ts
@@ -32,9 +32,12 @@ beforeEach(() => {
 // --- Pure functions ---
 
 describe('readonlyMountArgs', () => {
-  it('returns -v flag with :ro suffix', () => {
+  it('returns --mount flag with type=bind and readonly', () => {
     const args = readonlyMountArgs('/host/path', '/container/path');
-    expect(args).toEqual(['-v', '/host/path:/container/path:ro']);
+    expect(args).toEqual([
+      '--mount',
+      'type=bind,source=/host/path,target=/container/path,readonly',
+    ]);
   });
 });
 
@@ -55,18 +58,37 @@ describe('ensureContainerRuntimeRunning', () => {
     ensureContainerRuntimeRunning();
 
     expect(mockExecSync).toHaveBeenCalledTimes(1);
-    expect(mockExecSync).toHaveBeenCalledWith(`${CONTAINER_RUNTIME_BIN} info`, {
-      stdio: 'pipe',
-      timeout: 10000,
-    });
+    expect(mockExecSync).toHaveBeenCalledWith(
+      `${CONTAINER_RUNTIME_BIN} system status`,
+      { stdio: 'pipe' },
+    );
     expect(logger.debug).toHaveBeenCalledWith(
       'Container runtime already running',
     );
   });
 
-  it('throws when docker info fails', () => {
+  it('auto-starts when system status fails', () => {
+    // First call (system status) fails
     mockExecSync.mockImplementationOnce(() => {
-      throw new Error('Cannot connect to the Docker daemon');
+      throw new Error('not running');
+    });
+    // Second call (system start) succeeds
+    mockExecSync.mockReturnValueOnce('');
+
+    ensureContainerRuntimeRunning();
+
+    expect(mockExecSync).toHaveBeenCalledTimes(2);
+    expect(mockExecSync).toHaveBeenNthCalledWith(
+      2,
+      `${CONTAINER_RUNTIME_BIN} system start`,
+      { stdio: 'pipe', timeout: 30000 },
+    );
+    expect(logger.info).toHaveBeenCalledWith('Container runtime started');
+  });
+
+  it('throws when both status and start fail', () => {
+    mockExecSync.mockImplementation(() => {
+      throw new Error('failed');
     });
 
     expect(() => ensureContainerRuntimeRunning()).toThrow(
@@ -79,17 +101,21 @@ describe('ensureContainerRuntimeRunning', () => {
 // --- cleanupOrphans ---
 
 describe('cleanupOrphans', () => {
-  it('stops orphaned nanoclaw containers', () => {
-    // docker ps returns container names, one per line
-    mockExecSync.mockReturnValueOnce(
-      'nanoclaw-group1-111\nnanoclaw-group2-222\n',
-    );
+  it('stops orphaned nanoclaw containers from JSON output', () => {
+    // Apple Container ls returns JSON
+    const lsOutput = JSON.stringify([
+      { status: 'running', configuration: { id: 'nanoclaw-group1-111' } },
+      { status: 'stopped', configuration: { id: 'nanoclaw-group2-222' } },
+      { status: 'running', configuration: { id: 'nanoclaw-group3-333' } },
+      { status: 'running', configuration: { id: 'other-container' } },
+    ]);
+    mockExecSync.mockReturnValueOnce(lsOutput);
     // stop calls succeed
     mockExecSync.mockReturnValue('');
 
     cleanupOrphans();
 
-    // ps + 2 stop calls
+    // ls + 2 stop calls (only running nanoclaw- containers)
     expect(mockExecSync).toHaveBeenCalledTimes(3);
     expect(mockExecSync).toHaveBeenNthCalledWith(
       2,
@@ -98,17 +124,17 @@ describe('cleanupOrphans', () => {
     );
     expect(mockExecSync).toHaveBeenNthCalledWith(
       3,
-      `${CONTAINER_RUNTIME_BIN} stop nanoclaw-group2-222`,
+      `${CONTAINER_RUNTIME_BIN} stop nanoclaw-group3-333`,
       { stdio: 'pipe' },
     );
     expect(logger.info).toHaveBeenCalledWith(
-      { count: 2, names: ['nanoclaw-group1-111', 'nanoclaw-group2-222'] },
+      { count: 2, names: ['nanoclaw-group1-111', 'nanoclaw-group3-333'] },
       'Stopped orphaned containers',
     );
   });
 
   it('does nothing when no orphans exist', () => {
-    mockExecSync.mockReturnValueOnce('');
+    mockExecSync.mockReturnValueOnce('[]');
 
     cleanupOrphans();
 
@@ -116,9 +142,9 @@ describe('cleanupOrphans', () => {
     expect(logger.info).not.toHaveBeenCalled();
   });
 
-  it('warns and continues when ps fails', () => {
+  it('warns and continues when ls fails', () => {
     mockExecSync.mockImplementationOnce(() => {
-      throw new Error('docker not available');
+      throw new Error('container not available');
     });
 
     cleanupOrphans(); // should not throw
@@ -130,7 +156,11 @@ describe('cleanupOrphans', () => {
   });
 
   it('continues stopping remaining containers when one stop fails', () => {
-    mockExecSync.mockReturnValueOnce('nanoclaw-a-1\nnanoclaw-b-2\n');
+    const lsOutput = JSON.stringify([
+      { status: 'running', configuration: { id: 'nanoclaw-a-1' } },
+      { status: 'running', configuration: { id: 'nanoclaw-b-2' } },
+    ]);
+    mockExecSync.mockReturnValueOnce(lsOutput);
     // First stop fails
     mockExecSync.mockImplementationOnce(() => {
       throw new Error('already stopped');

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -9,10 +9,17 @@ import os from 'os';
 import { logger } from './logger.js';
 
 /** The container runtime binary name. */
-export const CONTAINER_RUNTIME_BIN = 'docker';
+export const CONTAINER_RUNTIME_BIN = 'container';
 
-/** Hostname containers use to reach the host machine. */
-export const CONTAINER_HOST_GATEWAY = 'host.docker.internal';
+/**
+ * Hostname/IP containers use to reach the host machine.
+ * Apple Container: use the bridge IP directly (no host.docker.internal support, no --add-host).
+ * Docker Desktop / Docker Linux: use host.docker.internal.
+ */
+export const CONTAINER_HOST_GATEWAY =
+  os.platform() === 'darwin'
+    ? (detectAppleContainerBridgeIp() ?? 'host.docker.internal')
+    : 'host.docker.internal';
 
 /**
  * Address the credential proxy binds to.
@@ -23,8 +30,29 @@ export const CONTAINER_HOST_GATEWAY = 'host.docker.internal';
 export const PROXY_BIND_HOST =
   process.env.CREDENTIAL_PROXY_HOST || detectProxyBindHost();
 
+/**
+ * Detect the Apple Container bridge IP on macOS.
+ * Apple Container creates a bridge interface (bridge100, etc.) with a 192.168.x.1 address.
+ * Returns the host-side IP of that bridge, or null if not found.
+ */
+function detectAppleContainerBridgeIp(): string | null {
+  const ifaces = os.networkInterfaces();
+  for (const [name, addrs] of Object.entries(ifaces)) {
+    if (!name.startsWith('bridge') || !addrs) continue;
+    const ipv4 = addrs.find((a) => a.family === 'IPv4' && !a.internal);
+    if (ipv4) return ipv4.address;
+  }
+  return null;
+}
+
 function detectProxyBindHost(): string {
-  if (os.platform() === 'darwin') return '127.0.0.1';
+  if (os.platform() === 'darwin') {
+    // Apple Container: bind to the bridge interface so containers can reach the proxy.
+    // Docker Desktop: 127.0.0.1 works because the VM routes host.docker.internal to loopback.
+    const bridgeIp = detectAppleContainerBridgeIp();
+    if (bridgeIp) return bridgeIp;
+    return '127.0.0.1';
+  }
 
   // WSL uses Docker Desktop (same VM routing as macOS) — loopback is correct.
   // Check /proc filesystem, not env vars — WSL_DISTRO_NAME isn't set under systemd.
@@ -42,7 +70,9 @@ function detectProxyBindHost(): string {
 
 /** CLI args needed for the container to resolve the host gateway. */
 export function hostGatewayArgs(): string[] {
-  // On Linux, host.docker.internal isn't built-in — add it explicitly
+  // Apple Container (macOS): CONTAINER_HOST_GATEWAY is already the bridge IP — no extra args.
+  // Docker Desktop (macOS): host.docker.internal is built-in — no extra args.
+  // Docker (Linux): host.docker.internal isn't built-in — add it explicitly.
   if (os.platform() === 'linux') {
     return ['--add-host=host.docker.internal:host-gateway'];
   }
@@ -54,7 +84,10 @@ export function readonlyMountArgs(
   hostPath: string,
   containerPath: string,
 ): string[] {
-  return ['-v', `${hostPath}:${containerPath}:ro`];
+  return [
+    '--mount',
+    `type=bind,source=${hostPath},target=${containerPath},readonly`,
+  ];
 }
 
 /** Returns the shell command to stop a container by name. */
@@ -65,49 +98,62 @@ export function stopContainer(name: string): string {
 /** Ensure the container runtime is running, starting it if needed. */
 export function ensureContainerRuntimeRunning(): void {
   try {
-    execSync(`${CONTAINER_RUNTIME_BIN} info`, {
-      stdio: 'pipe',
-      timeout: 10000,
-    });
+    execSync(`${CONTAINER_RUNTIME_BIN} system status`, { stdio: 'pipe' });
     logger.debug('Container runtime already running');
-  } catch (err) {
-    logger.error({ err }, 'Failed to reach container runtime');
-    console.error(
-      '\n╔════════════════════════════════════════════════════════════════╗',
-    );
-    console.error(
-      '║  FATAL: Container runtime failed to start                      ║',
-    );
-    console.error(
-      '║                                                                ║',
-    );
-    console.error(
-      '║  Agents cannot run without a container runtime. To fix:        ║',
-    );
-    console.error(
-      '║  1. Ensure Docker is installed and running                     ║',
-    );
-    console.error(
-      '║  2. Run: docker info                                           ║',
-    );
-    console.error(
-      '║  3. Restart NanoClaw                                           ║',
-    );
-    console.error(
-      '╚════════════════════════════════════════════════════════════════╝\n',
-    );
-    throw new Error('Container runtime is required but failed to start');
+  } catch {
+    logger.info('Starting container runtime...');
+    try {
+      execSync(`${CONTAINER_RUNTIME_BIN} system start`, {
+        stdio: 'pipe',
+        timeout: 30000,
+      });
+      logger.info('Container runtime started');
+    } catch (err) {
+      logger.error({ err }, 'Failed to start container runtime');
+      console.error(
+        '\n╔════════════════════════════════════════════════════════════════╗',
+      );
+      console.error(
+        '║  FATAL: Container runtime failed to start                      ║',
+      );
+      console.error(
+        '║                                                                ║',
+      );
+      console.error(
+        '║  Agents cannot run without a container runtime. To fix:        ║',
+      );
+      console.error(
+        '║  1. Ensure Apple Container is installed                        ║',
+      );
+      console.error(
+        '║  2. Run: container system start                                ║',
+      );
+      console.error(
+        '║  3. Restart NanoClaw                                           ║',
+      );
+      console.error(
+        '╚════════════════════════════════════════════════════════════════╝\n',
+      );
+      throw new Error('Container runtime is required but failed to start');
+    }
   }
 }
 
 /** Kill orphaned NanoClaw containers from previous runs. */
 export function cleanupOrphans(): void {
   try {
-    const output = execSync(
-      `${CONTAINER_RUNTIME_BIN} ps --filter name=nanoclaw- --format '{{.Names}}'`,
-      { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8' },
-    );
-    const orphans = output.trim().split('\n').filter(Boolean);
+    const output = execSync(`${CONTAINER_RUNTIME_BIN} ls --format json`, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      encoding: 'utf-8',
+    });
+    const containers: { status: string; configuration: { id: string } }[] =
+      JSON.parse(output || '[]');
+    const orphans = containers
+      .filter(
+        (c) =>
+          c.status === 'running' && c.configuration.id.startsWith('nanoclaw-'),
+      )
+      .map((c) => c.configuration.id);
     for (const name of orphans) {
       try {
         execSync(stopContainer(name), { stdio: 'pipe' });

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -5,13 +5,18 @@ import {
   createTask,
   deleteTask,
   getAllChats,
-  getAllRegisteredGroups,
+  getLatestMessage,
+  getMessageFromMe,
+  getMessagesByReaction,
   getMessagesSince,
   getNewMessages,
+  getReactionsForMessage,
+  getReactionsByUser,
+  getReactionStats,
   getTaskById,
-  setRegisteredGroup,
   storeChatMetadata,
   storeMessage,
+  storeReaction,
   updateTask,
 } from './db.js';
 
@@ -391,94 +396,320 @@ describe('task CRUD', () => {
   });
 });
 
-// --- LIMIT behavior ---
+// --- getLatestMessage ---
 
-describe('message query LIMIT', () => {
-  beforeEach(() => {
+describe('getLatestMessage', () => {
+  it('returns the most recent message for a chat', () => {
     storeChatMetadata('group@g.us', '2024-01-01T00:00:00.000Z');
+    store({
+      id: 'old',
+      chat_jid: 'group@g.us',
+      sender: 'a@s.whatsapp.net',
+      sender_name: 'A',
+      content: 'old',
+      timestamp: '2024-01-01T00:00:01.000Z',
+    });
+    store({
+      id: 'new',
+      chat_jid: 'group@g.us',
+      sender: 'b@s.whatsapp.net',
+      sender_name: 'B',
+      content: 'new',
+      timestamp: '2024-01-01T00:00:02.000Z',
+    });
 
-    for (let i = 1; i <= 10; i++) {
-      store({
-        id: `lim-${i}`,
-        chat_jid: 'group@g.us',
-        sender: 'user@s.whatsapp.net',
-        sender_name: 'User',
-        content: `message ${i}`,
-        timestamp: `2024-01-01T00:00:${String(i).padStart(2, '0')}.000Z`,
-      });
-    }
+    const latest = getLatestMessage('group@g.us');
+    expect(latest).toEqual({ id: 'new', fromMe: false });
   });
 
-  it('getNewMessages caps to limit and returns most recent in chronological order', () => {
-    const { messages, newTimestamp } = getNewMessages(
-      ['group@g.us'],
-      '2024-01-01T00:00:00.000Z',
-      'Andy',
-      3,
-    );
-    expect(messages).toHaveLength(3);
-    expect(messages[0].content).toBe('message 8');
-    expect(messages[2].content).toBe('message 10');
-    // Chronological order preserved
-    expect(messages[1].timestamp > messages[0].timestamp).toBe(true);
-    // newTimestamp reflects latest returned row
-    expect(newTimestamp).toBe('2024-01-01T00:00:10.000Z');
+  it('returns fromMe: true for own messages', () => {
+    storeChatMetadata('group@g.us', '2024-01-01T00:00:00.000Z');
+    store({
+      id: 'mine',
+      chat_jid: 'group@g.us',
+      sender: 'me@s.whatsapp.net',
+      sender_name: 'Me',
+      content: 'my msg',
+      timestamp: '2024-01-01T00:00:01.000Z',
+      is_from_me: true,
+    });
+
+    const latest = getLatestMessage('group@g.us');
+    expect(latest).toEqual({ id: 'mine', fromMe: true });
   });
 
-  it('getMessagesSince caps to limit and returns most recent in chronological order', () => {
-    const messages = getMessagesSince(
-      'group@g.us',
-      '2024-01-01T00:00:00.000Z',
-      'Andy',
-      3,
-    );
-    expect(messages).toHaveLength(3);
-    expect(messages[0].content).toBe('message 8');
-    expect(messages[2].content).toBe('message 10');
-    expect(messages[1].timestamp > messages[0].timestamp).toBe(true);
-  });
-
-  it('returns all messages when count is under the limit', () => {
-    const { messages } = getNewMessages(
-      ['group@g.us'],
-      '2024-01-01T00:00:00.000Z',
-      'Andy',
-      50,
-    );
-    expect(messages).toHaveLength(10);
+  it('returns undefined for empty chat', () => {
+    expect(getLatestMessage('nonexistent@g.us')).toBeUndefined();
   });
 });
 
-// --- RegisteredGroup isMain round-trip ---
+// --- getMessageFromMe ---
 
-describe('registered group isMain', () => {
-  it('persists isMain=true through set/get round-trip', () => {
-    setRegisteredGroup('main@s.whatsapp.net', {
-      name: 'Main Chat',
-      folder: 'whatsapp_main',
-      trigger: '@Andy',
-      added_at: '2024-01-01T00:00:00.000Z',
-      isMain: true,
+describe('getMessageFromMe', () => {
+  it('returns true for own messages', () => {
+    storeChatMetadata('group@g.us', '2024-01-01T00:00:00.000Z');
+    store({
+      id: 'mine',
+      chat_jid: 'group@g.us',
+      sender: 'me@s.whatsapp.net',
+      sender_name: 'Me',
+      content: 'my msg',
+      timestamp: '2024-01-01T00:00:01.000Z',
+      is_from_me: true,
     });
 
-    const groups = getAllRegisteredGroups();
-    const group = groups['main@s.whatsapp.net'];
-    expect(group).toBeDefined();
-    expect(group.isMain).toBe(true);
-    expect(group.folder).toBe('whatsapp_main');
+    expect(getMessageFromMe('mine', 'group@g.us')).toBe(true);
   });
 
-  it('omits isMain for non-main groups', () => {
-    setRegisteredGroup('group@g.us', {
-      name: 'Family Chat',
-      folder: 'whatsapp_family-chat',
-      trigger: '@Andy',
-      added_at: '2024-01-01T00:00:00.000Z',
+  it('returns false for other messages', () => {
+    storeChatMetadata('group@g.us', '2024-01-01T00:00:00.000Z');
+    store({
+      id: 'theirs',
+      chat_jid: 'group@g.us',
+      sender: 'a@s.whatsapp.net',
+      sender_name: 'A',
+      content: 'their msg',
+      timestamp: '2024-01-01T00:00:01.000Z',
     });
 
-    const groups = getAllRegisteredGroups();
-    const group = groups['group@g.us'];
-    expect(group).toBeDefined();
-    expect(group.isMain).toBeUndefined();
+    expect(getMessageFromMe('theirs', 'group@g.us')).toBe(false);
+  });
+
+  it('returns false for nonexistent message', () => {
+    expect(getMessageFromMe('nonexistent', 'group@g.us')).toBe(false);
+  });
+});
+
+// --- storeReaction ---
+
+describe('storeReaction', () => {
+  it('stores and retrieves a reaction', () => {
+    storeReaction({
+      message_id: 'msg-1',
+      message_chat_jid: 'group@g.us',
+      reactor_jid: 'user@s.whatsapp.net',
+      reactor_name: 'Alice',
+      emoji: '👍',
+      timestamp: '2024-01-01T00:00:01.000Z',
+    });
+
+    const reactions = getReactionsForMessage('msg-1', 'group@g.us');
+    expect(reactions).toHaveLength(1);
+    expect(reactions[0].emoji).toBe('👍');
+    expect(reactions[0].reactor_name).toBe('Alice');
+  });
+
+  it('upserts on same reactor + message', () => {
+    const base = {
+      message_id: 'msg-1',
+      message_chat_jid: 'group@g.us',
+      reactor_jid: 'user@s.whatsapp.net',
+      reactor_name: 'Alice',
+      timestamp: '2024-01-01T00:00:01.000Z',
+    };
+    storeReaction({ ...base, emoji: '👍' });
+    storeReaction({
+      ...base,
+      emoji: '❤️',
+      timestamp: '2024-01-01T00:00:02.000Z',
+    });
+
+    const reactions = getReactionsForMessage('msg-1', 'group@g.us');
+    expect(reactions).toHaveLength(1);
+    expect(reactions[0].emoji).toBe('❤️');
+  });
+
+  it('removes reaction when emoji is empty', () => {
+    storeReaction({
+      message_id: 'msg-1',
+      message_chat_jid: 'group@g.us',
+      reactor_jid: 'user@s.whatsapp.net',
+      emoji: '👍',
+      timestamp: '2024-01-01T00:00:01.000Z',
+    });
+    storeReaction({
+      message_id: 'msg-1',
+      message_chat_jid: 'group@g.us',
+      reactor_jid: 'user@s.whatsapp.net',
+      emoji: '',
+      timestamp: '2024-01-01T00:00:02.000Z',
+    });
+
+    expect(getReactionsForMessage('msg-1', 'group@g.us')).toHaveLength(0);
+  });
+});
+
+// --- getReactionsForMessage ---
+
+describe('getReactionsForMessage', () => {
+  it('returns multiple reactions ordered by timestamp', () => {
+    storeReaction({
+      message_id: 'msg-1',
+      message_chat_jid: 'group@g.us',
+      reactor_jid: 'b@s.whatsapp.net',
+      emoji: '❤️',
+      timestamp: '2024-01-01T00:00:02.000Z',
+    });
+    storeReaction({
+      message_id: 'msg-1',
+      message_chat_jid: 'group@g.us',
+      reactor_jid: 'a@s.whatsapp.net',
+      emoji: '👍',
+      timestamp: '2024-01-01T00:00:01.000Z',
+    });
+
+    const reactions = getReactionsForMessage('msg-1', 'group@g.us');
+    expect(reactions).toHaveLength(2);
+    expect(reactions[0].reactor_jid).toBe('a@s.whatsapp.net');
+    expect(reactions[1].reactor_jid).toBe('b@s.whatsapp.net');
+  });
+
+  it('returns empty array for message with no reactions', () => {
+    expect(getReactionsForMessage('nonexistent', 'group@g.us')).toEqual([]);
+  });
+});
+
+// --- getMessagesByReaction ---
+
+describe('getMessagesByReaction', () => {
+  beforeEach(() => {
+    storeChatMetadata('group@g.us', '2024-01-01T00:00:00.000Z');
+    store({
+      id: 'msg-1',
+      chat_jid: 'group@g.us',
+      sender: 'author@s.whatsapp.net',
+      sender_name: 'Author',
+      content: 'bookmarked msg',
+      timestamp: '2024-01-01T00:00:01.000Z',
+    });
+    storeReaction({
+      message_id: 'msg-1',
+      message_chat_jid: 'group@g.us',
+      reactor_jid: 'user@s.whatsapp.net',
+      emoji: '📌',
+      timestamp: '2024-01-01T00:00:02.000Z',
+    });
+  });
+
+  it('joins reactions with messages', () => {
+    const results = getMessagesByReaction('user@s.whatsapp.net', '📌');
+    expect(results).toHaveLength(1);
+    expect(results[0].content).toBe('bookmarked msg');
+    expect(results[0].sender_name).toBe('Author');
+  });
+
+  it('filters by chatJid when provided', () => {
+    const results = getMessagesByReaction(
+      'user@s.whatsapp.net',
+      '📌',
+      'group@g.us',
+    );
+    expect(results).toHaveLength(1);
+
+    const empty = getMessagesByReaction(
+      'user@s.whatsapp.net',
+      '📌',
+      'other@g.us',
+    );
+    expect(empty).toHaveLength(0);
+  });
+
+  it('returns empty when no matching reactions', () => {
+    expect(getMessagesByReaction('user@s.whatsapp.net', '🔥')).toHaveLength(0);
+  });
+});
+
+// --- getReactionsByUser ---
+
+describe('getReactionsByUser', () => {
+  it('returns reactions for a user ordered by timestamp desc', () => {
+    storeReaction({
+      message_id: 'msg-1',
+      message_chat_jid: 'group@g.us',
+      reactor_jid: 'user@s.whatsapp.net',
+      emoji: '👍',
+      timestamp: '2024-01-01T00:00:01.000Z',
+    });
+    storeReaction({
+      message_id: 'msg-2',
+      message_chat_jid: 'group@g.us',
+      reactor_jid: 'user@s.whatsapp.net',
+      emoji: '❤️',
+      timestamp: '2024-01-01T00:00:02.000Z',
+    });
+
+    const reactions = getReactionsByUser('user@s.whatsapp.net');
+    expect(reactions).toHaveLength(2);
+    expect(reactions[0].emoji).toBe('❤️'); // newer first
+    expect(reactions[1].emoji).toBe('👍');
+  });
+
+  it('respects the limit parameter', () => {
+    for (let i = 0; i < 5; i++) {
+      storeReaction({
+        message_id: `msg-${i}`,
+        message_chat_jid: 'group@g.us',
+        reactor_jid: 'user@s.whatsapp.net',
+        emoji: '👍',
+        timestamp: `2024-01-01T00:00:0${i}.000Z`,
+      });
+    }
+
+    expect(getReactionsByUser('user@s.whatsapp.net', 3)).toHaveLength(3);
+  });
+
+  it('returns empty for user with no reactions', () => {
+    expect(getReactionsByUser('nobody@s.whatsapp.net')).toEqual([]);
+  });
+});
+
+// --- getReactionStats ---
+
+describe('getReactionStats', () => {
+  beforeEach(() => {
+    storeReaction({
+      message_id: 'msg-1',
+      message_chat_jid: 'group@g.us',
+      reactor_jid: 'a@s.whatsapp.net',
+      emoji: '👍',
+      timestamp: '2024-01-01T00:00:01.000Z',
+    });
+    storeReaction({
+      message_id: 'msg-2',
+      message_chat_jid: 'group@g.us',
+      reactor_jid: 'b@s.whatsapp.net',
+      emoji: '👍',
+      timestamp: '2024-01-01T00:00:02.000Z',
+    });
+    storeReaction({
+      message_id: 'msg-1',
+      message_chat_jid: 'group@g.us',
+      reactor_jid: 'c@s.whatsapp.net',
+      emoji: '❤️',
+      timestamp: '2024-01-01T00:00:03.000Z',
+    });
+    storeReaction({
+      message_id: 'msg-1',
+      message_chat_jid: 'other@g.us',
+      reactor_jid: 'a@s.whatsapp.net',
+      emoji: '🔥',
+      timestamp: '2024-01-01T00:00:04.000Z',
+    });
+  });
+
+  it('returns global stats ordered by count desc', () => {
+    const stats = getReactionStats();
+    expect(stats[0]).toEqual({ emoji: '👍', count: 2 });
+    expect(stats).toHaveLength(3);
+  });
+
+  it('filters by chatJid', () => {
+    const stats = getReactionStats('group@g.us');
+    expect(stats).toHaveLength(2);
+    expect(stats.find((s) => s.emoji === '🔥')).toBeUndefined();
+  });
+
+  it('returns empty for chat with no reactions', () => {
+    expect(getReactionStats('empty@g.us')).toEqual([]);
   });
 });

--- a/src/db.ts
+++ b/src/db.ts
@@ -14,6 +14,15 @@ import {
 
 let db: Database.Database;
 
+export interface Reaction {
+  message_id: string;
+  message_chat_jid: string;
+  reactor_jid: string;
+  reactor_name?: string;
+  emoji: string;
+  timestamp: string;
+}
+
 function createSchema(database: Database.Database): void {
   database.exec(`
     CREATE TABLE IF NOT EXISTS chats (
@@ -82,6 +91,20 @@ function createSchema(database: Database.Database): void {
       container_config TEXT,
       requires_trigger INTEGER DEFAULT 1
     );
+
+    CREATE TABLE IF NOT EXISTS reactions (
+      message_id TEXT NOT NULL,
+      message_chat_jid TEXT NOT NULL,
+      reactor_jid TEXT NOT NULL,
+      reactor_name TEXT,
+      emoji TEXT NOT NULL,
+      timestamp TEXT NOT NULL,
+      PRIMARY KEY (message_id, message_chat_jid, reactor_jid)
+    );
+    CREATE INDEX IF NOT EXISTS idx_reactions_message ON reactions(message_id, message_chat_jid);
+    CREATE INDEX IF NOT EXISTS idx_reactions_reactor ON reactions(reactor_jid);
+    CREATE INDEX IF NOT EXISTS idx_reactions_emoji ON reactions(emoji);
+    CREATE INDEX IF NOT EXISTS idx_reactions_timestamp ON reactions(timestamp);
   `);
 
   // Add context_mode column if it doesn't exist (migration for existing DBs)
@@ -102,19 +125,6 @@ function createSchema(database: Database.Database): void {
     database
       .prepare(`UPDATE messages SET is_bot_message = 1 WHERE content LIKE ?`)
       .run(`${ASSISTANT_NAME}:%`);
-  } catch {
-    /* column already exists */
-  }
-
-  // Add is_main column if it doesn't exist (migration for existing DBs)
-  try {
-    database.exec(
-      `ALTER TABLE registered_groups ADD COLUMN is_main INTEGER DEFAULT 0`,
-    );
-    // Backfill: existing rows with folder = 'main' are the main group
-    database.exec(
-      `UPDATE registered_groups SET is_main = 1 WHERE folder = 'main'`,
-    );
   } catch {
     /* column already exists */
   }
@@ -276,7 +286,7 @@ export function storeMessage(msg: NewMessage): void {
 }
 
 /**
- * Store a message directly.
+ * Store a message directly (for non-WhatsApp channels that don't use Baileys proto).
  */
 export function storeMessageDirect(msg: {
   id: string;
@@ -306,29 +316,24 @@ export function getNewMessages(
   jids: string[],
   lastTimestamp: string,
   botPrefix: string,
-  limit: number = 200,
 ): { messages: NewMessage[]; newTimestamp: string } {
   if (jids.length === 0) return { messages: [], newTimestamp: lastTimestamp };
 
   const placeholders = jids.map(() => '?').join(',');
   // Filter bot messages using both the is_bot_message flag AND the content
   // prefix as a backstop for messages written before the migration ran.
-  // Subquery takes the N most recent, outer query re-sorts chronologically.
   const sql = `
-    SELECT * FROM (
-      SELECT id, chat_jid, sender, sender_name, content, timestamp, is_from_me
-      FROM messages
-      WHERE timestamp > ? AND chat_jid IN (${placeholders})
-        AND is_bot_message = 0 AND content NOT LIKE ?
-        AND content != '' AND content IS NOT NULL
-      ORDER BY timestamp DESC
-      LIMIT ?
-    ) ORDER BY timestamp
+    SELECT id, chat_jid, sender, sender_name, content, timestamp
+    FROM messages
+    WHERE timestamp > ? AND chat_jid IN (${placeholders})
+      AND is_bot_message = 0 AND content NOT LIKE ?
+      AND content != '' AND content IS NOT NULL
+    ORDER BY timestamp
   `;
 
   const rows = db
     .prepare(sql)
-    .all(lastTimestamp, ...jids, `${botPrefix}:%`, limit) as NewMessage[];
+    .all(lastTimestamp, ...jids, `${botPrefix}:%`) as NewMessage[];
 
   let newTimestamp = lastTimestamp;
   for (const row of rows) {
@@ -342,25 +347,141 @@ export function getMessagesSince(
   chatJid: string,
   sinceTimestamp: string,
   botPrefix: string,
-  limit: number = 200,
 ): NewMessage[] {
   // Filter bot messages using both the is_bot_message flag AND the content
   // prefix as a backstop for messages written before the migration ran.
-  // Subquery takes the N most recent, outer query re-sorts chronologically.
   const sql = `
-    SELECT * FROM (
-      SELECT id, chat_jid, sender, sender_name, content, timestamp, is_from_me
-      FROM messages
-      WHERE chat_jid = ? AND timestamp > ?
-        AND is_bot_message = 0 AND content NOT LIKE ?
-        AND content != '' AND content IS NOT NULL
-      ORDER BY timestamp DESC
-      LIMIT ?
-    ) ORDER BY timestamp
+    SELECT id, chat_jid, sender, sender_name, content, timestamp
+    FROM messages
+    WHERE chat_jid = ? AND timestamp > ?
+      AND is_bot_message = 0 AND content NOT LIKE ?
+      AND content != '' AND content IS NOT NULL
+    ORDER BY timestamp
   `;
   return db
     .prepare(sql)
-    .all(chatJid, sinceTimestamp, `${botPrefix}:%`, limit) as NewMessage[];
+    .all(chatJid, sinceTimestamp, `${botPrefix}:%`) as NewMessage[];
+}
+
+export function getMessageFromMe(messageId: string, chatJid: string): boolean {
+  const row = db
+    .prepare(
+      `SELECT is_from_me FROM messages WHERE id = ? AND chat_jid = ? LIMIT 1`,
+    )
+    .get(messageId, chatJid) as { is_from_me: number | null } | undefined;
+  return row?.is_from_me === 1;
+}
+
+export function getLatestMessage(
+  chatJid: string,
+): { id: string; fromMe: boolean } | undefined {
+  const row = db
+    .prepare(
+      `SELECT id, is_from_me FROM messages WHERE chat_jid = ? ORDER BY timestamp DESC LIMIT 1`,
+    )
+    .get(chatJid) as { id: string; is_from_me: number | null } | undefined;
+  if (!row) return undefined;
+  return { id: row.id, fromMe: row.is_from_me === 1 };
+}
+
+export function storeReaction(reaction: Reaction): void {
+  if (!reaction.emoji) {
+    db.prepare(
+      `DELETE FROM reactions WHERE message_id = ? AND message_chat_jid = ? AND reactor_jid = ?`,
+    ).run(reaction.message_id, reaction.message_chat_jid, reaction.reactor_jid);
+    return;
+  }
+  db.prepare(
+    `INSERT OR REPLACE INTO reactions (message_id, message_chat_jid, reactor_jid, reactor_name, emoji, timestamp)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run(
+    reaction.message_id,
+    reaction.message_chat_jid,
+    reaction.reactor_jid,
+    reaction.reactor_name || null,
+    reaction.emoji,
+    reaction.timestamp,
+  );
+}
+
+export function getReactionsForMessage(
+  messageId: string,
+  chatJid: string,
+): Reaction[] {
+  return db
+    .prepare(
+      `SELECT * FROM reactions WHERE message_id = ? AND message_chat_jid = ? ORDER BY timestamp`,
+    )
+    .all(messageId, chatJid) as Reaction[];
+}
+
+export function getMessagesByReaction(
+  reactorJid: string,
+  emoji: string,
+  chatJid?: string,
+): Array<
+  Reaction & { content: string; sender_name: string; message_timestamp: string }
+> {
+  const sql = chatJid
+    ? `
+      SELECT r.*, m.content, m.sender_name, m.timestamp as message_timestamp
+      FROM reactions r
+      JOIN messages m ON r.message_id = m.id AND r.message_chat_jid = m.chat_jid
+      WHERE r.reactor_jid = ? AND r.emoji = ? AND r.message_chat_jid = ?
+      ORDER BY r.timestamp DESC
+    `
+    : `
+      SELECT r.*, m.content, m.sender_name, m.timestamp as message_timestamp
+      FROM reactions r
+      JOIN messages m ON r.message_id = m.id AND r.message_chat_jid = m.chat_jid
+      WHERE r.reactor_jid = ? AND r.emoji = ?
+      ORDER BY r.timestamp DESC
+    `;
+
+  type Result = Reaction & {
+    content: string;
+    sender_name: string;
+    message_timestamp: string;
+  };
+  return chatJid
+    ? (db.prepare(sql).all(reactorJid, emoji, chatJid) as Result[])
+    : (db.prepare(sql).all(reactorJid, emoji) as Result[]);
+}
+
+export function getReactionsByUser(
+  reactorJid: string,
+  limit: number = 50,
+): Reaction[] {
+  return db
+    .prepare(
+      `SELECT * FROM reactions WHERE reactor_jid = ? ORDER BY timestamp DESC LIMIT ?`,
+    )
+    .all(reactorJid, limit) as Reaction[];
+}
+
+export function getReactionStats(chatJid?: string): Array<{
+  emoji: string;
+  count: number;
+}> {
+  const sql = chatJid
+    ? `
+      SELECT emoji, COUNT(*) as count
+      FROM reactions
+      WHERE message_chat_jid = ?
+      GROUP BY emoji
+      ORDER BY count DESC
+    `
+    : `
+      SELECT emoji, COUNT(*) as count
+      FROM reactions
+      GROUP BY emoji
+      ORDER BY count DESC
+    `;
+
+  type Result = { emoji: string; count: number };
+  return chatJid
+    ? (db.prepare(sql).all(chatJid) as Result[])
+    : (db.prepare(sql).all() as Result[]);
 }
 
 export function createTask(
@@ -553,7 +674,6 @@ export function getRegisteredGroup(
         added_at: string;
         container_config: string | null;
         requires_trigger: number | null;
-        is_main: number | null;
       }
     | undefined;
   if (!row) return undefined;
@@ -575,7 +695,6 @@ export function getRegisteredGroup(
       : undefined,
     requiresTrigger:
       row.requires_trigger === null ? undefined : row.requires_trigger === 1,
-    isMain: row.is_main === 1 ? true : undefined,
   };
 }
 
@@ -584,8 +703,8 @@ export function setRegisteredGroup(jid: string, group: RegisteredGroup): void {
     throw new Error(`Invalid group folder "${group.folder}" for JID ${jid}`);
   }
   db.prepare(
-    `INSERT OR REPLACE INTO registered_groups (jid, name, folder, trigger_pattern, added_at, container_config, requires_trigger, is_main)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT OR REPLACE INTO registered_groups (jid, name, folder, trigger_pattern, added_at, container_config, requires_trigger)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     jid,
     group.name,
@@ -594,7 +713,6 @@ export function setRegisteredGroup(jid: string, group: RegisteredGroup): void {
     group.added_at,
     group.containerConfig ? JSON.stringify(group.containerConfig) : null,
     group.requiresTrigger === undefined ? 1 : group.requiresTrigger ? 1 : 0,
-    group.isMain ? 1 : 0,
   );
 }
 
@@ -607,7 +725,6 @@ export function getAllRegisteredGroups(): Record<string, RegisteredGroup> {
     added_at: string;
     container_config: string | null;
     requires_trigger: number | null;
-    is_main: number | null;
   }>;
   const result: Record<string, RegisteredGroup> = {};
   for (const row of rows) {
@@ -628,7 +745,6 @@ export function getAllRegisteredGroups(): Record<string, RegisteredGroup> {
         : undefined,
       requiresTrigger:
         row.requires_trigger === null ? undefined : row.requires_trigger === 1,
-      isMain: row.is_main === 1 ? true : undefined,
     };
   }
   return result;

--- a/src/group-queue.test.ts
+++ b/src/group-queue.test.ts
@@ -481,4 +481,30 @@ describe('GroupQueue', () => {
     resolveProcess!();
     await vi.advanceTimersByTimeAsync(10);
   });
+
+  describe('isActive', () => {
+    it('returns false for unknown groups', () => {
+      expect(queue.isActive('unknown@g.us')).toBe(false);
+    });
+
+    it('returns true when group has active container', async () => {
+      let resolve: () => void;
+      const block = new Promise<void>((r) => {
+        resolve = r;
+      });
+
+      queue.setProcessMessagesFn(async () => {
+        await block;
+        return true;
+      });
+      queue.enqueueMessageCheck('group@g.us');
+
+      // Let the microtask start running
+      await vi.advanceTimersByTimeAsync(0);
+      expect(queue.isActive('group@g.us')).toBe(true);
+
+      resolve!();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+  });
 });

--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -344,6 +344,10 @@ export class GroupQueue {
     }
   }
 
+  isActive(groupJid: string): boolean {
+    return this.getGroup(groupJid).active;
+  }
+
   async shutdown(_gracePeriodMs: number): Promise<void> {
     this.shuttingDown = true;
 

--- a/src/image.test.ts
+++ b/src/image.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'fs';
+
+// Mock sharp
+vi.mock('sharp', () => {
+  const mockSharp = vi.fn(() => ({
+    resize: vi.fn().mockReturnThis(),
+    jpeg: vi.fn().mockReturnThis(),
+    toBuffer: vi.fn().mockResolvedValue(Buffer.from('resized-image-data')),
+  }));
+  return { default: mockSharp };
+});
+
+vi.mock('fs');
+
+import { processImage, parseImageReferences, isImageMessage } from './image.js';
+
+describe('image processing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fs.mkdirSync).mockReturnValue(undefined);
+    vi.mocked(fs.writeFileSync).mockReturnValue(undefined);
+  });
+
+  describe('isImageMessage', () => {
+    it('returns true for image messages', () => {
+      const msg = { message: { imageMessage: { mimetype: 'image/jpeg' } } };
+      expect(isImageMessage(msg as any)).toBe(true);
+    });
+
+    it('returns false for non-image messages', () => {
+      const msg = { message: { conversation: 'hello' } };
+      expect(isImageMessage(msg as any)).toBe(false);
+    });
+
+    it('returns false for null message', () => {
+      const msg = { message: null };
+      expect(isImageMessage(msg as any)).toBe(false);
+    });
+  });
+
+  describe('processImage', () => {
+    it('resizes and saves image, returns content string', async () => {
+      const buffer = Buffer.from('raw-image-data');
+      const result = await processImage(
+        buffer,
+        '/tmp/groups/test',
+        'Check this out',
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.content).toMatch(
+        /^\[Image: attachments\/img-\d+-[a-z0-9]+\.jpg\] Check this out$/,
+      );
+      expect(result!.relativePath).toMatch(
+        /^attachments\/img-\d+-[a-z0-9]+\.jpg$/,
+      );
+      expect(fs.mkdirSync).toHaveBeenCalled();
+      expect(fs.writeFileSync).toHaveBeenCalled();
+    });
+
+    it('returns content without caption when none provided', async () => {
+      const buffer = Buffer.from('raw-image-data');
+      const result = await processImage(buffer, '/tmp/groups/test', '');
+
+      expect(result).not.toBeNull();
+      expect(result!.content).toMatch(
+        /^\[Image: attachments\/img-\d+-[a-z0-9]+\.jpg\]$/,
+      );
+    });
+
+    it('returns null on empty buffer', async () => {
+      const result = await processImage(
+        Buffer.alloc(0),
+        '/tmp/groups/test',
+        '',
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('parseImageReferences', () => {
+    it('extracts image paths from message content', () => {
+      const messages = [
+        { content: '[Image: attachments/img-123.jpg] hello' },
+        { content: 'plain text' },
+        { content: '[Image: attachments/img-456.jpg]' },
+      ];
+      const refs = parseImageReferences(messages as any);
+
+      expect(refs).toEqual([
+        { relativePath: 'attachments/img-123.jpg', mediaType: 'image/jpeg' },
+        { relativePath: 'attachments/img-456.jpg', mediaType: 'image/jpeg' },
+      ]);
+    });
+
+    it('returns empty array when no images', () => {
+      const messages = [{ content: 'just text' }];
+      expect(parseImageReferences(messages as any)).toEqual([]);
+    });
+  });
+});

--- a/src/image.ts
+++ b/src/image.ts
@@ -1,0 +1,66 @@
+import fs from 'fs';
+import path from 'path';
+import sharp from 'sharp';
+import type { WAMessage } from '@whiskeysockets/baileys';
+
+const MAX_DIMENSION = 1024;
+const IMAGE_REF_PATTERN = /\[Image: (attachments\/[^\]]+)\]/g;
+
+export interface ProcessedImage {
+  content: string;
+  relativePath: string;
+}
+
+export interface ImageAttachment {
+  relativePath: string;
+  mediaType: string;
+}
+
+export function isImageMessage(msg: WAMessage): boolean {
+  return !!msg.message?.imageMessage;
+}
+
+export async function processImage(
+  buffer: Buffer,
+  groupDir: string,
+  caption: string,
+): Promise<ProcessedImage | null> {
+  if (!buffer || buffer.length === 0) return null;
+
+  const resized = await sharp(buffer)
+    .resize(MAX_DIMENSION, MAX_DIMENSION, {
+      fit: 'inside',
+      withoutEnlargement: true,
+    })
+    .jpeg({ quality: 85 })
+    .toBuffer();
+
+  const attachDir = path.join(groupDir, 'attachments');
+  fs.mkdirSync(attachDir, { recursive: true });
+
+  const filename = `img-${Date.now()}-${Math.random().toString(36).slice(2, 6)}.jpg`;
+  const filePath = path.join(attachDir, filename);
+  fs.writeFileSync(filePath, resized);
+
+  const relativePath = `attachments/${filename}`;
+  const content = caption
+    ? `[Image: ${relativePath}] ${caption}`
+    : `[Image: ${relativePath}]`;
+
+  return { content, relativePath };
+}
+
+export function parseImageReferences(
+  messages: Array<{ content: string }>,
+): ImageAttachment[] {
+  const refs: ImageAttachment[] = [];
+  for (const msg of messages) {
+    let match: RegExpExecArray | null;
+    IMAGE_REF_PATTERN.lastIndex = 0;
+    while ((match = IMAGE_REF_PATTERN.exec(msg.content)) !== null) {
+      // Always JPEG — processImage() normalizes all images to .jpg
+      refs.push({ relativePath: match[1], mediaType: 'image/jpeg' });
+    }
+  }
+  return refs;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,9 +31,9 @@ import {
   getAllRegisteredGroups,
   getAllSessions,
   getAllTasks,
+  getMessageFromMe,
   getMessagesSince,
   getNewMessages,
-  getRegisteredGroup,
   getRouterState,
   initDatabase,
   setRegisteredGroup,
@@ -59,6 +59,8 @@ import {
 } from './sender-allowlist.js';
 import { startSchedulerLoop } from './task-scheduler.js';
 import { Channel, NewMessage, RegisteredGroup } from './types.js';
+import { parseImageReferences } from './image.js';
+import { StatusTracker } from './status-tracker.js';
 import { logger } from './logger.js';
 
 // Re-export for backwards compatibility during refactor
@@ -68,10 +70,14 @@ let lastTimestamp = '';
 let sessions: Record<string, string> = {};
 let registeredGroups: Record<string, RegisteredGroup> = {};
 let lastAgentTimestamp: Record<string, string> = {};
+// Tracks cursor value before messages were piped to an active container.
+// Used to roll back if the container dies after piping.
+let cursorBeforePipe: Record<string, string> = {};
 let messageLoopRunning = false;
 
 const channels: Channel[] = [];
 const queue = new GroupQueue();
+let statusTracker: StatusTracker;
 
 function loadState(): void {
   lastTimestamp = getRouterState('last_timestamp') || '';
@@ -81,6 +87,13 @@ function loadState(): void {
   } catch {
     logger.warn('Corrupted last_agent_timestamp in DB, resetting');
     lastAgentTimestamp = {};
+  }
+  const pipeCursor = getRouterState('cursor_before_pipe');
+  try {
+    cursorBeforePipe = pipeCursor ? JSON.parse(pipeCursor) : {};
+  } catch {
+    logger.warn('Corrupted cursor_before_pipe in DB, resetting');
+    cursorBeforePipe = {};
   }
   sessions = getAllSessions();
   registeredGroups = getAllRegisteredGroups();
@@ -93,6 +106,7 @@ function loadState(): void {
 function saveState(): void {
   setRouterState('last_timestamp', lastTimestamp);
   setRouterState('last_agent_timestamp', JSON.stringify(lastAgentTimestamp));
+  setRouterState('cursor_before_pipe', JSON.stringify(cursorBeforePipe));
 }
 
 function registerGroup(jid: string, group: RegisteredGroup): void {
@@ -180,7 +194,23 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     if (!hasTrigger) return true;
   }
 
+  // Ensure all user messages are tracked — recovery messages enter processGroupMessages
+  // directly via the queue, bypassing startMessageLoop where markReceived normally fires.
+  // markReceived is idempotent (rejects duplicates), so this is safe for normal-path messages too.
+  for (const msg of missedMessages) {
+    statusTracker.markReceived(msg.id, chatJid, false);
+  }
+
+  // Mark all user messages as thinking (container is spawning)
+  const userMessages = missedMessages.filter(
+    (m) => !m.is_from_me && !m.is_bot_message,
+  );
+  for (const msg of userMessages) {
+    statusTracker.markThinking(msg.id);
+  }
+
   const prompt = formatMessages(missedMessages, TIMEZONE);
+  const imageAttachments = parseImageReferences(missedMessages);
 
   // Advance cursor so the piping path in startMessageLoop won't re-fetch
   // these messages. Save the old cursor so we can roll back on error.
@@ -211,57 +241,91 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   await channel.setTyping?.(chatJid, true);
   let hadError = false;
   let outputSentToUser = false;
+  let firstOutputSeen = false;
 
-  const output = await runAgent(group, prompt, chatJid, async (result) => {
-    // Streaming output callback — called for each agent result
-    if (result.result) {
-      const raw =
-        typeof result.result === 'string'
-          ? result.result
-          : JSON.stringify(result.result);
-      // Strip <internal>...</internal> blocks — agent uses these for internal reasoning
-      const text = raw.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
-      logger.info({ group: group.name }, `Agent output: ${raw.slice(0, 200)}`);
-      if (text) {
-        await channel.sendMessage(chatJid, text);
-        outputSentToUser = true;
+  const output = await runAgent(
+    group,
+    prompt,
+    chatJid,
+    imageAttachments,
+    async (result) => {
+      // Streaming output callback — called for each agent result
+      if (result.result) {
+        if (!firstOutputSeen) {
+          firstOutputSeen = true;
+          for (const um of userMessages) {
+            statusTracker.markWorking(um.id);
+          }
+        }
+        const raw =
+          typeof result.result === 'string'
+            ? result.result
+            : JSON.stringify(result.result);
+        // Strip <internal>...</internal> blocks — agent uses these for internal reasoning
+        const text = raw.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
+        logger.info(
+          { group: group.name },
+          `Agent output: ${raw.slice(0, 200)}`,
+        );
+        if (text) {
+          await channel.sendMessage(chatJid, text);
+          outputSentToUser = true;
+        }
+        // Only reset idle timer on actual results, not session-update markers (result: null)
+        resetIdleTimer();
       }
-      // Only reset idle timer on actual results, not session-update markers (result: null)
-      resetIdleTimer();
-    }
 
-    if (result.status === 'success') {
-      queue.notifyIdle(chatJid);
-    }
+      if (result.status === 'success') {
+        statusTracker.markAllDone(chatJid);
+        queue.notifyIdle(chatJid);
+      }
 
-    if (result.status === 'error') {
-      hadError = true;
-    }
-  });
+      if (result.status === 'error') {
+        hadError = true;
+      }
+    },
+  );
 
   await channel.setTyping?.(chatJid, false);
   if (idleTimer) clearTimeout(idleTimer);
 
   if (output === 'error' || hadError) {
-    // If we already sent output to the user, don't roll back the cursor —
-    // the user got their response and re-processing would send duplicates.
     if (outputSentToUser) {
+      // Output was sent for the initial batch, so don't roll those back.
+      // But if messages were piped AFTER that output, roll back to recover them.
+      if (cursorBeforePipe[chatJid]) {
+        lastAgentTimestamp[chatJid] = cursorBeforePipe[chatJid];
+        delete cursorBeforePipe[chatJid];
+        saveState();
+        logger.warn(
+          { group: group.name },
+          'Agent error after output, rolled back piped messages for retry',
+        );
+        statusTracker.markAllFailed(chatJid, 'Task crashed — retrying.');
+        return false;
+      }
       logger.warn(
         { group: group.name },
-        'Agent error after output was sent, skipping cursor rollback to prevent duplicates',
+        'Agent error after output was sent, no piped messages to recover',
       );
+      statusTracker.markAllDone(chatJid);
       return true;
     }
-    // Roll back cursor so retries can re-process these messages
+    // No output sent — roll back everything so the full batch is retried
     lastAgentTimestamp[chatJid] = previousCursor;
+    delete cursorBeforePipe[chatJid];
     saveState();
     logger.warn(
       { group: group.name },
       'Agent error, rolled back message cursor for retry',
     );
+    statusTracker.markAllFailed(chatJid, 'Task crashed — retrying.');
     return false;
   }
 
+  // Success — clear pipe tracking (markAllDone already fired in streaming callback)
+  delete cursorBeforePipe[chatJid];
+  saveState();
   return true;
 }
 
@@ -269,6 +333,7 @@ async function runAgent(
   group: RegisteredGroup,
   prompt: string,
   chatJid: string,
+  imageAttachments: Array<{ relativePath: string; mediaType: string }>,
   onOutput?: (output: ContainerOutput) => Promise<void>,
 ): Promise<'success' | 'error'> {
   const isMain = group.isMain === true;
@@ -320,6 +385,7 @@ async function runAgent(
         chatJid,
         isMain,
         assistantName: ASSISTANT_NAME,
+        ...(imageAttachments.length > 0 && { imageAttachments }),
       },
       (proc, containerName) =>
         queue.registerProcess(chatJid, proc, containerName, group.folder),
@@ -409,6 +475,13 @@ async function startMessageLoop(): Promise<void> {
             if (!hasTrigger) continue;
           }
 
+          // Mark each user message as received (status emoji)
+          for (const msg of groupMessages) {
+            if (!msg.is_from_me && !msg.is_bot_message) {
+              statusTracker.markReceived(msg.id, chatJid, false);
+            }
+          }
+
           // Pull all messages since lastAgentTimestamp so non-trigger
           // context that accumulated between triggers is included.
           const allPending = getMessagesSince(
@@ -425,6 +498,17 @@ async function startMessageLoop(): Promise<void> {
               { chatJid, count: messagesToSend.length },
               'Piped messages to active container',
             );
+            // Mark new user messages as thinking (only groupMessages were markReceived'd;
+            // accumulated allPending context messages are untracked and would no-op)
+            for (const msg of groupMessages) {
+              if (!msg.is_from_me && !msg.is_bot_message) {
+                statusTracker.markThinking(msg.id);
+              }
+            }
+            // Save cursor before first pipe so we can roll back if container dies
+            if (!cursorBeforePipe[chatJid]) {
+              cursorBeforePipe[chatJid] = lastAgentTimestamp[chatJid] || '';
+            }
             lastAgentTimestamp[chatJid] =
               messagesToSend[messagesToSend.length - 1].timestamp;
             saveState();
@@ -452,6 +536,31 @@ async function startMessageLoop(): Promise<void> {
  * Handles crash between advancing lastTimestamp and processing messages.
  */
 function recoverPendingMessages(): void {
+  // Roll back any piped-message cursors that were persisted before a crash.
+  // This ensures messages piped to a now-dead container are re-fetched.
+  // IMPORTANT: Only roll back if the container is no longer running — rolling
+  // back while the container is alive causes duplicate processing.
+  let rolledBack = false;
+  for (const [chatJid, savedCursor] of Object.entries(cursorBeforePipe)) {
+    if (queue.isActive(chatJid)) {
+      logger.debug(
+        { chatJid },
+        'Recovery: skipping piped-cursor rollback, container still active',
+      );
+      continue;
+    }
+    logger.info(
+      { chatJid, rolledBackTo: savedCursor },
+      'Recovery: rolling back piped-message cursor',
+    );
+    lastAgentTimestamp[chatJid] = savedCursor;
+    delete cursorBeforePipe[chatJid];
+    rolledBack = true;
+  }
+  if (rolledBack) {
+    saveState();
+  }
+
   for (const [chatJid, group] of Object.entries(registeredGroups)) {
     const sinceTimestamp = lastAgentTimestamp[chatJid] || '';
     const pending = getMessagesSince(chatJid, sinceTimestamp, ASSISTANT_NAME);
@@ -489,6 +598,7 @@ async function main(): Promise<void> {
     proxyServer.close();
     await queue.shutdown(10000);
     for (const ch of channels) await ch.disconnect();
+    await statusTracker.shutdown();
     process.exit(0);
   };
   process.on('SIGTERM', () => shutdown('SIGTERM'));
@@ -576,6 +686,25 @@ async function main(): Promise<void> {
     registeredGroups: () => registeredGroups,
   };
 
+  // Initialize status tracker (uses channels via callbacks, channels don't need to be connected yet)
+  statusTracker = new StatusTracker({
+    sendReaction: async (chatJid, messageKey, emoji) => {
+      const channel = findChannel(channels, chatJid);
+      if (!channel?.sendReaction) return;
+      await channel.sendReaction(chatJid, messageKey, emoji);
+    },
+    sendMessage: async (chatJid, text) => {
+      const channel = findChannel(channels, chatJid);
+      if (!channel) return;
+      await channel.sendMessage(chatJid, text);
+    },
+    isMainGroup: (chatJid) => {
+      const group = registeredGroups[chatJid];
+      return group?.isMain === true;
+    },
+    isContainerAlive: (chatJid) => queue.isActive(chatJid),
+  });
+
   // Create and connect all registered channels.
   // Each channel self-registers via the barrel import above.
   // Factories return null when credentials are missing, so unconfigured channels are skipped.
@@ -620,6 +749,24 @@ async function main(): Promise<void> {
       if (!channel) throw new Error(`No channel for JID: ${jid}`);
       return channel.sendMessage(jid, text);
     },
+    sendReaction: async (jid, emoji, messageId) => {
+      const channel = findChannel(channels, jid);
+      if (!channel) throw new Error(`No channel for JID: ${jid}`);
+      if (messageId) {
+        if (!channel.sendReaction)
+          throw new Error('Channel does not support sendReaction');
+        const messageKey = {
+          id: messageId,
+          remoteJid: jid,
+          fromMe: getMessageFromMe(messageId, jid),
+        };
+        await channel.sendReaction(jid, messageKey, emoji);
+      } else {
+        if (!channel.reactToLatestMessage)
+          throw new Error('Channel does not support reactions');
+        await channel.reactToLatestMessage(jid, emoji);
+      }
+    },
     registeredGroups: () => registeredGroups,
     registerGroup,
     syncGroups: async (force: boolean) => {
@@ -632,7 +779,12 @@ async function main(): Promise<void> {
     getAvailableGroups,
     writeGroupsSnapshot: (gf, im, ag, rj) =>
       writeGroupsSnapshot(gf, im, ag, rj),
+    statusHeartbeat: () => statusTracker.heartbeatCheck(),
+    recoverPendingMessages,
   });
+  // Recover status tracker AFTER channels connect, so recovery reactions
+  // can actually be sent via the WhatsApp channel.
+  await statusTracker.recover();
   queue.setProcessMessagesFn(processGroupMessages);
   recoverPendingMessages();
   startMessageLoop().catch((err) => {

--- a/src/ipc-auth.test.ts
+++ b/src/ipc-auth.test.ts
@@ -14,10 +14,9 @@ import { RegisteredGroup } from './types.js';
 // Set up registered groups used across tests
 const MAIN_GROUP: RegisteredGroup = {
   name: 'Main',
-  folder: 'whatsapp_main',
+  folder: 'main',
   trigger: 'always',
   added_at: '2024-01-01T00:00:00.000Z',
-  isMain: true,
 };
 
 const OTHER_GROUP: RegisteredGroup = {
@@ -53,11 +52,11 @@ beforeEach(() => {
 
   deps = {
     sendMessage: async () => {},
+    sendReaction: async () => {},
     registeredGroups: () => groups,
     registerGroup: (jid, group) => {
       groups[jid] = group;
       setRegisteredGroup(jid, group);
-      // Mock the fs.mkdirSync that registerGroup does
     },
     syncGroups: async () => {},
     getAvailableGroups: () => [],
@@ -74,10 +73,10 @@ describe('schedule_task authorization', () => {
         type: 'schedule_task',
         prompt: 'do something',
         schedule_type: 'once',
-        schedule_value: '2025-06-01T00:00:00',
+        schedule_value: '2025-06-01T00:00:00.000Z',
         targetJid: 'other@g.us',
       },
-      'whatsapp_main',
+      'main',
       true,
       deps,
     );
@@ -94,7 +93,7 @@ describe('schedule_task authorization', () => {
         type: 'schedule_task',
         prompt: 'self task',
         schedule_type: 'once',
-        schedule_value: '2025-06-01T00:00:00',
+        schedule_value: '2025-06-01T00:00:00.000Z',
         targetJid: 'other@g.us',
       },
       'other-group',
@@ -113,7 +112,7 @@ describe('schedule_task authorization', () => {
         type: 'schedule_task',
         prompt: 'unauthorized',
         schedule_type: 'once',
-        schedule_value: '2025-06-01T00:00:00',
+        schedule_value: '2025-06-01T00:00:00.000Z',
         targetJid: 'main@g.us',
       },
       'other-group',
@@ -131,10 +130,10 @@ describe('schedule_task authorization', () => {
         type: 'schedule_task',
         prompt: 'no target',
         schedule_type: 'once',
-        schedule_value: '2025-06-01T00:00:00',
+        schedule_value: '2025-06-01T00:00:00.000Z',
         targetJid: 'unknown@g.us',
       },
-      'whatsapp_main',
+      'main',
       true,
       deps,
     );
@@ -150,11 +149,11 @@ describe('pause_task authorization', () => {
   beforeEach(() => {
     createTask({
       id: 'task-main',
-      group_folder: 'whatsapp_main',
+      group_folder: 'main',
       chat_jid: 'main@g.us',
       prompt: 'main task',
       schedule_type: 'once',
-      schedule_value: '2025-06-01T00:00:00',
+      schedule_value: '2025-06-01T00:00:00.000Z',
       context_mode: 'isolated',
       next_run: '2025-06-01T00:00:00.000Z',
       status: 'active',
@@ -166,7 +165,7 @@ describe('pause_task authorization', () => {
       chat_jid: 'other@g.us',
       prompt: 'other task',
       schedule_type: 'once',
-      schedule_value: '2025-06-01T00:00:00',
+      schedule_value: '2025-06-01T00:00:00.000Z',
       context_mode: 'isolated',
       next_run: '2025-06-01T00:00:00.000Z',
       status: 'active',
@@ -177,7 +176,7 @@ describe('pause_task authorization', () => {
   it('main group can pause any task', async () => {
     await processTaskIpc(
       { type: 'pause_task', taskId: 'task-other' },
-      'whatsapp_main',
+      'main',
       true,
       deps,
     );
@@ -215,7 +214,7 @@ describe('resume_task authorization', () => {
       chat_jid: 'other@g.us',
       prompt: 'paused task',
       schedule_type: 'once',
-      schedule_value: '2025-06-01T00:00:00',
+      schedule_value: '2025-06-01T00:00:00.000Z',
       context_mode: 'isolated',
       next_run: '2025-06-01T00:00:00.000Z',
       status: 'paused',
@@ -226,7 +225,7 @@ describe('resume_task authorization', () => {
   it('main group can resume any task', async () => {
     await processTaskIpc(
       { type: 'resume_task', taskId: 'task-paused' },
-      'whatsapp_main',
+      'main',
       true,
       deps,
     );
@@ -264,7 +263,7 @@ describe('cancel_task authorization', () => {
       chat_jid: 'other@g.us',
       prompt: 'cancel me',
       schedule_type: 'once',
-      schedule_value: '2025-06-01T00:00:00',
+      schedule_value: '2025-06-01T00:00:00.000Z',
       context_mode: 'isolated',
       next_run: null,
       status: 'active',
@@ -273,7 +272,7 @@ describe('cancel_task authorization', () => {
 
     await processTaskIpc(
       { type: 'cancel_task', taskId: 'task-to-cancel' },
-      'whatsapp_main',
+      'main',
       true,
       deps,
     );
@@ -287,7 +286,7 @@ describe('cancel_task authorization', () => {
       chat_jid: 'other@g.us',
       prompt: 'my task',
       schedule_type: 'once',
-      schedule_value: '2025-06-01T00:00:00',
+      schedule_value: '2025-06-01T00:00:00.000Z',
       context_mode: 'isolated',
       next_run: null,
       status: 'active',
@@ -306,11 +305,11 @@ describe('cancel_task authorization', () => {
   it('non-main group cannot cancel another groups task', async () => {
     createTask({
       id: 'task-foreign',
-      group_folder: 'whatsapp_main',
+      group_folder: 'main',
       chat_jid: 'main@g.us',
       prompt: 'not yours',
       schedule_type: 'once',
-      schedule_value: '2025-06-01T00:00:00',
+      schedule_value: '2025-06-01T00:00:00.000Z',
       context_mode: 'isolated',
       next_run: null,
       status: 'active',
@@ -357,7 +356,7 @@ describe('register_group authorization', () => {
         folder: '../../outside',
         trigger: '@Andy',
       },
-      'whatsapp_main',
+      'main',
       true,
       deps,
     );
@@ -398,12 +397,8 @@ describe('IPC message authorization', () => {
   }
 
   it('main group can send to any group', () => {
-    expect(
-      isMessageAuthorized('whatsapp_main', true, 'other@g.us', groups),
-    ).toBe(true);
-    expect(
-      isMessageAuthorized('whatsapp_main', true, 'third@g.us', groups),
-    ).toBe(true);
+    expect(isMessageAuthorized('main', true, 'other@g.us', groups)).toBe(true);
+    expect(isMessageAuthorized('main', true, 'third@g.us', groups)).toBe(true);
   });
 
   it('non-main group can send to its own chat', () => {
@@ -429,9 +424,138 @@ describe('IPC message authorization', () => {
 
   it('main group can send to unregistered JID', () => {
     // Main is always authorized regardless of target
+    expect(isMessageAuthorized('main', true, 'unknown@g.us', groups)).toBe(
+      true,
+    );
+  });
+});
+
+// --- IPC reaction authorization ---
+// Same authorization pattern as message sending (ipc.ts lines 104-127).
+
+describe('IPC reaction authorization', () => {
+  // Replicate the exact check from the IPC watcher for reactions
+  function isReactionAuthorized(
+    sourceGroup: string,
+    isMain: boolean,
+    targetChatJid: string,
+    registeredGroups: Record<string, RegisteredGroup>,
+  ): boolean {
+    const targetGroup = registeredGroups[targetChatJid];
+    return isMain || (!!targetGroup && targetGroup.folder === sourceGroup);
+  }
+
+  it('main group can react in any chat', () => {
+    expect(isReactionAuthorized('main', true, 'other@g.us', groups)).toBe(true);
+    expect(isReactionAuthorized('main', true, 'third@g.us', groups)).toBe(true);
+  });
+
+  it('non-main group can react in its own chat', () => {
     expect(
-      isMessageAuthorized('whatsapp_main', true, 'unknown@g.us', groups),
+      isReactionAuthorized('other-group', false, 'other@g.us', groups),
     ).toBe(true);
+  });
+
+  it('non-main group cannot react in another groups chat', () => {
+    expect(
+      isReactionAuthorized('other-group', false, 'main@g.us', groups),
+    ).toBe(false);
+    expect(
+      isReactionAuthorized('other-group', false, 'third@g.us', groups),
+    ).toBe(false);
+  });
+
+  it('non-main group cannot react in unregistered JID', () => {
+    expect(
+      isReactionAuthorized('other-group', false, 'unknown@g.us', groups),
+    ).toBe(false);
+  });
+});
+
+// --- sendReaction mock is exercised ---
+// The sendReaction dep is wired in but was never called in tests.
+// These tests verify startIpcWatcher would call it by testing the pattern inline.
+
+describe('IPC reaction sendReaction integration', () => {
+  it('sendReaction mock is callable', async () => {
+    const calls: Array<{ jid: string; emoji: string; messageId?: string }> = [];
+    deps.sendReaction = async (jid, emoji, messageId) => {
+      calls.push({ jid, emoji, messageId });
+    };
+
+    // Simulate what processIpcFiles does for a reaction
+    const data = {
+      type: 'reaction' as const,
+      chatJid: 'other@g.us',
+      emoji: '👍',
+      messageId: 'msg-123',
+    };
+    const sourceGroup = 'main';
+    const isMain = true;
+    const registeredGroups = deps.registeredGroups();
+    const targetGroup = registeredGroups[data.chatJid];
+
+    if (isMain || (targetGroup && targetGroup.folder === sourceGroup)) {
+      await deps.sendReaction(data.chatJid, data.emoji, data.messageId);
+    }
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({
+      jid: 'other@g.us',
+      emoji: '👍',
+      messageId: 'msg-123',
+    });
+  });
+
+  it('sendReaction is blocked for unauthorized group', async () => {
+    const calls: Array<{ jid: string; emoji: string; messageId?: string }> = [];
+    deps.sendReaction = async (jid, emoji, messageId) => {
+      calls.push({ jid, emoji, messageId });
+    };
+
+    const data = {
+      type: 'reaction' as const,
+      chatJid: 'main@g.us',
+      emoji: '❤️',
+    };
+    const sourceGroup = 'other-group';
+    const isMain = false;
+    const registeredGroups = deps.registeredGroups();
+    const targetGroup = registeredGroups[data.chatJid];
+
+    if (isMain || (targetGroup && targetGroup.folder === sourceGroup)) {
+      await deps.sendReaction(data.chatJid, data.emoji);
+    }
+
+    expect(calls).toHaveLength(0);
+  });
+
+  it('sendReaction works without messageId (react to latest)', async () => {
+    const calls: Array<{ jid: string; emoji: string; messageId?: string }> = [];
+    deps.sendReaction = async (jid, emoji, messageId) => {
+      calls.push({ jid, emoji, messageId });
+    };
+
+    const data = {
+      type: 'reaction' as const,
+      chatJid: 'other@g.us',
+      emoji: '🔥',
+    };
+    const sourceGroup = 'other-group';
+    const isMain = false;
+    const registeredGroups = deps.registeredGroups();
+    const targetGroup = registeredGroups[data.chatJid];
+
+    if (isMain || (targetGroup && targetGroup.folder === sourceGroup)) {
+      await deps.sendReaction(data.chatJid, data.emoji, undefined);
+    }
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({
+      jid: 'other@g.us',
+      emoji: '🔥',
+      messageId: undefined,
+    });
   });
 });
 
@@ -447,7 +571,7 @@ describe('schedule_task schedule types', () => {
         schedule_value: '0 9 * * *', // every day at 9am
         targetJid: 'other@g.us',
       },
-      'whatsapp_main',
+      'main',
       true,
       deps,
     );
@@ -471,7 +595,7 @@ describe('schedule_task schedule types', () => {
         schedule_value: 'not a cron',
         targetJid: 'other@g.us',
       },
-      'whatsapp_main',
+      'main',
       true,
       deps,
     );
@@ -490,7 +614,7 @@ describe('schedule_task schedule types', () => {
         schedule_value: '3600000', // 1 hour
         targetJid: 'other@g.us',
       },
-      'whatsapp_main',
+      'main',
       true,
       deps,
     );
@@ -513,7 +637,7 @@ describe('schedule_task schedule types', () => {
         schedule_value: 'abc',
         targetJid: 'other@g.us',
       },
-      'whatsapp_main',
+      'main',
       true,
       deps,
     );
@@ -530,7 +654,7 @@ describe('schedule_task schedule types', () => {
         schedule_value: '0',
         targetJid: 'other@g.us',
       },
-      'whatsapp_main',
+      'main',
       true,
       deps,
     );
@@ -547,7 +671,7 @@ describe('schedule_task schedule types', () => {
         schedule_value: 'not-a-date',
         targetJid: 'other@g.us',
       },
-      'whatsapp_main',
+      'main',
       true,
       deps,
     );
@@ -565,11 +689,11 @@ describe('schedule_task context_mode', () => {
         type: 'schedule_task',
         prompt: 'group context',
         schedule_type: 'once',
-        schedule_value: '2025-06-01T00:00:00',
+        schedule_value: '2025-06-01T00:00:00.000Z',
         context_mode: 'group',
         targetJid: 'other@g.us',
       },
-      'whatsapp_main',
+      'main',
       true,
       deps,
     );
@@ -584,11 +708,11 @@ describe('schedule_task context_mode', () => {
         type: 'schedule_task',
         prompt: 'isolated context',
         schedule_type: 'once',
-        schedule_value: '2025-06-01T00:00:00',
+        schedule_value: '2025-06-01T00:00:00.000Z',
         context_mode: 'isolated',
         targetJid: 'other@g.us',
       },
-      'whatsapp_main',
+      'main',
       true,
       deps,
     );
@@ -603,11 +727,11 @@ describe('schedule_task context_mode', () => {
         type: 'schedule_task',
         prompt: 'bad context',
         schedule_type: 'once',
-        schedule_value: '2025-06-01T00:00:00',
+        schedule_value: '2025-06-01T00:00:00.000Z',
         context_mode: 'bogus' as any,
         targetJid: 'other@g.us',
       },
-      'whatsapp_main',
+      'main',
       true,
       deps,
     );
@@ -622,10 +746,10 @@ describe('schedule_task context_mode', () => {
         type: 'schedule_task',
         prompt: 'no context mode',
         schedule_type: 'once',
-        schedule_value: '2025-06-01T00:00:00',
+        schedule_value: '2025-06-01T00:00:00.000Z',
         targetJid: 'other@g.us',
       },
-      'whatsapp_main',
+      'main',
       true,
       deps,
     );
@@ -647,7 +771,7 @@ describe('register_group success', () => {
         folder: 'new-group',
         trigger: '@Andy',
       },
-      'whatsapp_main',
+      'main',
       true,
       deps,
     );
@@ -668,7 +792,7 @@ describe('register_group success', () => {
         name: 'Partial',
         // missing folder and trigger
       },
-      'whatsapp_main',
+      'main',
       true,
       deps,
     );

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -12,6 +12,11 @@ import { RegisteredGroup } from './types.js';
 
 export interface IpcDeps {
   sendMessage: (jid: string, text: string) => Promise<void>;
+  sendReaction?: (
+    jid: string,
+    emoji: string,
+    messageId?: string,
+  ) => Promise<void>;
   registeredGroups: () => Record<string, RegisteredGroup>;
   registerGroup: (jid: string, group: RegisteredGroup) => void;
   syncGroups: (force: boolean) => Promise<void>;
@@ -22,9 +27,12 @@ export interface IpcDeps {
     availableGroups: AvailableGroup[],
     registeredJids: Set<string>,
   ) => void;
+  statusHeartbeat?: () => void;
+  recoverPendingMessages?: () => void;
 }
 
 let ipcWatcherRunning = false;
+const RECOVERY_INTERVAL_MS = 60_000;
 
 export function startIpcWatcher(deps: IpcDeps): void {
   if (ipcWatcherRunning) {
@@ -35,6 +43,7 @@ export function startIpcWatcher(deps: IpcDeps): void {
 
   const ipcBaseDir = path.join(DATA_DIR, 'ipc');
   fs.mkdirSync(ipcBaseDir, { recursive: true });
+  let lastRecoveryTime = Date.now();
 
   const processIpcFiles = async () => {
     // Scan all group IPC directories (identity determined by directory)
@@ -91,6 +100,44 @@ export function startIpcWatcher(deps: IpcDeps): void {
                     'Unauthorized IPC message attempt blocked',
                   );
                 }
+              } else if (
+                data.type === 'reaction' &&
+                data.chatJid &&
+                data.emoji &&
+                deps.sendReaction
+              ) {
+                const targetGroup = registeredGroups[data.chatJid];
+                if (
+                  isMain ||
+                  (targetGroup && targetGroup.folder === sourceGroup)
+                ) {
+                  try {
+                    await deps.sendReaction(
+                      data.chatJid,
+                      data.emoji,
+                      data.messageId,
+                    );
+                    logger.info(
+                      { chatJid: data.chatJid, emoji: data.emoji, sourceGroup },
+                      'IPC reaction sent',
+                    );
+                  } catch (err) {
+                    logger.error(
+                      {
+                        chatJid: data.chatJid,
+                        emoji: data.emoji,
+                        sourceGroup,
+                        err,
+                      },
+                      'IPC reaction failed',
+                    );
+                  }
+                } else {
+                  logger.warn(
+                    { chatJid: data.chatJid, sourceGroup },
+                    'Unauthorized IPC reaction attempt blocked',
+                  );
+                }
               }
               fs.unlinkSync(filePath);
             } catch (err) {
@@ -144,6 +191,16 @@ export function startIpcWatcher(deps: IpcDeps): void {
       } catch (err) {
         logger.error({ err, sourceGroup }, 'Error reading IPC tasks directory');
       }
+    }
+
+    // Status emoji heartbeat — detect dead containers with stale emoji state
+    deps.statusHeartbeat?.();
+
+    // Periodic message recovery — catch stuck messages after retry exhaustion or pipeline stalls
+    const now = Date.now();
+    if (now - lastRecoveryTime >= RECOVERY_INTERVAL_MS) {
+      lastRecoveryTime = now;
+      deps.recoverPendingMessages?.();
     }
 
     setTimeout(processIpcFiles, IPC_POLL_INTERVAL);
@@ -236,20 +293,18 @@ export async function processTaskIpc(
           }
           nextRun = new Date(Date.now() + ms).toISOString();
         } else if (scheduleType === 'once') {
-          const date = new Date(data.schedule_value);
-          if (isNaN(date.getTime())) {
+          const scheduled = new Date(data.schedule_value);
+          if (isNaN(scheduled.getTime())) {
             logger.warn(
               { scheduleValue: data.schedule_value },
               'Invalid timestamp',
             );
             break;
           }
-          nextRun = date.toISOString();
+          nextRun = scheduled.toISOString();
         }
 
-        const taskId =
-          data.taskId ||
-          `task-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        const taskId = `task-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
         const contextMode =
           data.context_mode === 'group' || data.context_mode === 'isolated'
             ? data.context_mode
@@ -324,70 +379,6 @@ export async function processTaskIpc(
             'Unauthorized task cancel attempt',
           );
         }
-      }
-      break;
-
-    case 'update_task':
-      if (data.taskId) {
-        const task = getTaskById(data.taskId);
-        if (!task) {
-          logger.warn(
-            { taskId: data.taskId, sourceGroup },
-            'Task not found for update',
-          );
-          break;
-        }
-        if (!isMain && task.group_folder !== sourceGroup) {
-          logger.warn(
-            { taskId: data.taskId, sourceGroup },
-            'Unauthorized task update attempt',
-          );
-          break;
-        }
-
-        const updates: Parameters<typeof updateTask>[1] = {};
-        if (data.prompt !== undefined) updates.prompt = data.prompt;
-        if (data.schedule_type !== undefined)
-          updates.schedule_type = data.schedule_type as
-            | 'cron'
-            | 'interval'
-            | 'once';
-        if (data.schedule_value !== undefined)
-          updates.schedule_value = data.schedule_value;
-
-        // Recompute next_run if schedule changed
-        if (data.schedule_type || data.schedule_value) {
-          const updatedTask = {
-            ...task,
-            ...updates,
-          };
-          if (updatedTask.schedule_type === 'cron') {
-            try {
-              const interval = CronExpressionParser.parse(
-                updatedTask.schedule_value,
-                { tz: TIMEZONE },
-              );
-              updates.next_run = interval.next().toISOString();
-            } catch {
-              logger.warn(
-                { taskId: data.taskId, value: updatedTask.schedule_value },
-                'Invalid cron in task update',
-              );
-              break;
-            }
-          } else if (updatedTask.schedule_type === 'interval') {
-            const ms = parseInt(updatedTask.schedule_value, 10);
-            if (!isNaN(ms) && ms > 0) {
-              updates.next_run = new Date(Date.now() + ms).toISOString();
-            }
-          }
-        }
-
-        updateTask(data.taskId, updates);
-        logger.info(
-          { taskId: data.taskId, sourceGroup, updates },
-          'Task updated via IPC',
-        );
       }
       break;
 

--- a/src/remote-control.test.ts
+++ b/src/remote-control.test.ts
@@ -45,14 +45,20 @@ describe('remote-control', () => {
     stdoutFileContent = '';
 
     // Default fs mocks
-    mkdirSyncSpy = vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined as any);
-    writeFileSyncSpy = vi.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+    mkdirSyncSpy = vi
+      .spyOn(fs, 'mkdirSync')
+      .mockImplementation(() => undefined as any);
+    writeFileSyncSpy = vi
+      .spyOn(fs, 'writeFileSync')
+      .mockImplementation(() => {});
     unlinkSyncSpy = vi.spyOn(fs, 'unlinkSync').mockImplementation(() => {});
     openSyncSpy = vi.spyOn(fs, 'openSync').mockReturnValue(42 as any);
     closeSyncSpy = vi.spyOn(fs, 'closeSync').mockImplementation(() => {});
 
     // readFileSync: return stdoutFileContent for the stdout file, state file, etc.
-    readFileSyncSpy = vi.spyOn(fs, 'readFileSync').mockImplementation(((p: string) => {
+    readFileSyncSpy = vi.spyOn(fs, 'readFileSync').mockImplementation(((
+      p: string,
+    ) => {
       if (p.endsWith('remote-control.stdout')) return stdoutFileContent;
       if (p.endsWith('remote-control.json')) {
         throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
@@ -74,7 +80,8 @@ describe('remote-control', () => {
       spawnMock.mockReturnValue(proc);
 
       // Simulate URL appearing in stdout file on first poll
-      stdoutFileContent = 'Session URL: https://claude.ai/code?bridge=env_abc123\n';
+      stdoutFileContent =
+        'Session URL: https://claude.ai/code?bridge=env_abc123\n';
       vi.spyOn(process, 'kill').mockImplementation((() => true) as any);
 
       const result = await startRemoteControl('user1', 'tg:123', '/project');
@@ -157,7 +164,9 @@ describe('remote-control', () => {
       spawnMock.mockReturnValueOnce(proc1).mockReturnValueOnce(proc2);
 
       // First start: process alive, URL found
-      const killSpy = vi.spyOn(process, 'kill').mockImplementation((() => true) as any);
+      const killSpy = vi
+        .spyOn(process, 'kill')
+        .mockImplementation((() => true) as any);
       stdoutFileContent = 'https://claude.ai/code?bridge=env_first\n';
       await startRemoteControl('user1', 'tg:123', '/project');
 
@@ -239,7 +248,9 @@ describe('remote-control', () => {
       const proc = createMockProcess(55555);
       spawnMock.mockReturnValue(proc);
       stdoutFileContent = 'https://claude.ai/code?bridge=env_stop\n';
-      const killSpy = vi.spyOn(process, 'kill').mockImplementation((() => true) as any);
+      const killSpy = vi
+        .spyOn(process, 'kill')
+        .mockImplementation((() => true) as any);
 
       await startRemoteControl('user1', 'tg:123', '/project');
 
@@ -337,7 +348,9 @@ describe('remote-control', () => {
         if (p.endsWith('remote-control.json')) return JSON.stringify(session);
         return '';
       }) as any);
-      const killSpy = vi.spyOn(process, 'kill').mockImplementation((() => true) as any);
+      const killSpy = vi
+        .spyOn(process, 'kill')
+        .mockImplementation((() => true) as any);
 
       restoreRemoteControl();
       expect(getActiveSession()).not.toBeNull();
@@ -365,13 +378,15 @@ describe('remote-control', () => {
 
       restoreRemoteControl();
 
-      return startRemoteControl('user2', 'tg:456', '/project').then((result) => {
-        expect(result).toEqual({
-          ok: true,
-          url: 'https://claude.ai/code?bridge=env_restored',
-        });
-        expect(spawnMock).not.toHaveBeenCalled();
-      });
+      return startRemoteControl('user2', 'tg:456', '/project').then(
+        (result) => {
+          expect(result).toEqual({
+            ok: true,
+            url: 'https://claude.ai/code?bridge=env_restored',
+          });
+          expect(spawnMock).not.toHaveBeenCalled();
+        },
+      );
     });
   });
 });

--- a/src/remote-control.ts
+++ b/src/remote-control.ts
@@ -196,9 +196,11 @@ export async function startRemoteControl(
   });
 }
 
-export function stopRemoteControl(): {
-  ok: true;
-} | { ok: false; error: string } {
+export function stopRemoteControl():
+  | {
+      ok: true;
+    }
+  | { ok: false; error: string } {
   if (!activeSession) {
     return { ok: false, error: 'No active Remote Control session' };
   }

--- a/src/status-tracker.test.ts
+++ b/src/status-tracker.test.ts
@@ -1,0 +1,523 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      existsSync: vi.fn(() => false),
+      writeFileSync: vi.fn(),
+      readFileSync: vi.fn(() => '[]'),
+      mkdirSync: vi.fn(),
+    },
+  };
+});
+
+vi.mock('./logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import {
+  StatusTracker,
+  StatusState,
+  StatusTrackerDeps,
+} from './status-tracker.js';
+
+function makeDeps() {
+  return {
+    sendReaction: vi.fn<StatusTrackerDeps['sendReaction']>(async () => {}),
+    sendMessage: vi.fn<StatusTrackerDeps['sendMessage']>(async () => {}),
+    isMainGroup: vi.fn<StatusTrackerDeps['isMainGroup']>(
+      (jid) => jid === 'main@s.whatsapp.net',
+    ),
+    isContainerAlive: vi.fn<StatusTrackerDeps['isContainerAlive']>(() => true),
+  };
+}
+
+describe('StatusTracker', () => {
+  let tracker: StatusTracker;
+  let deps: ReturnType<typeof makeDeps>;
+
+  beforeEach(() => {
+    deps = makeDeps();
+    tracker = new StatusTracker(deps);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('forward-only transitions', () => {
+    it('transitions RECEIVED -> THINKING -> WORKING -> DONE', async () => {
+      tracker.markReceived('msg1', 'main@s.whatsapp.net', false);
+      tracker.markThinking('msg1');
+      tracker.markWorking('msg1');
+      tracker.markDone('msg1');
+
+      // Wait for all reaction sends to complete
+      await tracker.flush();
+
+      expect(deps.sendReaction).toHaveBeenCalledTimes(4);
+      const emojis = deps.sendReaction.mock.calls.map((c) => c[2]);
+      expect(emojis).toEqual([
+        '\u{1F440}',
+        '\u{1F4AD}',
+        '\u{1F504}',
+        '\u{2705}',
+      ]);
+    });
+
+    it('rejects backward transitions (WORKING -> THINKING is no-op)', async () => {
+      tracker.markReceived('msg1', 'main@s.whatsapp.net', false);
+      tracker.markThinking('msg1');
+      tracker.markWorking('msg1');
+
+      const result = tracker.markThinking('msg1');
+      expect(result).toBe(false);
+
+      await tracker.flush();
+      expect(deps.sendReaction).toHaveBeenCalledTimes(3);
+    });
+
+    it('rejects duplicate transitions (DONE -> DONE is no-op)', async () => {
+      tracker.markReceived('msg1', 'main@s.whatsapp.net', false);
+      tracker.markDone('msg1');
+
+      const result = tracker.markDone('msg1');
+      expect(result).toBe(false);
+
+      await tracker.flush();
+      expect(deps.sendReaction).toHaveBeenCalledTimes(2);
+    });
+
+    it('allows FAILED from any non-terminal state', async () => {
+      tracker.markReceived('msg1', 'main@s.whatsapp.net', false);
+      tracker.markFailed('msg1');
+      await tracker.flush();
+
+      const emojis = deps.sendReaction.mock.calls.map((c) => c[2]);
+      expect(emojis).toEqual(['\u{1F440}', '\u{274C}']);
+    });
+
+    it('rejects FAILED after DONE', async () => {
+      tracker.markReceived('msg1', 'main@s.whatsapp.net', false);
+      tracker.markDone('msg1');
+
+      const result = tracker.markFailed('msg1');
+      expect(result).toBe(false);
+
+      await tracker.flush();
+      expect(deps.sendReaction).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('main group gating', () => {
+    it('ignores messages from non-main groups', async () => {
+      tracker.markReceived('msg1', 'group@g.us', false);
+      await tracker.flush();
+      expect(deps.sendReaction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('duplicate tracking', () => {
+    it('rejects duplicate markReceived for same messageId', async () => {
+      const first = tracker.markReceived('msg1', 'main@s.whatsapp.net', false);
+      const second = tracker.markReceived('msg1', 'main@s.whatsapp.net', false);
+
+      expect(first).toBe(true);
+      expect(second).toBe(false);
+
+      await tracker.flush();
+      expect(deps.sendReaction).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('unknown message handling', () => {
+    it('returns false for transitions on untracked messages', () => {
+      expect(tracker.markThinking('unknown')).toBe(false);
+      expect(tracker.markWorking('unknown')).toBe(false);
+      expect(tracker.markDone('unknown')).toBe(false);
+      expect(tracker.markFailed('unknown')).toBe(false);
+    });
+  });
+
+  describe('batch operations', () => {
+    it('markAllDone transitions all tracked messages for a chatJid', async () => {
+      tracker.markReceived('msg1', 'main@s.whatsapp.net', false);
+      tracker.markReceived('msg2', 'main@s.whatsapp.net', false);
+      tracker.markAllDone('main@s.whatsapp.net');
+      await tracker.flush();
+
+      const doneCalls = deps.sendReaction.mock.calls.filter(
+        (c) => c[2] === '\u{2705}',
+      );
+      expect(doneCalls).toHaveLength(2);
+    });
+
+    it('markAllFailed transitions all tracked messages and sends error message', async () => {
+      tracker.markReceived('msg1', 'main@s.whatsapp.net', false);
+      tracker.markReceived('msg2', 'main@s.whatsapp.net', false);
+      tracker.markAllFailed('main@s.whatsapp.net', 'Task crashed');
+      await tracker.flush();
+
+      const failCalls = deps.sendReaction.mock.calls.filter(
+        (c) => c[2] === '\u{274C}',
+      );
+      expect(failCalls).toHaveLength(2);
+      expect(deps.sendMessage).toHaveBeenCalledWith(
+        'main@s.whatsapp.net',
+        '[system] Task crashed',
+      );
+    });
+  });
+
+  describe('serialized sends', () => {
+    it('sends reactions in order even when transitions are rapid', async () => {
+      const order: string[] = [];
+      deps.sendReaction.mockImplementation(async (_jid, _key, emoji) => {
+        await new Promise((r) => setTimeout(r, Math.random() * 10));
+        order.push(emoji);
+      });
+
+      tracker.markReceived('msg1', 'main@s.whatsapp.net', false);
+      tracker.markThinking('msg1');
+      tracker.markWorking('msg1');
+      tracker.markDone('msg1');
+
+      await tracker.flush();
+      expect(order).toEqual([
+        '\u{1F440}',
+        '\u{1F4AD}',
+        '\u{1F504}',
+        '\u{2705}',
+      ]);
+    });
+  });
+
+  describe('recover', () => {
+    it('marks orphaned non-terminal entries as failed and sends error message', async () => {
+      const fs = await import('fs');
+      const persisted = JSON.stringify([
+        {
+          messageId: 'orphan1',
+          chatJid: 'main@s.whatsapp.net',
+          fromMe: false,
+          state: 0,
+          terminal: null,
+          trackedAt: 1000,
+        },
+        {
+          messageId: 'orphan2',
+          chatJid: 'main@s.whatsapp.net',
+          fromMe: false,
+          state: 2,
+          terminal: null,
+          trackedAt: 2000,
+        },
+        {
+          messageId: 'done1',
+          chatJid: 'main@s.whatsapp.net',
+          fromMe: false,
+          state: 3,
+          terminal: 'done',
+          trackedAt: 3000,
+        },
+      ]);
+      (fs.default.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      (fs.default.readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(
+        persisted,
+      );
+
+      await tracker.recover();
+
+      // Should send ❌ reaction for the 2 non-terminal entries only
+      const failCalls = deps.sendReaction.mock.calls.filter(
+        (c) => c[2] === '❌',
+      );
+      expect(failCalls).toHaveLength(2);
+
+      // Should send one error message per chatJid
+      expect(deps.sendMessage).toHaveBeenCalledWith(
+        'main@s.whatsapp.net',
+        '[system] Restarted — reprocessing your message.',
+      );
+      expect(deps.sendMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles missing persistence file gracefully', async () => {
+      const fs = await import('fs');
+      (fs.default.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(
+        false,
+      );
+
+      await tracker.recover(); // should not throw
+      expect(deps.sendReaction).not.toHaveBeenCalled();
+    });
+
+    it('skips error message when sendErrorMessage is false', async () => {
+      const fs = await import('fs');
+      const persisted = JSON.stringify([
+        {
+          messageId: 'orphan1',
+          chatJid: 'main@s.whatsapp.net',
+          fromMe: false,
+          state: 1,
+          terminal: null,
+          trackedAt: 1000,
+        },
+      ]);
+      (fs.default.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      (fs.default.readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(
+        persisted,
+      );
+
+      await tracker.recover(false);
+
+      // Still sends ❌ reaction
+      expect(deps.sendReaction).toHaveBeenCalledTimes(1);
+      expect(deps.sendReaction.mock.calls[0][2]).toBe('❌');
+      // But no text message
+      expect(deps.sendMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('heartbeatCheck', () => {
+    it('marks messages as failed when container is dead', async () => {
+      deps.isContainerAlive.mockReturnValue(false);
+      tracker.markReceived('msg1', 'main@s.whatsapp.net', false);
+      tracker.markThinking('msg1');
+
+      tracker.heartbeatCheck();
+      await tracker.flush();
+
+      const failCalls = deps.sendReaction.mock.calls.filter(
+        (c) => c[2] === '❌',
+      );
+      expect(failCalls).toHaveLength(1);
+      expect(deps.sendMessage).toHaveBeenCalledWith(
+        'main@s.whatsapp.net',
+        '[system] Task crashed — retrying.',
+      );
+    });
+
+    it('does nothing when container is alive', async () => {
+      deps.isContainerAlive.mockReturnValue(true);
+      tracker.markReceived('msg1', 'main@s.whatsapp.net', false);
+      tracker.markThinking('msg1');
+
+      tracker.heartbeatCheck();
+      await tracker.flush();
+
+      // Only the 👀 and 💭 reactions, no ❌
+      expect(deps.sendReaction).toHaveBeenCalledTimes(2);
+      const emojis = deps.sendReaction.mock.calls.map((c) => c[2]);
+      expect(emojis).toEqual(['👀', '💭']);
+    });
+
+    it('skips RECEIVED messages within grace period even if container is dead', async () => {
+      vi.useFakeTimers();
+      deps.isContainerAlive.mockReturnValue(false);
+      tracker.markReceived('msg1', 'main@s.whatsapp.net', false);
+
+      // Only 10s elapsed — within 30s grace period
+      vi.advanceTimersByTime(10_000);
+      tracker.heartbeatCheck();
+      await tracker.flush();
+
+      // Only the 👀 reaction, no ❌
+      expect(deps.sendReaction).toHaveBeenCalledTimes(1);
+      expect(deps.sendReaction.mock.calls[0][2]).toBe('👀');
+    });
+
+    it('fails RECEIVED messages after grace period when container is dead', async () => {
+      vi.useFakeTimers();
+      deps.isContainerAlive.mockReturnValue(false);
+      tracker.markReceived('msg1', 'main@s.whatsapp.net', false);
+
+      // 31s elapsed — past 30s grace period
+      vi.advanceTimersByTime(31_000);
+      tracker.heartbeatCheck();
+      await tracker.flush();
+
+      const failCalls = deps.sendReaction.mock.calls.filter(
+        (c) => c[2] === '❌',
+      );
+      expect(failCalls).toHaveLength(1);
+      expect(deps.sendMessage).toHaveBeenCalledWith(
+        'main@s.whatsapp.net',
+        '[system] Task crashed — retrying.',
+      );
+    });
+
+    it('does NOT fail RECEIVED messages after grace period when container is alive', async () => {
+      vi.useFakeTimers();
+      deps.isContainerAlive.mockReturnValue(true);
+      tracker.markReceived('msg1', 'main@s.whatsapp.net', false);
+
+      // 31s elapsed but container is alive — don't fail
+      vi.advanceTimersByTime(31_000);
+      tracker.heartbeatCheck();
+      await tracker.flush();
+
+      expect(deps.sendReaction).toHaveBeenCalledTimes(1);
+      expect(deps.sendReaction.mock.calls[0][2]).toBe('👀');
+    });
+
+    it('detects stuck messages beyond timeout', async () => {
+      vi.useFakeTimers();
+      deps.isContainerAlive.mockReturnValue(true); // container "alive" but hung
+
+      tracker.markReceived('msg1', 'main@s.whatsapp.net', false);
+      tracker.markThinking('msg1');
+
+      // Advance time beyond container timeout (default 1800000ms = 30min)
+      vi.advanceTimersByTime(1_800_001);
+
+      tracker.heartbeatCheck();
+      await tracker.flush();
+
+      const failCalls = deps.sendReaction.mock.calls.filter(
+        (c) => c[2] === '❌',
+      );
+      expect(failCalls).toHaveLength(1);
+      expect(deps.sendMessage).toHaveBeenCalledWith(
+        'main@s.whatsapp.net',
+        '[system] Task timed out — retrying.',
+      );
+    });
+
+    it('does not timeout messages queued long in RECEIVED before reaching THINKING', async () => {
+      vi.useFakeTimers();
+      deps.isContainerAlive.mockReturnValue(true);
+
+      tracker.markReceived('msg1', 'main@s.whatsapp.net', false);
+
+      // Message sits in RECEIVED for longer than CONTAINER_TIMEOUT (queued, waiting for slot)
+      vi.advanceTimersByTime(2_000_000);
+
+      // Now container starts — trackedAt resets on THINKING transition
+      tracker.markThinking('msg1');
+
+      // Check immediately — should NOT timeout (trackedAt was just reset)
+      tracker.heartbeatCheck();
+      await tracker.flush();
+
+      const failCalls = deps.sendReaction.mock.calls.filter(
+        (c) => c[2] === '❌',
+      );
+      expect(failCalls).toHaveLength(0);
+
+      // Advance past CONTAINER_TIMEOUT from THINKING — NOW it should timeout
+      vi.advanceTimersByTime(1_800_001);
+
+      tracker.heartbeatCheck();
+      await tracker.flush();
+
+      const failCallsAfter = deps.sendReaction.mock.calls.filter(
+        (c) => c[2] === '❌',
+      );
+      expect(failCallsAfter).toHaveLength(1);
+    });
+  });
+
+  describe('cleanup', () => {
+    it('removes terminal messages after delay', async () => {
+      vi.useFakeTimers();
+      tracker.markReceived('msg1', 'main@s.whatsapp.net', false);
+      tracker.markDone('msg1');
+
+      // Message should still be tracked
+      expect(tracker.isTracked('msg1')).toBe(true);
+
+      // Advance past cleanup delay
+      vi.advanceTimersByTime(6000);
+
+      expect(tracker.isTracked('msg1')).toBe(false);
+    });
+  });
+
+  describe('reaction retry', () => {
+    it('retries failed sends with exponential backoff (2s, 4s)', async () => {
+      vi.useFakeTimers();
+      let callCount = 0;
+      deps.sendReaction.mockImplementation(async () => {
+        callCount++;
+        if (callCount <= 2) throw new Error('network error');
+      });
+
+      tracker.markReceived('msg1', 'main@s.whatsapp.net', false);
+
+      // First attempt fires immediately
+      await vi.advanceTimersByTimeAsync(0);
+      expect(callCount).toBe(1);
+
+      // After 2s: second attempt (first retry delay = 2s)
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(callCount).toBe(2);
+
+      // After 1s more (3s total): still waiting for 4s delay
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(callCount).toBe(2);
+
+      // After 3s more (6s total): third attempt fires (second retry delay = 4s)
+      await vi.advanceTimersByTimeAsync(3000);
+      expect(callCount).toBe(3);
+
+      await tracker.flush();
+    });
+
+    it('gives up after max retries', async () => {
+      vi.useFakeTimers();
+      let callCount = 0;
+      deps.sendReaction.mockImplementation(async () => {
+        callCount++;
+        throw new Error('permanent failure');
+      });
+
+      tracker.markReceived('msg1', 'main@s.whatsapp.net', false);
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      await tracker.flush();
+
+      expect(callCount).toBe(3); // MAX_RETRIES = 3
+    });
+  });
+
+  describe('batch transitions', () => {
+    it('markThinking can be called on multiple messages independently', async () => {
+      tracker.markReceived('msg1', 'main@s.whatsapp.net', false);
+      tracker.markReceived('msg2', 'main@s.whatsapp.net', false);
+      tracker.markReceived('msg3', 'main@s.whatsapp.net', false);
+
+      // Mark all as thinking (simulates batch behavior)
+      tracker.markThinking('msg1');
+      tracker.markThinking('msg2');
+      tracker.markThinking('msg3');
+
+      await tracker.flush();
+
+      const thinkingCalls = deps.sendReaction.mock.calls.filter(
+        (c) => c[2] === '💭',
+      );
+      expect(thinkingCalls).toHaveLength(3);
+    });
+
+    it('markWorking can be called on multiple messages independently', async () => {
+      tracker.markReceived('msg1', 'main@s.whatsapp.net', false);
+      tracker.markReceived('msg2', 'main@s.whatsapp.net', false);
+      tracker.markThinking('msg1');
+      tracker.markThinking('msg2');
+
+      tracker.markWorking('msg1');
+      tracker.markWorking('msg2');
+
+      await tracker.flush();
+
+      const workingCalls = deps.sendReaction.mock.calls.filter(
+        (c) => c[2] === '🔄',
+      );
+      expect(workingCalls).toHaveLength(2);
+    });
+  });
+});

--- a/src/status-tracker.ts
+++ b/src/status-tracker.ts
@@ -1,0 +1,363 @@
+import fs from 'fs';
+import path from 'path';
+
+import { DATA_DIR, CONTAINER_TIMEOUT } from './config.js';
+import { logger } from './logger.js';
+
+// DONE and FAILED share value 3: both are terminal states with monotonic
+// forward-only transitions (state >= current). The emoji differs but the
+// ordering logic treats them identically.
+export enum StatusState {
+  RECEIVED = 0,
+  THINKING = 1,
+  WORKING = 2,
+  DONE = 3,
+  FAILED = 3,
+}
+
+const DONE_EMOJI = '\u{2705}';
+const FAILED_EMOJI = '\u{274C}';
+
+const CLEANUP_DELAY_MS = 5000;
+const RECEIVED_GRACE_MS = 30_000;
+const REACTION_MAX_RETRIES = 3;
+const REACTION_BASE_DELAY_MS = 2000;
+
+interface MessageKey {
+  id: string;
+  remoteJid: string;
+  fromMe?: boolean;
+}
+
+interface TrackedMessage {
+  messageId: string;
+  chatJid: string;
+  fromMe: boolean;
+  state: number;
+  terminal: 'done' | 'failed' | null;
+  sendChain: Promise<void>;
+  trackedAt: number;
+}
+
+interface PersistedEntry {
+  messageId: string;
+  chatJid: string;
+  fromMe: boolean;
+  state: number;
+  terminal: 'done' | 'failed' | null;
+  trackedAt: number;
+}
+
+export interface StatusTrackerDeps {
+  sendReaction: (
+    chatJid: string,
+    messageKey: MessageKey,
+    emoji: string,
+  ) => Promise<void>;
+  sendMessage: (chatJid: string, text: string) => Promise<void>;
+  isMainGroup: (chatJid: string) => boolean;
+  isContainerAlive: (chatJid: string) => boolean;
+}
+
+export class StatusTracker {
+  private tracked = new Map<string, TrackedMessage>();
+  private deps: StatusTrackerDeps;
+  private persistPath: string;
+  private _shuttingDown = false;
+
+  constructor(deps: StatusTrackerDeps) {
+    this.deps = deps;
+    this.persistPath = path.join(DATA_DIR, 'status-tracker.json');
+  }
+
+  markReceived(messageId: string, chatJid: string, fromMe: boolean): boolean {
+    if (!this.deps.isMainGroup(chatJid)) return false;
+    if (this.tracked.has(messageId)) return false;
+
+    const msg: TrackedMessage = {
+      messageId,
+      chatJid,
+      fromMe,
+      state: StatusState.RECEIVED,
+      terminal: null,
+      sendChain: Promise.resolve(),
+      trackedAt: Date.now(),
+    };
+
+    this.tracked.set(messageId, msg);
+    this.enqueueSend(msg, '\u{1F440}');
+    this.persist();
+    return true;
+  }
+
+  markThinking(messageId: string): boolean {
+    return this.transition(messageId, StatusState.THINKING, '\u{1F4AD}');
+  }
+
+  markWorking(messageId: string): boolean {
+    return this.transition(messageId, StatusState.WORKING, '\u{1F504}');
+  }
+
+  markDone(messageId: string): boolean {
+    return this.transitionTerminal(messageId, 'done', DONE_EMOJI);
+  }
+
+  markFailed(messageId: string): boolean {
+    return this.transitionTerminal(messageId, 'failed', FAILED_EMOJI);
+  }
+
+  markAllDone(chatJid: string): void {
+    for (const [id, msg] of this.tracked) {
+      if (msg.chatJid === chatJid && msg.terminal === null) {
+        this.transitionTerminal(id, 'done', DONE_EMOJI);
+      }
+    }
+  }
+
+  markAllFailed(chatJid: string, errorMessage: string): void {
+    let anyFailed = false;
+    for (const [id, msg] of this.tracked) {
+      if (msg.chatJid === chatJid && msg.terminal === null) {
+        this.transitionTerminal(id, 'failed', FAILED_EMOJI);
+        anyFailed = true;
+      }
+    }
+    if (anyFailed) {
+      this.deps
+        .sendMessage(chatJid, `[system] ${errorMessage}`)
+        .catch((err) =>
+          logger.error({ chatJid, err }, 'Failed to send status error message'),
+        );
+    }
+  }
+
+  isTracked(messageId: string): boolean {
+    return this.tracked.has(messageId);
+  }
+
+  /** Wait for all pending reaction sends to complete. */
+  async flush(): Promise<void> {
+    const chains = Array.from(this.tracked.values()).map((m) => m.sendChain);
+    await Promise.allSettled(chains);
+  }
+
+  /** Signal shutdown and flush. Prevents new retry sleeps so flush resolves quickly. */
+  async shutdown(): Promise<void> {
+    this._shuttingDown = true;
+    await this.flush();
+  }
+
+  /**
+   * Startup recovery: read persisted state and mark all non-terminal entries as failed.
+   * Call this before the message loop starts.
+   */
+  async recover(sendErrorMessage: boolean = true): Promise<void> {
+    let entries: PersistedEntry[] = [];
+    try {
+      if (fs.existsSync(this.persistPath)) {
+        const raw = fs.readFileSync(this.persistPath, 'utf-8');
+        entries = JSON.parse(raw);
+      }
+    } catch (err) {
+      logger.warn({ err }, 'Failed to read status tracker persistence file');
+      return;
+    }
+
+    const orphanedByChat = new Map<string, number>();
+    for (const entry of entries) {
+      if (entry.terminal !== null) continue;
+
+      // Reconstruct tracked message for the reaction send
+      const msg: TrackedMessage = {
+        messageId: entry.messageId,
+        chatJid: entry.chatJid,
+        fromMe: entry.fromMe,
+        state: entry.state,
+        terminal: null,
+        sendChain: Promise.resolve(),
+        trackedAt: entry.trackedAt,
+      };
+      this.tracked.set(entry.messageId, msg);
+      this.transitionTerminal(entry.messageId, 'failed', FAILED_EMOJI);
+      orphanedByChat.set(
+        entry.chatJid,
+        (orphanedByChat.get(entry.chatJid) || 0) + 1,
+      );
+    }
+
+    if (sendErrorMessage) {
+      for (const [chatJid] of orphanedByChat) {
+        this.deps
+          .sendMessage(
+            chatJid,
+            `[system] Restarted \u{2014} reprocessing your message.`,
+          )
+          .catch((err) =>
+            logger.error({ chatJid, err }, 'Failed to send recovery message'),
+          );
+      }
+    }
+
+    await this.flush();
+    this.clearPersistence();
+    logger.info(
+      { recoveredCount: entries.filter((e) => e.terminal === null).length },
+      'Status tracker recovery complete',
+    );
+  }
+
+  /**
+   * Heartbeat: check for stale tracked messages where container has died.
+   * Call this from the IPC poll cycle.
+   */
+  heartbeatCheck(): void {
+    const now = Date.now();
+    for (const [id, msg] of this.tracked) {
+      if (msg.terminal !== null) continue;
+
+      // For RECEIVED messages, only fail if container is dead AND grace period elapsed.
+      // This closes the gap where a container dies before advancing to THINKING.
+      if (msg.state < StatusState.THINKING) {
+        if (
+          !this.deps.isContainerAlive(msg.chatJid) &&
+          now - msg.trackedAt > RECEIVED_GRACE_MS
+        ) {
+          logger.warn(
+            { messageId: id, chatJid: msg.chatJid, age: now - msg.trackedAt },
+            'Heartbeat: RECEIVED message stuck with dead container',
+          );
+          this.markAllFailed(msg.chatJid, 'Task crashed \u{2014} retrying.');
+          return; // Safe for main-chat-only scope. If expanded to multiple chats, loop instead of return.
+        }
+        continue;
+      }
+
+      if (!this.deps.isContainerAlive(msg.chatJid)) {
+        logger.warn(
+          { messageId: id, chatJid: msg.chatJid },
+          'Heartbeat: container dead, marking failed',
+        );
+        this.markAllFailed(msg.chatJid, 'Task crashed \u{2014} retrying.');
+        return; // Safe for main-chat-only scope. If expanded to multiple chats, loop instead of return.
+      }
+
+      if (now - msg.trackedAt > CONTAINER_TIMEOUT) {
+        logger.warn(
+          { messageId: id, chatJid: msg.chatJid, age: now - msg.trackedAt },
+          'Heartbeat: message stuck beyond timeout',
+        );
+        this.markAllFailed(msg.chatJid, 'Task timed out \u{2014} retrying.');
+        return; // See above re: single-chat scope.
+      }
+    }
+  }
+
+  private transition(
+    messageId: string,
+    newState: number,
+    emoji: string,
+  ): boolean {
+    const msg = this.tracked.get(messageId);
+    if (!msg) return false;
+    if (msg.terminal !== null) return false;
+    if (newState <= msg.state) return false;
+
+    msg.state = newState;
+    // Reset trackedAt on THINKING so heartbeat timeout measures from container start, not message receipt
+    if (newState === StatusState.THINKING) {
+      msg.trackedAt = Date.now();
+    }
+    this.enqueueSend(msg, emoji);
+    this.persist();
+    return true;
+  }
+
+  private transitionTerminal(
+    messageId: string,
+    terminal: 'done' | 'failed',
+    emoji: string,
+  ): boolean {
+    const msg = this.tracked.get(messageId);
+    if (!msg) return false;
+    if (msg.terminal !== null) return false;
+
+    msg.state = StatusState.DONE; // DONE and FAILED both = 3
+    msg.terminal = terminal;
+    this.enqueueSend(msg, emoji);
+    this.persist();
+    this.scheduleCleanup(messageId);
+    return true;
+  }
+
+  private enqueueSend(msg: TrackedMessage, emoji: string): void {
+    const key: MessageKey = {
+      id: msg.messageId,
+      remoteJid: msg.chatJid,
+      fromMe: msg.fromMe,
+    };
+    msg.sendChain = msg.sendChain.then(async () => {
+      for (let attempt = 1; attempt <= REACTION_MAX_RETRIES; attempt++) {
+        try {
+          await this.deps.sendReaction(msg.chatJid, key, emoji);
+          return;
+        } catch (err) {
+          if (attempt === REACTION_MAX_RETRIES) {
+            logger.error(
+              { messageId: msg.messageId, emoji, err, attempts: attempt },
+              'Failed to send status reaction after retries',
+            );
+          } else if (this._shuttingDown) {
+            logger.warn(
+              { messageId: msg.messageId, emoji, attempt, err },
+              'Reaction send failed, skipping retry (shutting down)',
+            );
+            return;
+          } else {
+            const delay = REACTION_BASE_DELAY_MS * Math.pow(2, attempt - 1);
+            logger.warn(
+              { messageId: msg.messageId, emoji, attempt, delay, err },
+              'Reaction send failed, retrying',
+            );
+            await new Promise((r) => setTimeout(r, delay));
+          }
+        }
+      }
+    });
+  }
+
+  /** Must remain async (setTimeout) — synchronous deletion would break iteration in markAllDone/markAllFailed. */
+  private scheduleCleanup(messageId: string): void {
+    setTimeout(() => {
+      this.tracked.delete(messageId);
+      this.persist();
+    }, CLEANUP_DELAY_MS);
+  }
+
+  private persist(): void {
+    try {
+      const entries: PersistedEntry[] = [];
+      for (const msg of this.tracked.values()) {
+        entries.push({
+          messageId: msg.messageId,
+          chatJid: msg.chatJid,
+          fromMe: msg.fromMe,
+          state: msg.state,
+          terminal: msg.terminal,
+          trackedAt: msg.trackedAt,
+        });
+      }
+      fs.mkdirSync(path.dirname(this.persistPath), { recursive: true });
+      fs.writeFileSync(this.persistPath, JSON.stringify(entries));
+    } catch (err) {
+      logger.warn({ err }, 'Failed to persist status tracker state');
+    }
+  }
+
+  private clearPersistence(): void {
+    try {
+      fs.writeFileSync(this.persistPath, '[]');
+    } catch {
+      // ignore
+    }
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,6 +90,18 @@ export interface Channel {
   setTyping?(jid: string, isTyping: boolean): Promise<void>;
   // Optional: sync group/chat names from the platform.
   syncGroups?(force: boolean): Promise<void>;
+  // Optional: reaction support
+  sendReaction?(
+    chatJid: string,
+    messageKey: {
+      id: string;
+      remoteJid: string;
+      fromMe?: boolean;
+      participant?: string;
+    },
+    emoji: string,
+  ): Promise<void>;
+  reactToLatestMessage?(chatJid: string, emoji: string): Promise<void>;
 }
 
 // Callback type that channels use to deliver inbound messages

--- a/src/whatsapp-auth.ts
+++ b/src/whatsapp-auth.ts
@@ -1,0 +1,180 @@
+/**
+ * WhatsApp Authentication Script
+ *
+ * Run this during setup to authenticate with WhatsApp.
+ * Displays QR code, waits for scan, saves credentials, then exits.
+ *
+ * Usage: npx tsx src/whatsapp-auth.ts
+ */
+import fs from 'fs';
+import path from 'path';
+import pino from 'pino';
+import qrcode from 'qrcode-terminal';
+import readline from 'readline';
+
+import makeWASocket, {
+  Browsers,
+  DisconnectReason,
+  fetchLatestWaWebVersion,
+  makeCacheableSignalKeyStore,
+  useMultiFileAuthState,
+} from '@whiskeysockets/baileys';
+
+const AUTH_DIR = './store/auth';
+const QR_FILE = './store/qr-data.txt';
+const STATUS_FILE = './store/auth-status.txt';
+
+const logger = pino({
+  level: 'warn', // Quiet logging - only show errors
+});
+
+// Check for --pairing-code flag and phone number
+const usePairingCode = process.argv.includes('--pairing-code');
+const phoneArg = process.argv.find((_, i, arr) => arr[i - 1] === '--phone');
+
+function askQuestion(prompt: string): Promise<string> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  return new Promise((resolve) => {
+    rl.question(prompt, (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+async function connectSocket(
+  phoneNumber?: string,
+  isReconnect = false,
+): Promise<void> {
+  const { state, saveCreds } = await useMultiFileAuthState(AUTH_DIR);
+
+  if (state.creds.registered && !isReconnect) {
+    fs.writeFileSync(STATUS_FILE, 'already_authenticated');
+    console.log('✓ Already authenticated with WhatsApp');
+    console.log(
+      '  To re-authenticate, delete the store/auth folder and run again.',
+    );
+    process.exit(0);
+  }
+
+  const { version } = await fetchLatestWaWebVersion({}).catch((err) => {
+    logger.warn(
+      { err },
+      'Failed to fetch latest WA Web version, using default',
+    );
+    return { version: undefined };
+  });
+  const sock = makeWASocket({
+    version,
+    auth: {
+      creds: state.creds,
+      keys: makeCacheableSignalKeyStore(state.keys, logger),
+    },
+    printQRInTerminal: false,
+    logger,
+    browser: Browsers.macOS('Chrome'),
+  });
+
+  if (usePairingCode && phoneNumber && !state.creds.me) {
+    // Request pairing code after a short delay for connection to initialize
+    // Only on first connect (not reconnect after 515)
+    setTimeout(async () => {
+      try {
+        const code = await sock.requestPairingCode(phoneNumber!);
+        console.log(`\n🔗 Your pairing code: ${code}\n`);
+        console.log('  1. Open WhatsApp on your phone');
+        console.log('  2. Tap Settings → Linked Devices → Link a Device');
+        console.log('  3. Tap "Link with phone number instead"');
+        console.log(`  4. Enter this code: ${code}\n`);
+        fs.writeFileSync(STATUS_FILE, `pairing_code:${code}`);
+      } catch (err: any) {
+        console.error('Failed to request pairing code:', err.message);
+        process.exit(1);
+      }
+    }, 3000);
+  }
+
+  sock.ev.on('connection.update', (update) => {
+    const { connection, lastDisconnect, qr } = update;
+
+    if (qr) {
+      // Write raw QR data to file so the setup skill can render it
+      fs.writeFileSync(QR_FILE, qr);
+      console.log('Scan this QR code with WhatsApp:\n');
+      console.log('  1. Open WhatsApp on your phone');
+      console.log('  2. Tap Settings → Linked Devices → Link a Device');
+      console.log('  3. Point your camera at the QR code below\n');
+      qrcode.generate(qr, { small: true });
+    }
+
+    if (connection === 'close') {
+      const reason = (lastDisconnect?.error as any)?.output?.statusCode;
+
+      if (reason === DisconnectReason.loggedOut) {
+        fs.writeFileSync(STATUS_FILE, 'failed:logged_out');
+        console.log('\n✗ Logged out. Delete store/auth and try again.');
+        process.exit(1);
+      } else if (reason === DisconnectReason.timedOut) {
+        fs.writeFileSync(STATUS_FILE, 'failed:qr_timeout');
+        console.log('\n✗ QR code timed out. Please try again.');
+        process.exit(1);
+      } else if (reason === 515) {
+        // 515 = stream error, often happens after pairing succeeds but before
+        // registration completes. Reconnect to finish the handshake.
+        console.log('\n⟳ Stream error (515) after pairing — reconnecting...');
+        connectSocket(phoneNumber, true);
+      } else {
+        fs.writeFileSync(STATUS_FILE, `failed:${reason || 'unknown'}`);
+        console.log('\n✗ Connection failed. Please try again.');
+        process.exit(1);
+      }
+    }
+
+    if (connection === 'open') {
+      fs.writeFileSync(STATUS_FILE, 'authenticated');
+      // Clean up QR file now that we're connected
+      try {
+        fs.unlinkSync(QR_FILE);
+      } catch {}
+      console.log('\n✓ Successfully authenticated with WhatsApp!');
+      console.log('  Credentials saved to store/auth/');
+      console.log('  You can now start the NanoClaw service.\n');
+
+      // Give it a moment to save credentials, then exit
+      setTimeout(() => process.exit(0), 1000);
+    }
+  });
+
+  sock.ev.on('creds.update', saveCreds);
+}
+
+async function authenticate(): Promise<void> {
+  fs.mkdirSync(AUTH_DIR, { recursive: true });
+
+  // Clean up any stale QR/status files from previous runs
+  try {
+    fs.unlinkSync(QR_FILE);
+  } catch {}
+  try {
+    fs.unlinkSync(STATUS_FILE);
+  } catch {}
+
+  let phoneNumber = phoneArg;
+  if (usePairingCode && !phoneNumber) {
+    phoneNumber = await askQuestion(
+      'Enter your phone number (with country code, no + or spaces, e.g. 14155551234): ',
+    );
+  }
+
+  console.log('Starting WhatsApp authentication...\n');
+
+  await connectSocket(phoneNumber);
+}
+
+authenticate().catch((err) => {
+  console.error('Authentication failed:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- **Apple Container networking**: Fix credential proxy bind address and host gateway resolution so containers can reach the proxy on macOS (bridge IP `192.168.65.1` instead of `host.docker.internal` which Apple Container doesn't support)
- **Apple Container compatibility**: Remove `/dev/null` bind mount (unsupported by Apple Container; `.env` shadowing is handled in the container entrypoint instead)
- **Model forwarding**: Forward `ANTHROPIC_MODEL` from `.env` to container, enabling LiteLLM/custom endpoint support
- **Launchd PATH**: Add `/opt/homebrew/bin` so `container` binary is found by the service
- **Image vision**: WhatsApp images downloaded, resized via sharp, and passed to Claude as multimodal content blocks
- **Emoji reactions**: Receive/store reactions in SQLite, StatusTracker lifecycle signaling (👀/✅), agent can send reactions via `react_to_message` MCP tool

## Test plan

- [ ] Start service with Apple Container runtime — verify it starts without "Container runtime failed" error
- [ ] Send a message to the bot — verify agent responds (no ENOTFOUND error)
- [ ] Send an image — verify agent describes the image content
- [ ] React to a message — verify it appears in `SELECT * FROM reactions` in SQLite
- [ ] Ask agent to react — verify emoji reaction appears on the message in WhatsApp

🤖 Generated with [Claude Code](https://claude.com/claude-code)