### PR TITLE
security: stop logging user prompt content on container errors

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -503,10 +503,24 @@ export async function runContainerAgent(
       const isError = code !== 0;
 
       if (isVerbose || isError) {
+        // On error, log input metadata only — not the full prompt.
+        // Full input is only included at verbose level to avoid
+        // persisting user conversation content on every non-zero exit.
+        if (isVerbose) {
+          logLines.push(
+            `=== Input ===`,
+            JSON.stringify(input, null, 2),
+            ``,
+          );
+        } else {
+          logLines.push(
+            `=== Input Summary ===`,
+            `Prompt length: ${input.prompt.length} chars`,
+            `Session ID: ${input.sessionId || 'new'}`,
+            ``,
+          );
+        }
         logLines.push(
-          `=== Input ===`,
-          JSON.stringify(input, null, 2),
-          ``,
           `=== Container Args ===`,
           containerArgs.join(' '),
           ``,

--- a/src/index.ts
+++ b/src/index.ts
@@ -221,7 +221,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
           : JSON.stringify(result.result);
       // Strip <internal>...</internal> blocks — agent uses these for internal reasoning
       const text = raw.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
-      logger.info({ group: group.name }, `Agent output: ${raw.slice(0, 200)}`);
+      logger.info({ group: group.name }, `Agent output: ${raw.length} chars`);
       if (text) {
         await channel.sendMessage(chatJid, text);
         outputSentToUser = true;


### PR DESCRIPTION
Fixes #1150.

Container error logs wrote the full `ContainerInput` (including user prompt) to disk on every non-zero exit. The structured log stream also included the first 200 chars of agent output, which could travel to centralised logging.

- `container-runner.ts`: only include full input at verbose log level; error path now logs prompt length and session ID instead
- `index.ts`: log output length instead of content snippet