### PR TITLE
feat: add Telegram inline keyboard (callback query) support

### DIFF
--- a/.claude/skills/add-telegram-callback/SKILL.md
+++ b/.claude/skills/add-telegram-callback/SKILL.md
@@ -1,19 +1,17 @@
 ---
 name: add-telegram-callback
-description: Add inline keyboard (callback query) support to the Telegram channel. After applying, agents can send messages with clickable buttons, and button presses are routed to the agent as messages.
+description: Add inline keyboard (callback query) support to the Telegram channel. After applying, agents can send messages with clickable buttons, and button presses are routed to the agent as structured JSON events.
 ---
 
 # Add Telegram Callback Query Support
 
-This skill adds inline keyboard button support to the Telegram channel. After applying, you can send messages with `reply_markup` inline keyboards via the Telegram Bot API, and when users press buttons, the click is routed to the agent as a `[Button: <data>]` message.
+This skill adds inline keyboard button support to the Telegram channel. After applying, you can send messages with `reply_markup` inline keyboards, and when users press buttons, the event is routed to the agent as a structured JSON message — not a raw string — making it easy to parse without regex.
 
 ## Prerequisites
 
 This skill requires the Telegram channel to already be installed. Run `/add-telegram` first if you haven't already.
 
 ## Phase 1: Check Prerequisites
-
-Verify the Telegram channel is installed:
 
 ```bash
 test -f src/channels/telegram.ts && echo "OK" || echo "MISSING — run /add-telegram first"
@@ -23,7 +21,7 @@ If missing, stop and tell the user to run `/add-telegram` first.
 
 ## Phase 2: Apply Code Changes
 
-Open `src/channels/telegram.ts` and find this block (near the end of the `connect()` method, just before `this.bot.catch`):
+Open `src/channels/telegram.ts` and find this block near the end of the `connect()` method, just before `this.bot.catch`:
 
 ```typescript
     this.bot.on('message:contact', (ctx) => storeNonText(ctx, '[Contact]'));
@@ -37,27 +35,35 @@ Insert the following callback query handler **between** those two blocks:
 ```typescript
     // Handle inline keyboard button clicks
     this.bot.on('callback_query:data', async (ctx) => {
-      // Immediately acknowledge to dismiss the loading indicator on the button
+      // Immediately acknowledge to dismiss the loading indicator
       await ctx.answerCallbackQuery();
 
       const chatJid = `tg:${ctx.chat?.id}`;
       const group = this.opts.registeredGroups()[chatJid];
       if (!group) return;
 
-      const timestamp = new Date().toISOString();
       const senderName =
-        ctx.from?.first_name ||
-        ctx.from?.username ||
-        ctx.from?.id.toString() ||
+        ctx.from?.first_name ??
+        ctx.from?.username ??
+        ctx.from?.id.toString() ??
         'Unknown';
+
+      // Deliver as structured JSON so agents can parse without regex
+      const payload = {
+        _type: 'callback_query',
+        data: ctx.callbackQuery.data,
+        message_id: ctx.callbackQuery.message?.message_id,
+        query_id: ctx.callbackQuery.id,
+        from_name: senderName,
+      };
 
       this.opts.onMessage(chatJid, {
         id: ctx.callbackQuery.id,
         chat_jid: chatJid,
-        sender: ctx.from.id.toString(),
+        sender: ctx.from?.id.toString() ?? 'unknown',
         sender_name: senderName,
-        content: `[Button: ${ctx.callbackQuery.data}]`,
-        timestamp,
+        content: JSON.stringify(payload),
+        timestamp: new Date().toISOString(),
         is_from_me: false,
       });
 
@@ -75,17 +81,13 @@ Insert the following callback query handler **between** those two blocks:
 npm run build
 ```
 
-The build must be clean with no TypeScript errors before proceeding.
-
-If there are test files, run them:
+The build must be clean with no TypeScript errors.
 
 ```bash
 npx vitest run src/channels/telegram.test.ts 2>/dev/null || echo "No test file found, skipping"
 ```
 
 ## Phase 4: Restart and Test
-
-Restart NanoClaw:
 
 ```bash
 # macOS:
@@ -96,7 +98,7 @@ systemctl --user restart nanoclaw
 
 Tell the user:
 
-> Callback query support is now active. You can test it by sending a message with an inline keyboard via the Telegram Bot API:
+> Callback query support is now active. Send a test message with an inline keyboard:
 >
 > ```bash
 > curl -s "https://api.telegram.org/bot<TOKEN>/sendMessage" \
@@ -107,21 +109,34 @@ Tell the user:
 >     "reply_markup": {
 >       "inline_keyboard": [[
 >         {"text": "✅ Yes", "callback_data": "answer_yes"},
->         {"text": "❌ No", "callback_data": "answer_no"}
+>         {"text": "❌ No",  "callback_data": "answer_no"}
 >       ]]
 >     }
 >   }'
 > ```
 >
-> When you tap a button, the agent will receive a message: `[Button: answer_yes]`
+> When you tap a button, the agent will receive:
+> ```json
+> {"_type":"callback_query","data":"answer_yes","message_id":123,"query_id":"...","from_name":"Alice"}
+> ```
 
 ## How Agents Use This
 
-Agents can now:
+When a user taps a button, the agent receives a message whose `content` is a JSON string:
 
-1. **Send messages with buttons** — Use the Telegram Bot API directly (or a helper script) to send a `reply_markup` message with `inline_keyboard` buttons
-2. **Receive button presses** — When a user taps a button, the agent receives a message formatted as `[Button: <callback_data>]`
-3. **React accordingly** — The agent processes the button press like any other message
+```json
+{
+  "_type": "callback_query",
+  "data": "answer_yes",
+  "message_id": 123,
+  "query_id": "287714725902572059",
+  "from_name": "Alice"
+}
+```
+
+Agents should parse this with `JSON.parse()` and check `_type === "callback_query"` before handling.
+
+**`message_id`** is the ID of the original message that contained the buttons. Agents can use this to edit that message — for example, to mark the selected button — via `editMessageReplyMarkup` through the Telegram Bot API or a host IPC call.
 
 ### Example: Confirmation flow
 
@@ -131,15 +146,32 @@ Should I add this paper to your reading list?
 [✅ Add it]  [⏭ Skip]
 ```
 
-User taps "Add it" → Agent receives: `[Button: add_to_list]`
+User taps "Add it" → Agent receives:
+```json
+{"_type":"callback_query","data":"add_to_list","message_id":250,"query_id":"...","from_name":"Alice"}
+```
 
-Agent responds: "Added to your reading list!"
+Agent can then:
+1. Act on `data` ("add_to_list")
+2. Edit the original message (using `message_id`) to show which option was selected
+
+### Example: Agent-side parsing
+
+```typescript
+const event = JSON.parse(msg.content);
+if (event._type === 'callback_query') {
+  handleButtonPress(event.data, event.message_id);
+}
+```
 
 ## Removal
 
-To remove callback query support, delete the `callback_query:data` handler block added in Phase 2, then rebuild:
+Delete the `callback_query:data` handler block added in Phase 2, then rebuild:
 
 ```bash
-npm run build && launchctl kickstart -k gui/$(id -u)/com.nanoclaw  # macOS
-# Linux: npm run build && systemctl --user restart nanoclaw
+npm run build
+# macOS:
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+# Linux:
+systemctl --user restart nanoclaw
 ```


### PR DESCRIPTION
This PR adds support for Telegram inline keyboard callback queries in NanoClaw.

Replaces #1014 (branch migrated due to repository cleanup).