### PR TITLE
fix: forward NanoClaw slash commands through Telegram and improve isMain backfill

### DIFF
--- a/src/channels/telegram.test.ts
+++ b/src/channels/telegram.test.ts
@@ -295,16 +295,38 @@ describe('TelegramChannel', () => {
       expect(opts.onMessage).not.toHaveBeenCalled();
     });
 
-    it('skips command messages (starting with /)', async () => {
+    it('skips native bot commands (/chatid, /ping)', async () => {
       const opts = createTestOpts();
       const channel = new TelegramChannel('test-token', opts);
       await channel.connect();
 
-      const ctx = createTextCtx({ text: '/start' });
-      await triggerTextMessage(ctx);
+      for (const cmd of ['/chatid', '/ping', '/chatid@my_bot', '/ping@my_bot']) {
+        vi.clearAllMocks();
+        await triggerTextMessage(createTextCtx({ text: cmd }));
+        expect(opts.onMessage).not.toHaveBeenCalled();
+      }
+    });
 
-      expect(opts.onMessage).not.toHaveBeenCalled();
-      expect(opts.onChatMetadata).not.toHaveBeenCalled();
+    it('forwards non-native slash commands to onMessage (e.g. /remote-control)', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      // Plain command
+      await triggerTextMessage(createTextCtx({ text: '/remote-control' }));
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '/remote-control' }),
+      );
+
+      vi.clearAllMocks();
+
+      // With @bot_username suffix (Telegram appends this in group chats)
+      await triggerTextMessage(createTextCtx({ text: '/remote-control@my_bot' }));
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '/remote-control' }),
+      );
     });
 
     it('extracts sender name from first_name', async () => {

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -81,11 +81,20 @@ export class TelegramChannel implements Channel {
     });
 
     this.bot.on('message:text', async (ctx) => {
-      // Skip commands
-      if (ctx.message.text.startsWith('/')) return;
+      // Strip the @bot_username suffix Telegram appends to slash commands in
+      // group chats (e.g. /remote-control@my_bot → /remote-control).
+      const rawText = ctx.message.text;
+      const normalizedText = rawText.replace(/^(\/\S+?)@\w+/, '$1');
+
+      // Skip commands handled natively by this bot via bot.command() to avoid
+      // double-handling. Any other slash commands (e.g. /remote-control sent
+      // to NanoClaw's dispatcher) are forwarded to onMessage as normal text.
+      const NATIVE_BOT_COMMANDS = new Set(['chatid', 'ping']);
+      const cmdName = normalizedText.match(/^\/(\w+)/)?.[1]?.toLowerCase();
+      if (cmdName && NATIVE_BOT_COMMANDS.has(cmdName)) return;
 
       const chatJid = `tg:${ctx.chat.id}`;
-      let content = ctx.message.text;
+      let content = normalizedText;
       const timestamp = new Date(ctx.message.date * 1000).toISOString();
       const senderName =
         ctx.from?.first_name ||

--- a/src/db.ts
+++ b/src/db.ts
@@ -111,9 +111,10 @@ function createSchema(database: Database.Database): void {
     database.exec(
       `ALTER TABLE registered_groups ADD COLUMN is_main INTEGER DEFAULT 0`,
     );
-    // Backfill: existing rows with folder = 'main' are the main group
+    // Backfill: mark groups whose folder is 'main' or ends with '_main'
+    // (e.g. 'telegram_main', 'whatsapp_main', 'discord_main')
     database.exec(
-      `UPDATE registered_groups SET is_main = 1 WHERE folder = 'main'`,
+      `UPDATE registered_groups SET is_main = 1 WHERE folder = 'main' OR folder LIKE '%_main'`,
     );
   } catch {
     /* column already exists */


### PR DESCRIPTION
## Problem

Two bugs prevent \`/remote-control\` (and any future NanoClaw slash commands) from working via Telegram:

**1. All \`/\` messages silently dropped**
\`telegram.ts\`'s \`message:text\` handler had a blanket \`if (text.startsWith('/')) return\` that discarded every slash command before it could reach NanoClaw's dispatcher.

**2. \`@bot_username\` suffix not stripped**
Telegram appends \`@bot_username\` to slash commands in group chats (e.g. \`/remote-control@my_bot\`). Even if the message reached the dispatcher, the exact-string match would fail.

**3. \`isMain\` backfill too narrow**
The \`is_main\` migration only backfilled \`folder = 'main'\`, missing channel-specific main groups like \`telegram_main\` and \`whatsapp_main\`. This meant the remote-control security check always rejected the command — no group was ever marked as main on existing installs.

## Fix

**\`telegram.ts\`**: Only skip commands handled natively by the bot (\`chatid\`, \`ping\`). All other slash commands are forwarded to \`onMessage\` as normal text. Strip \`@bot_username\` suffix before matching. Adding new bot commands in future only requires updating \`NATIVE_BOT_COMMANDS\`.

**\`db.ts\`**: Extend backfill to \`folder = 'main' OR folder LIKE '%_main'\` to cover \`telegram_main\`, \`whatsapp_main\`, \`discord_main\`, etc.

**\`telegram.test.ts\`**: Updated test to verify native commands are still blocked, and new test to verify NanoClaw slash commands (including \`@bot_username\` suffix variant) are forwarded correctly.

## Testing

51 telegram tests pass. Verified end-to-end: \`/remote-control\` and \`/remote-control@bot_name\` both reach NanoClaw's dispatcher correctly.