### PR TITLE
feat: add /model command for runtime model switching

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -392,6 +392,14 @@ async function runQuery(
   for await (const message of query({
     prompt: stream,
     options: {
+      model: (() => {
+        try {
+          const m = fs.readFileSync('/workspace/group/model.txt', 'utf-8').trim();
+          return m || 'claude-sonnet-4-6';
+        } catch {
+          return 'claude-sonnet-4-6';
+        }
+      })(),
       cwd: '/workspace/group',
       additionalDirectories: extraDirs.length > 0 ? extraDirs : undefined,
       resume: sessionId,

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,32 @@ import { logger } from './logger.js';
 // Re-export for backwards compatibility during refactor
 export { escapeXml, formatMessages } from './router.js';
 
+const AVAILABLE_MODELS: Record<string, string> = {
+  haiku: 'claude-haiku-4-5-20251001',
+  sonnet: 'claude-sonnet-4-6',
+  opus: 'claude-opus-4-6',
+};
+const DEFAULT_MODEL = 'claude-sonnet-4-6';
+
+function modelFilePath(groupFolder: string): string {
+  return resolveGroupFolderPath(groupFolder) + '/model.txt';
+}
+
+function readGroupModel(groupFolder: string): string {
+  try {
+    return (
+      fs.readFileSync(modelFilePath(groupFolder), 'utf-8').trim() ||
+      DEFAULT_MODEL
+    );
+  } catch {
+    return DEFAULT_MODEL;
+  }
+}
+
+function writeGroupModel(groupFolder: string, modelId: string): void {
+  fs.writeFileSync(modelFilePath(groupFolder), modelId, 'utf-8');
+}
+
 let lastTimestamp = '';
 let sessions: Record<string, string> = {};
 let registeredGroups: Record<string, RegisteredGroup> = {};
@@ -493,6 +519,54 @@ async function main(): Promise<void> {
   process.on('SIGTERM', () => shutdown('SIGTERM'));
   process.on('SIGINT', () => shutdown('SIGINT'));
 
+  // Handle /model [name] command
+  async function handleModelCommand(
+    args: string,
+    chatJid: string,
+    msg: NewMessage,
+  ): Promise<void> {
+    if (!msg.is_from_me) return; // admin only
+
+    const group = registeredGroups[chatJid];
+    if (!group) return;
+    const channel = findChannel(channels, chatJid);
+    if (!channel) return;
+
+    const alias = args.trim().toLowerCase();
+
+    if (!alias) {
+      const current = readGroupModel(group.folder);
+      const currentAlias =
+        Object.entries(AVAILABLE_MODELS).find(
+          ([, id]) => id === current,
+        )?.[0] ?? current;
+      const list = Object.entries(AVAILABLE_MODELS)
+        .map(([a, id]) => `  ${a} — ${id}${id === current ? ' ✓' : ''}`)
+        .join('\n');
+      await channel.sendMessage(
+        chatJid,
+        `Current model: ${currentAlias}\n\nAvailable:\n${list}`,
+      );
+      return;
+    }
+
+    const modelId = AVAILABLE_MODELS[alias];
+    if (!modelId) {
+      const names = Object.keys(AVAILABLE_MODELS).join(', ');
+      await channel.sendMessage(
+        chatJid,
+        `Unknown model "${alias}". Available: ${names}`,
+      );
+      return;
+    }
+
+    writeGroupModel(group.folder, modelId);
+    await channel.sendMessage(
+      chatJid,
+      `Model switched to ${alias} (${modelId}). Takes effect on the next message.`,
+    );
+  }
+
   // Handle /remote-control and /remote-control-end commands
   async function handleRemoteControl(
     command: string,
@@ -538,11 +612,17 @@ async function main(): Promise<void> {
   // Channel callbacks (shared by all channels)
   const channelOpts = {
     onMessage: (chatJid: string, msg: NewMessage) => {
-      // Remote control commands — intercept before storage
+      // Intercept admin commands before storage
       const trimmed = msg.content.trim();
       if (trimmed === '/remote-control' || trimmed === '/remote-control-end') {
         handleRemoteControl(trimmed, chatJid, msg).catch((err) =>
           logger.error({ err, chatJid }, 'Remote control command error'),
+        );
+        return;
+      }
+      if (trimmed === '/model' || trimmed.startsWith('/model ')) {
+        handleModelCommand(trimmed.slice('/model'.length), chatJid, msg).catch(
+          (err) => logger.error({ err, chatJid }, 'Model command error'),
         );
         return;
       }


### PR DESCRIPTION
## Summary

- Adds a `/model` chat command so admins can switch the Claude model per-group at runtime without restarting the service
- Model preference is persisted to `groups/{folder}/model.txt` and read by the agent-runner at each container startup
- Only the device owner (`is_from_me`) can use the command

## Usage

- `/model` — list available models, marks current with ✓
- `/model haiku` — switch to `claude-haiku-4-5-20251001`
- `/model sonnet` — switch to `claude-sonnet-4-6` (default)
- `/model opus` — switch to `claude-opus-4-6`

## How it works

**`src/index.ts`** — intercepts `/model` in `onMessage` before messages are stored (same pattern as `/remote-control`). Writes the model ID to `groups/{folder}/model.txt`.

**`container/agent-runner/src/index.ts`** — reads `/workspace/group/model.txt` at query time and passes it as the `model` option to the SDK `query()` call. Falls back to `claude-sonnet-4-6` if the file is absent.

The model file lives in the group folder, which is already mounted as `/workspace/group` in the container, so no new mounts or container rebuilds are needed.

## Test plan

- [ ] Send `/model` — verify list is returned with current model marked ✓
- [ ] Send `/model haiku` — verify confirmation message, verify next agent response comes from haiku (check session JSONL `model` field)
- [ ] Send `/model opus` — verify switch, verify response comes from opus
- [ ] Send `/model invalid` — verify error message listing valid options
- [ ] Send `/model` from a non-`is_from_me` message — verify it is silently ignored (not intercepted, forwarded to agent as normal message)
- [ ] Restart service — verify model preference is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)