### PR TITLE
fix: honour ANTHROPIC_BASE_URL path for third-party API endpoints

### DIFF
--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -79,11 +79,14 @@ export function startCredentialProxy(
           }
         }
 
+        const basePath = upstreamUrl.pathname.replace(/\/+$/, '');
+        const fullPath = basePath + req.url;
+
         const upstream = makeRequest(
           {
             hostname: upstreamUrl.hostname,
             port: upstreamUrl.port || (isHttps ? 443 : 80),
-            path: req.url,
+            path: fullPath,
             method: req.method,
             headers,
           } as RequestOptions,


### PR DESCRIPTION
## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description

Third-party Anthropic-compatible APIs are often mounted at a sub-path, not the root. For example, Z.AI's Claude endpoint is `https://api.z.ai/api/anthropic` — as documented at https://docs.z.ai/devpack/tool/claude — and requires `ANTHROPIC_BASE_URL` to be set to that full path. The credential proxy was silently dropping the path component.

The Claude Code SDK always sends requests relative to the root — `/v1/messages`, `/v1/complete`, etc. — because it constructs URLs from `ANTHROPIC_BASE_URL` by appending the API path directly. Inside the container, `ANTHROPIC_BASE_URL` is set to `http://host.docker.internal:3001` (the proxy), so `req.url` arriving at the proxy is always something like `/v1/messages` with no prefix.

When the proxy forwards the request it was using `path: req.url` verbatim, discarding `upstreamUrl.pathname`. So a `ANTHROPIC_BASE_URL` of `https://api.z.ai/api/anthropic` would forward to `api.z.ai/v1/messages` (404) instead of `api.z.ai/api/anthropic/v1/messages`.

### Changes

Prepend `upstreamUrl.pathname` to `req.url` before forwarding. Trailing slashes on the base path are stripped to avoid double slashes. No change in behaviour when `ANTHROPIC_BASE_URL` has no path (the default Anthropic endpoint).