### PR TITLE
fix: relay agent text when turn ends with tool call instead of text

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -363,6 +363,7 @@ async function runQuery(
 
   let newSessionId: string | undefined;
   let lastAssistantUuid: string | undefined;
+  let lastAssistantText: string | undefined;
   let messageCount = 0;
   let resultCount = 0;
 
@@ -435,6 +436,17 @@ async function runQuery(
 
     if (message.type === 'assistant' && 'uuid' in message) {
       lastAssistantUuid = (message as { uuid: string }).uuid;
+      // Track last assistant text so we can use it as a fallback if the SDK's
+      // result.result is empty (happens when the turn ends with a tool call
+      // rather than text — e.g. agent replies then silently updates memory).
+      const assistantContent = (message as { message?: { content?: unknown[] } }).message?.content;
+      if (Array.isArray(assistantContent)) {
+        const text = assistantContent
+          .filter((b): b is { type: 'text'; text: string } => (b as { type?: string }).type === 'text')
+          .map((b) => b.text)
+          .join('');
+        if (text) lastAssistantText = text;
+      }
     }
 
     if (message.type === 'system' && message.subtype === 'init') {
@@ -450,12 +462,18 @@ async function runQuery(
     if (message.type === 'result') {
       resultCount++;
       const textResult = 'result' in message ? (message as { result?: string }).result : null;
-      log(`Result #${resultCount}: subtype=${message.subtype}${textResult ? ` text=${textResult.slice(0, 200)}` : ''}`);
+      // Fall back to the last captured assistant text when result.result is empty.
+      // This covers the case where the agent's turn ends with a tool call (e.g.
+      // writing memory) rather than a text response, causing result.result to be
+      // empty even though the agent did produce visible text earlier in the turn.
+      const effectiveResult = textResult || lastAssistantText || null;
+      log(`Result #${resultCount}: subtype=${message.subtype}${effectiveResult ? ` text=${effectiveResult.slice(0, 200)}` : ''}${!textResult && effectiveResult ? ' (from lastAssistantText fallback)' : ''}`);
       writeOutput({
         status: 'success',
-        result: textResult || null,
+        result: effectiveResult,
         newSessionId
       });
+      lastAssistantText = undefined;
     }
   }
 


### PR DESCRIPTION
## Problem

When an agent responds with text and then performs a tool call (e.g. updating memory after replying), the Claude Agent SDK's `result.result` field is empty because the final action in the turn was a tool call with no text after it.

This causes the agent's reply to **silently disappear** — the user sees a typing indicator but receives no response.

**Reproduction:** send a message that the agent responds to, then the agent updates its memory (or any other file/tool operation) in the same turn without producing another text block after the tool result. The response is swallowed.

## Root cause

In `runQuery()`, the output is emitted from `message.type === 'result'` events:

```ts
const textResult = 'result' in message ? (message as { result?: string }).result : null;
writeOutput({ status: 'success', result: textResult || null, newSessionId });
```

When the SDK's result message has an empty `result` field (turn ended with a tool call), `textResult` is falsy and `result: null` is written — which the host process ignores.

## Fix

Track text from each `assistant` message event during a query. If `result.result` is empty when the result event arrives, fall back to the last captured assistant text. The buffer is cleared after each result to avoid leaking text across separate IPC-driven queries in the same container session.

## Test plan

- [ ] Send a message that causes the agent to reply + update memory in the same turn — response should now arrive in chat
- [ ] Send a message that causes the agent to reply with no tool use — behaviour unchanged (uses `result.result` directly)
- [ ] Silent scheduled tasks (result: null, no assistant text) — still produce no output (no regression)