### PR TITLE
feat: suspend running tasks when user messages arrive

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -22,6 +22,7 @@ import { fileURLToPath } from 'url';
 interface ContainerInput {
   prompt: string;
   sessionId?: string;
+  resumeAt?: string; // lastAssistantUuid — resume from this point in the session
   groupFolder: string;
   chatJid: string;
   isMain: boolean;
@@ -30,9 +31,10 @@ interface ContainerInput {
 }
 
 interface ContainerOutput {
-  status: 'success' | 'error';
+  status: 'success' | 'error' | 'interrupted';
   result: string | null;
   newSessionId?: string;
+  lastAssistantUuid?: string;
   error?: string;
 }
 
@@ -56,6 +58,7 @@ interface SDKUserMessage {
 
 const IPC_INPUT_DIR = '/workspace/ipc/input';
 const IPC_INPUT_CLOSE_SENTINEL = path.join(IPC_INPUT_DIR, '_close');
+const IPC_INPUT_INTERRUPT_SENTINEL = path.join(IPC_INPUT_DIR, '_interrupt');
 const IPC_POLL_MS = 500;
 
 /**
@@ -270,6 +273,17 @@ function shouldClose(): boolean {
 }
 
 /**
+ * Check for _interrupt sentinel.
+ */
+function shouldInterrupt(): boolean {
+  if (fs.existsSync(IPC_INPUT_INTERRUPT_SENTINEL)) {
+    try { fs.unlinkSync(IPC_INPUT_INTERRUPT_SENTINEL); } catch { /* ignore */ }
+    return true;
+  }
+  return false;
+}
+
+/**
  * Drain all pending IPC input messages.
  * Returns messages found, or empty array.
  */
@@ -302,12 +316,16 @@ function drainIpcInput(): string[] {
 }
 
 /**
- * Wait for a new IPC message or _close sentinel.
- * Returns the messages as a single string, or null if _close.
+ * Wait for a new IPC message, _close sentinel, or _interrupt sentinel.
+ * Returns the messages as a single string, null if _close, or '__interrupted__' if _interrupt.
  */
 function waitForIpcMessage(): Promise<string | null> {
   return new Promise((resolve) => {
     const poll = () => {
+      if (shouldInterrupt()) {
+        resolve('__interrupted__');
+        return;
+      }
       if (shouldClose()) {
         resolve(null);
         return;
@@ -336,15 +354,25 @@ async function runQuery(
   containerInput: ContainerInput,
   sdkEnv: Record<string, string | undefined>,
   resumeAt?: string,
-): Promise<{ newSessionId?: string; lastAssistantUuid?: string; closedDuringQuery: boolean }> {
+  abortController?: AbortController,
+): Promise<{ newSessionId?: string; lastAssistantUuid?: string; closedDuringQuery: boolean; interrupted: boolean }> {
   const stream = new MessageStream();
   stream.push(prompt);
 
-  // Poll IPC for follow-up messages and _close sentinel during the query
+  // Poll IPC for follow-up messages, _close and _interrupt sentinels during the query
   let ipcPolling = true;
   let closedDuringQuery = false;
+  let interrupted = false;
   const pollIpcDuringQuery = () => {
     if (!ipcPolling) return;
+    if (shouldInterrupt()) {
+      log('Interrupt sentinel detected during query, aborting');
+      interrupted = true;
+      abortController?.abort();
+      stream.end();
+      ipcPolling = false;
+      return;
+    }
     if (shouldClose()) {
       log('Close sentinel detected during query, ending stream');
       closedDuringQuery = true;
@@ -454,14 +482,15 @@ async function runQuery(
       writeOutput({
         status: 'success',
         result: textResult || null,
-        newSessionId
+        newSessionId,
+        lastAssistantUuid,
       });
     }
   }
 
   ipcPolling = false;
-  log(`Query done. Messages: ${messageCount}, results: ${resultCount}, lastAssistantUuid: ${lastAssistantUuid || 'none'}, closedDuringQuery: ${closedDuringQuery}`);
-  return { newSessionId, lastAssistantUuid, closedDuringQuery };
+  log(`Query done. Messages: ${messageCount}, results: ${resultCount}, lastAssistantUuid: ${lastAssistantUuid || 'none'}, closedDuringQuery: ${closedDuringQuery}, interrupted: ${interrupted}`);
+  return { newSessionId, lastAssistantUuid, closedDuringQuery, interrupted };
 }
 
 async function main(): Promise<void> {
@@ -491,8 +520,9 @@ async function main(): Promise<void> {
   let sessionId = containerInput.sessionId;
   fs.mkdirSync(IPC_INPUT_DIR, { recursive: true });
 
-  // Clean up stale _close sentinel from previous container runs
+  // Clean up stale sentinels from previous container runs
   try { fs.unlinkSync(IPC_INPUT_CLOSE_SENTINEL); } catch { /* ignore */ }
+  try { fs.unlinkSync(IPC_INPUT_INTERRUPT_SENTINEL); } catch { /* ignore */ }
 
   // Build initial prompt (drain any pending IPC messages too)
   let prompt = containerInput.prompt;
@@ -506,17 +536,25 @@ async function main(): Promise<void> {
   }
 
   // Query loop: run query → wait for IPC message → run new query → repeat
-  let resumeAt: string | undefined;
+  let resumeAt: string | undefined = containerInput.resumeAt;
   try {
     while (true) {
       log(`Starting query (session: ${sessionId || 'new'}, resumeAt: ${resumeAt || 'latest'})...`);
 
-      const queryResult = await runQuery(prompt, sessionId, mcpServerPath, containerInput, sdkEnv, resumeAt);
+      const abortController = new AbortController();
+      const queryResult = await runQuery(prompt, sessionId, mcpServerPath, containerInput, sdkEnv, resumeAt, abortController);
       if (queryResult.newSessionId) {
         sessionId = queryResult.newSessionId;
       }
       if (queryResult.lastAssistantUuid) {
         resumeAt = queryResult.lastAssistantUuid;
+      }
+
+      // If interrupted, emit status and exit
+      if (queryResult.interrupted) {
+        log('Interrupted during query, exiting');
+        writeOutput({ status: 'interrupted', result: null, newSessionId: sessionId, lastAssistantUuid: resumeAt });
+        break;
       }
 
       // If _close was consumed during the query, exit immediately.
@@ -528,12 +566,17 @@ async function main(): Promise<void> {
       }
 
       // Emit session update so host can track it
-      writeOutput({ status: 'success', result: null, newSessionId: sessionId });
+      writeOutput({ status: 'success', result: null, newSessionId: sessionId, lastAssistantUuid: resumeAt });
 
       log('Query ended, waiting for next IPC message...');
 
-      // Wait for the next message or _close sentinel
+      // Wait for the next message, _close sentinel, or _interrupt sentinel
       const nextMessage = await waitForIpcMessage();
+      if (nextMessage === '__interrupted__') {
+        log('Interrupt sentinel received while idle, exiting');
+        writeOutput({ status: 'interrupted', result: null, newSessionId: sessionId, lastAssistantUuid: resumeAt });
+        break;
+      }
       if (nextMessage === null) {
         log('Close sentinel received, exiting');
         break;
@@ -544,14 +587,31 @@ async function main(): Promise<void> {
     }
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : String(err);
-    log(`Agent error: ${errorMessage}`);
-    writeOutput({
-      status: 'error',
-      result: null,
-      newSessionId: sessionId,
-      error: errorMessage
-    });
-    process.exit(1);
+    // AbortController.abort() in the SDK throws — treat as interrupt, not error.
+    const isAbort = errorMessage.includes('aborted') || (err instanceof Error && err.name === 'AbortError');
+    if (isAbort) {
+      log(`Agent aborted (interrupt): ${errorMessage}`);
+      writeOutput({
+        status: 'interrupted',
+        result: null,
+        newSessionId: sessionId,
+        lastAssistantUuid: resumeAt,
+      });
+      // Wait for stdout to flush before exiting — the host pipe reader needs
+      // to receive the interrupted marker before the process closes.
+      await new Promise<void>((resolve) => {
+        process.stdout.write('', () => resolve());
+      });
+    } else {
+      log(`Agent error: ${errorMessage}`);
+      writeOutput({
+        status: 'error',
+        result: null,
+        newSessionId: sessionId,
+        error: errorMessage
+      });
+      process.exit(1);
+    }
   }
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -71,3 +71,6 @@ export const TRIGGER_PATTERN = new RegExp(
 // Uses system timezone by default
 export const TIMEZONE =
   process.env.TZ || Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+// How long to wait for a container to exit after writing _interrupt before hard-killing it
+export const INTERRUPT_HARD_KILL_DELAY = 5000;

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -36,6 +36,7 @@ const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
 export interface ContainerInput {
   prompt: string;
   sessionId?: string;
+  resumeAt?: string; // lastAssistantUuid — resume from this point in the session
   groupFolder: string;
   chatJid: string;
   isMain: boolean;
@@ -44,9 +45,10 @@ export interface ContainerInput {
 }
 
 export interface ContainerOutput {
-  status: 'success' | 'error';
+  status: 'success' | 'error' | 'interrupted';
   result: string | null;
   newSessionId?: string;
+  lastAssistantUuid?: string;
   error?: string;
 }
 
@@ -324,6 +326,7 @@ export async function runContainerAgent(
     // Streaming output: parse OUTPUT_START/END marker pairs as they arrive
     let parseBuffer = '';
     let newSessionId: string | undefined;
+    let lastAssistantUuid: string | undefined;
     let outputChain = Promise.resolve();
 
     container.stdout.on('data', (data) => {
@@ -361,6 +364,9 @@ export async function runContainerAgent(
             const parsed: ContainerOutput = JSON.parse(jsonStr);
             if (parsed.newSessionId) {
               newSessionId = parsed.newSessionId;
+            }
+            if (parsed.lastAssistantUuid) {
+              lastAssistantUuid = parsed.lastAssistantUuid;
             }
             hadStreamingOutput = true;
             // Activity detected — reset the hard timeout
@@ -465,6 +471,7 @@ export async function runContainerAgent(
               status: 'success',
               result: null,
               newSessionId,
+              lastAssistantUuid,
             });
           });
           return;
@@ -573,6 +580,7 @@ export async function runContainerAgent(
             status: 'success',
             result: null,
             newSessionId,
+            lastAssistantUuid,
           });
         });
         return;

--- a/src/db.ts
+++ b/src/db.ts
@@ -9,6 +9,7 @@ import {
   NewMessage,
   RegisteredGroup,
   ScheduledTask,
+  SuspendedTask,
   TaskRunLog,
 } from './types.js';
 
@@ -83,6 +84,32 @@ function createSchema(database: Database.Database): void {
       requires_trigger INTEGER DEFAULT 1
     );
   `);
+
+  // Suspended tasks table for task suspend/resume durability.
+  // UNIQUE on group_folder enforces single-slot: only one suspended task per group.
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS suspended_tasks (
+      group_folder TEXT NOT NULL,
+      task_id TEXT NOT NULL PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      resume_at TEXT NOT NULL,
+      suspended_at TEXT NOT NULL
+    )
+  `);
+  // Add unique index on group_folder (migration for existing DBs).
+  // Clean up any pre-existing duplicates first — keep the most recent per group.
+  try {
+    database.exec(`
+      DELETE FROM suspended_tasks WHERE rowid NOT IN (
+        SELECT MAX(rowid) FROM suspended_tasks GROUP BY group_folder
+      )
+    `);
+    database.exec(
+      `CREATE UNIQUE INDEX idx_suspended_tasks_group ON suspended_tasks(group_folder)`,
+    );
+  } catch {
+    /* index already exists */
+  }
 
   // Add context_mode column if it doesn't exist (migration for existing DBs)
   try {
@@ -449,7 +476,18 @@ export function updateTask(
 export function deleteTask(id: string): void {
   // Delete child records first (FK constraint)
   db.prepare('DELETE FROM task_run_logs WHERE task_id = ?').run(id);
+  db.prepare('DELETE FROM suspended_tasks WHERE task_id = ?').run(id);
   db.prepare('DELETE FROM scheduled_tasks WHERE id = ?').run(id);
+}
+
+export function setTaskStatus(
+  id: string,
+  status: ScheduledTask['status'],
+): void {
+  db.prepare('UPDATE scheduled_tasks SET status = ? WHERE id = ?').run(
+    status,
+    id,
+  );
 }
 
 export function getDueTasks(): ScheduledTask[] {
@@ -694,4 +732,41 @@ function migrateJsonState(): void {
       }
     }
   }
+}
+
+// --- Suspended task accessors ---
+
+export function saveSuspendedTask(task: SuspendedTask): void {
+  // Clear any existing suspended task for this group first (single-slot invariant).
+  db.prepare('DELETE FROM suspended_tasks WHERE group_folder = ?').run(
+    task.group_folder,
+  );
+  db.prepare(
+    `INSERT INTO suspended_tasks (group_folder, task_id, session_id, resume_at, suspended_at)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).run(
+    task.group_folder,
+    task.task_id,
+    task.session_id,
+    task.resume_at,
+    task.suspended_at,
+  );
+}
+
+export function getSuspendedTask(
+  groupFolder: string,
+): SuspendedTask | null {
+  return (
+    (db
+      .prepare('SELECT * FROM suspended_tasks WHERE group_folder = ?')
+      .get(groupFolder) as SuspendedTask | undefined) ?? null
+  );
+}
+
+export function getAllSuspendedTasks(): SuspendedTask[] {
+  return db.prepare('SELECT * FROM suspended_tasks').all() as SuspendedTask[];
+}
+
+export function clearSuspendedTask(taskId: string): void {
+  db.prepare('DELETE FROM suspended_tasks WHERE task_id = ?').run(taskId);
 }

--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -1,8 +1,9 @@
-import { ChildProcess } from 'child_process';
+import { ChildProcess, execFile } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 
 import { DATA_DIR, MAX_CONCURRENT_CONTAINERS } from './config.js';
+import { CONTAINER_RUNTIME_BIN } from './container-runtime.js';
 import { logger } from './logger.js';
 
 interface QueuedTask {
@@ -19,12 +20,14 @@ interface GroupState {
   idleWaiting: boolean;
   isTaskContainer: boolean;
   runningTaskId: string | null;
+  suspendedTaskId: string | null;
   pendingMessages: boolean;
   pendingTasks: QueuedTask[];
   process: ChildProcess | null;
   containerName: string | null;
   groupFolder: string | null;
   retryCount: number;
+  interruptCallback: (() => void) | null;
 }
 
 export class GroupQueue {
@@ -32,6 +35,8 @@ export class GroupQueue {
   private activeCount = 0;
   private waitingGroups: string[] = [];
   private processMessagesFn: ((groupJid: string) => Promise<boolean>) | null =
+    null;
+  private resumeSuspendedFn: ((groupJid: string) => Promise<void>) | null =
     null;
   private shuttingDown = false;
 
@@ -43,12 +48,14 @@ export class GroupQueue {
         idleWaiting: false,
         isTaskContainer: false,
         runningTaskId: null,
+        suspendedTaskId: null,
         pendingMessages: false,
         pendingTasks: [],
         process: null,
         containerName: null,
         groupFolder: null,
         retryCount: 0,
+        interruptCallback: null,
       };
       this.groups.set(groupJid, state);
     }
@@ -57,6 +64,83 @@ export class GroupQueue {
 
   setProcessMessagesFn(fn: (groupJid: string) => Promise<boolean>): void {
     this.processMessagesFn = fn;
+  }
+
+  setResumeSuspendedFn(fn: (groupJid: string) => Promise<void>): void {
+    this.resumeSuspendedFn = fn;
+  }
+
+  setSuspendedTaskId(groupJid: string, taskId: string | null): void {
+    this.getGroup(groupJid).suspendedTaskId = taskId;
+  }
+
+  getSuspendedTaskId(groupJid: string): string | null {
+    return this.getGroup(groupJid).suspendedTaskId;
+  }
+
+  isTaskContainer(groupJid: string): boolean {
+    const state = this.getGroup(groupJid);
+    return state.active && state.isTaskContainer;
+  }
+
+  isIdleWaiting(groupJid: string): boolean {
+    const state = this.getGroup(groupJid);
+    return state.active && state.idleWaiting;
+  }
+
+  /**
+   * Write an interrupt sentinel to signal the container to abort immediately.
+   * Returns true if the sentinel was written (active container exists).
+   */
+  interruptAgent(groupJid: string): boolean {
+    const state = this.getGroup(groupJid);
+    if (!state.active || !state.groupFolder) return false;
+
+    const inputDir = path.join(DATA_DIR, 'ipc', state.groupFolder, 'input');
+    try {
+      fs.mkdirSync(inputDir, { recursive: true });
+      fs.writeFileSync(path.join(inputDir, '_interrupt'), '');
+      logger.info({ groupJid }, 'Interrupt sentinel written');
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Hard-kill the container process (used when agent doesn't exit gracefully).
+   */
+  hardKill(groupJid: string): void {
+    const state = this.getGroup(groupJid);
+    if (!state.active) return;
+
+    if (state.containerName) {
+      logger.warn(
+        { groupJid, containerName: state.containerName },
+        'Hard-killing container',
+      );
+      execFile(
+        CONTAINER_RUNTIME_BIN,
+        ['stop', state.containerName],
+        { timeout: 10000 },
+        (err) => {
+          if (err && state.process && !state.process.killed) {
+            logger.warn({ groupJid }, 'Container stop failed, sending SIGKILL');
+            state.process.kill('SIGKILL');
+          }
+        },
+      );
+    } else if (state.process && !state.process.killed) {
+      state.process.kill('SIGKILL');
+    }
+  }
+
+  setInterruptCallback(groupJid: string, cb: (() => void) | null): void {
+    this.getGroup(groupJid).interruptCallback = cb;
+  }
+
+  getInterruptCallback(groupJid: string): (() => void) | null {
+    return this.getGroup(groupJid).interruptCallback;
   }
 
   enqueueMessageCheck(groupJid: string): void {
@@ -249,6 +333,14 @@ export class GroupQueue {
     } catch (err) {
       logger.error({ groupJid, taskId: task.id, err }, 'Error running task');
     } finally {
+      // Clear interrupt callback (e.g. hard-kill timer) to prevent it from
+      // killing the NEXT container spawned for this group.
+      const interruptCleanup = state.interruptCallback;
+      if (interruptCleanup) {
+        interruptCleanup();
+        state.interruptCallback = null;
+      }
+
       state.active = false;
       state.isTaskContainer = false;
       state.runningTaskId = null;
@@ -283,29 +375,64 @@ export class GroupQueue {
     }, delayMs);
   }
 
+  /**
+   * Trigger a drain cycle for a group without setting pendingMessages.
+   * Used by startup recovery to resume suspended tasks without falsely
+   * claiming there are pending messages. Respects concurrency limits.
+   */
+  triggerDrain(groupJid: string): void {
+    const state = this.getGroup(groupJid);
+    if (state.active) return; // Will drain when current work finishes
+    if (this.activeCount >= MAX_CONCURRENT_CONTAINERS) {
+      // At capacity — add to waiting queue so drain fires when a slot opens
+      if (!this.waitingGroups.includes(groupJid)) {
+        this.waitingGroups.push(groupJid);
+      }
+      return;
+    }
+    this.drainGroup(groupJid);
+  }
+
   private drainGroup(groupJid: string): void {
     if (this.shuttingDown) return;
 
     const state = this.getGroup(groupJid);
 
-    // Tasks first (they won't be re-discovered from SQLite like messages)
+    // Drain priority: (1) messages, (2) suspended tasks, (3) scheduled tasks
+    if (state.pendingMessages) {
+      this.runForGroup(groupJid, 'drain').catch((err) =>
+        logger.error(
+          { groupJid, err },
+          'Unhandled error in runForGroup (drain)',
+        ),
+      );
+      return;
+    }
+
+    // Suspended task resume — higher priority than scheduled tasks
+    if (state.suspendedTaskId && this.resumeSuspendedFn) {
+      const taskId = state.suspendedTaskId;
+      const resumeFn = this.resumeSuspendedFn;
+      this.runTask(groupJid, {
+        id: `resume-${taskId}`,
+        groupJid,
+        fn: () => resumeFn(groupJid),
+      }).catch((err) =>
+        logger.error(
+          { groupJid, taskId, err },
+          'Unhandled error in resume suspended task',
+        ),
+      );
+      return;
+    }
+
+    // Then remaining pending tasks (scheduled)
     if (state.pendingTasks.length > 0) {
       const task = state.pendingTasks.shift()!;
       this.runTask(groupJid, task).catch((err) =>
         logger.error(
           { groupJid, taskId: task.id, err },
           'Unhandled error in runTask (drain)',
-        ),
-      );
-      return;
-    }
-
-    // Then pending messages
-    if (state.pendingMessages) {
-      this.runForGroup(groupJid, 'drain').catch((err) =>
-        logger.error(
-          { groupJid, err },
-          'Unhandled error in runForGroup (drain)',
         ),
       );
       return;
@@ -323,20 +450,33 @@ export class GroupQueue {
       const nextJid = this.waitingGroups.shift()!;
       const state = this.getGroup(nextJid);
 
-      // Prioritize tasks over messages
-      if (state.pendingTasks.length > 0) {
+      // Same priority as drainGroup: messages > suspended > scheduled
+      if (state.pendingMessages) {
+        this.runForGroup(nextJid, 'drain').catch((err) =>
+          logger.error(
+            { groupJid: nextJid, err },
+            'Unhandled error in runForGroup (waiting)',
+          ),
+        );
+      } else if (state.suspendedTaskId && this.resumeSuspendedFn) {
+        const taskId = state.suspendedTaskId;
+        const resumeFn = this.resumeSuspendedFn;
+        this.runTask(nextJid, {
+          id: `resume-${taskId}`,
+          groupJid: nextJid,
+          fn: () => resumeFn(nextJid),
+        }).catch((err) =>
+          logger.error(
+            { groupJid: nextJid, taskId, err },
+            'Unhandled error in resume suspended task (waiting)',
+          ),
+        );
+      } else if (state.pendingTasks.length > 0) {
         const task = state.pendingTasks.shift()!;
         this.runTask(nextJid, task).catch((err) =>
           logger.error(
             { groupJid: nextJid, taskId: task.id, err },
             'Unhandled error in runTask (waiting)',
-          ),
-        );
-      } else if (state.pendingMessages) {
-        this.runForGroup(nextJid, 'drain').catch((err) =>
-          logger.error(
-            { groupJid: nextJid, err },
-            'Unhandled error in runForGroup (waiting)',
           ),
         );
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import {
   ASSISTANT_NAME,
   CREDENTIAL_PROXY_PORT,
   IDLE_TIMEOUT,
+  INTERRUPT_HARD_KILL_DELAY,
   POLL_INTERVAL,
   TIMEZONE,
   TRIGGER_PATTERN,
@@ -27,14 +28,18 @@ import {
   PROXY_BIND_HOST,
 } from './container-runtime.js';
 import {
+  clearSuspendedTask,
   getAllChats,
   getAllRegisteredGroups,
   getAllSessions,
+  getAllSuspendedTasks,
   getAllTasks,
   getMessagesSince,
   getNewMessages,
   getRegisteredGroup,
   getRouterState,
+  getSuspendedTask,
+  getTaskById,
   initDatabase,
   setRegisteredGroup,
   setRouterState,
@@ -57,7 +62,11 @@ import {
   loadSenderAllowlist,
   shouldDropMessage,
 } from './sender-allowlist.js';
-import { startSchedulerLoop } from './task-scheduler.js';
+import {
+  resumeSuspendedTask,
+  startSchedulerLoop,
+} from './task-scheduler.js';
+import type { SchedulerDependencies } from './task-scheduler.js';
 import { Channel, NewMessage, RegisteredGroup } from './types.js';
 import { logger } from './logger.js';
 
@@ -409,6 +418,41 @@ async function startMessageLoop(): Promise<void> {
             if (!hasTrigger) continue;
           }
 
+          // Suspend task container for user message — instant responsiveness.
+          if (queue.isTaskContainer(chatJid)) {
+            if (queue.isIdleWaiting(chatJid)) {
+              // Task already finished its work and is idle-waiting for the
+              // close timer. Close it immediately (no suspend needed —
+              // next_run advances normally) and queue the message.
+              logger.info(
+                { chatJid },
+                'Closing idle task container for user message',
+              );
+              queue.closeStdin(chatJid);
+            } else {
+              // Task is actively working — suspend it
+              logger.info(
+                { chatJid },
+                'Suspending task container for user message',
+              );
+              queue.interruptAgent(chatJid);
+              if (!queue.getInterruptCallback(chatJid)) {
+                const hardKillTimer = setTimeout(() => {
+                  logger.warn({ chatJid }, 'Task suspend hard-kill timer fired');
+                  queue.hardKill(chatJid);
+                  queue.setInterruptCallback(chatJid, null);
+                }, INTERRUPT_HARD_KILL_DELAY);
+                queue.setInterruptCallback(chatJid, () =>
+                  clearTimeout(hardKillTimer),
+                );
+              }
+            }
+            // Enqueue IMMEDIATELY so pendingMessages is set before the task
+            // container exits and drainGroup runs.
+            queue.enqueueMessageCheck(chatJid);
+            continue;
+          }
+
           // Pull all messages since lastAgentTimestamp so non-trigger
           // context that accumulated between triggers is included.
           const allPending = getMessagesSince(
@@ -462,6 +506,42 @@ function recoverPendingMessages(): void {
       );
       queue.enqueueMessageCheck(chatJid);
     }
+  }
+}
+
+function recoverSuspendedTasks(schedulerDeps: SchedulerDependencies): void {
+  const allSuspended = getAllSuspendedTasks();
+  for (const st of allSuspended) {
+    const task = getTaskById(st.task_id);
+    if (!task || task.status !== 'suspended') {
+      clearSuspendedTask(st.task_id);
+      logger.info(
+        { taskId: st.task_id, status: task?.status },
+        'Recovery: discarded stale suspended task',
+      );
+      continue;
+    }
+    // Set suspendedTaskId and trigger a drain. We use triggerDrain()
+    // instead of enqueueTask() to avoid creating a concrete pending task
+    // that would duplicate with the drain-synthesized resume job.
+    // Find the chatJid for this group folder
+    const chatJid = Object.entries(registeredGroups).find(
+      ([, g]) => g.folder === st.group_folder,
+    )?.[0];
+    if (!chatJid) {
+      clearSuspendedTask(st.task_id);
+      logger.warn(
+        { taskId: st.task_id, groupFolder: st.group_folder },
+        'Recovery: no registered group for suspended task',
+      );
+      continue;
+    }
+    queue.setSuspendedTaskId(chatJid, st.task_id);
+    queue.triggerDrain(chatJid);
+    logger.info(
+      { groupFolder: st.group_folder, taskId: st.task_id },
+      'Recovery: marked suspended task for resume',
+    );
   }
 }
 
@@ -598,7 +678,7 @@ async function main(): Promise<void> {
   }
 
   // Start subsystems (independently of connection handler)
-  startSchedulerLoop({
+  const schedulerDeps: SchedulerDependencies = {
     registeredGroups: () => registeredGroups,
     getSessions: () => sessions,
     queue,
@@ -613,7 +693,25 @@ async function main(): Promise<void> {
       const text = formatOutbound(rawText);
       if (text) await channel.sendMessage(jid, text);
     },
+  };
+  startSchedulerLoop(schedulerDeps);
+
+  // Wire suspended task resume into drain callback
+  queue.setResumeSuspendedFn(async (groupJid: string) => {
+    const groupFolder = registeredGroups[groupJid]?.folder;
+    if (!groupFolder) {
+      queue.setSuspendedTaskId(groupJid, null);
+      return;
+    }
+    const suspended = getSuspendedTask(groupFolder);
+    if (!suspended) {
+      queue.setSuspendedTaskId(groupJid, null);
+      return;
+    }
+    await resumeSuspendedTask(suspended, schedulerDeps);
   });
+
+  recoverSuspendedTasks(schedulerDeps);
   startIpcWatcher({
     sendMessage: (jid, text) => {
       const channel = findChannel(channels, jid);

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -9,17 +9,20 @@ import {
   writeTasksSnapshot,
 } from './container-runner.js';
 import {
+  clearSuspendedTask,
   getAllTasks,
   getDueTasks,
   getTaskById,
   logTaskRun,
+  saveSuspendedTask,
+  setTaskStatus,
   updateTask,
   updateTaskAfterRun,
 } from './db.js';
 import { GroupQueue } from './group-queue.js';
 import { resolveGroupFolderPath } from './group-folder.js';
 import { logger } from './logger.js';
-import { RegisteredGroup, ScheduledTask } from './types.js';
+import { RegisteredGroup, ScheduledTask, SuspendedTask } from './types.js';
 
 /**
  * Compute the next run time for a recurring task, anchored to the
@@ -75,9 +78,15 @@ export interface SchedulerDependencies {
   sendMessage: (jid: string, text: string) => Promise<void>;
 }
 
+interface ResumeParams {
+  sessionId: string;
+  resumeAt: string;
+}
+
 async function runTask(
   task: ScheduledTask,
   deps: SchedulerDependencies,
+  resume?: ResumeParams,
 ): Promise<void> {
   const startTime = Date.now();
   let groupDir: string;
@@ -104,7 +113,7 @@ async function runTask(
   fs.mkdirSync(groupDir, { recursive: true });
 
   logger.info(
-    { taskId: task.id, group: task.group_folder },
+    { taskId: task.id, group: task.group_folder, resuming: !!resume },
     'Running scheduled task',
   );
 
@@ -148,11 +157,18 @@ async function runTask(
 
   let result: string | null = null;
   let error: string | null = null;
+  let wasInterrupted = false;
+  let lastSessionId: string | undefined;
+  let lastAssistantUuid: string | undefined;
 
   // For group context mode, use the group's current session
+  // Resume params override session selection
   const sessions = deps.getSessions();
-  const sessionId =
-    task.context_mode === 'group' ? sessions[task.group_folder] : undefined;
+  const sessionId = resume
+    ? resume.sessionId
+    : task.context_mode === 'group'
+      ? sessions[task.group_folder]
+      : undefined;
 
   // After the task produces a result, close the container promptly.
   // Tasks are single-turn — no need to wait IDLE_TIMEOUT (30 min) for the
@@ -174,6 +190,7 @@ async function runTask(
       {
         prompt: task.prompt,
         sessionId,
+        resumeAt: resume?.resumeAt,
         groupFolder: task.group_folder,
         chatJid: task.chat_jid,
         isMain,
@@ -183,6 +200,36 @@ async function runTask(
       (proc, containerName) =>
         deps.onProcess(task.chat_jid, proc, containerName, task.group_folder),
       async (streamedOutput: ContainerOutput) => {
+        // Track session and resume state for suspend/resume
+        if (streamedOutput.newSessionId) {
+          lastSessionId = streamedOutput.newSessionId;
+        }
+        if (streamedOutput.lastAssistantUuid) {
+          lastAssistantUuid = streamedOutput.lastAssistantUuid;
+        }
+
+        if (streamedOutput.status === 'interrupted') {
+          wasInterrupted = true;
+          // Save suspend state if we have the necessary info
+          if (lastSessionId && lastAssistantUuid) {
+            saveSuspendedTask({
+              group_folder: task.group_folder,
+              task_id: task.id,
+              session_id: lastSessionId,
+              resume_at: lastAssistantUuid,
+              suspended_at: new Date().toISOString(),
+            });
+            setTaskStatus(task.id, 'suspended');
+            deps.queue.setSuspendedTaskId(task.chat_jid, task.id);
+            logger.info(
+              { taskId: task.id, groupFolder: task.group_folder, sessionId: lastSessionId },
+              'Task suspended for user message',
+            );
+          }
+          scheduleClose();
+          return;
+        }
+
         if (streamedOutput.result) {
           result = streamedOutput.result;
           // Forward result to user (sendMessage handles formatting)
@@ -200,6 +247,54 @@ async function runTask(
     );
 
     if (closeTimer) clearTimeout(closeTimer);
+
+    // Capture session info from final output (may not have reached streaming callback)
+    if (output.newSessionId) lastSessionId = output.newSessionId;
+    if (output.lastAssistantUuid) lastAssistantUuid = output.lastAssistantUuid;
+
+    // Check final output for interrupted status too.
+    // Also check if the abort error was caught (agent-runner exits cleanly
+    // after abort but streaming callback may not have seen 'interrupted').
+    if (
+      !wasInterrupted &&
+      (output.status === 'interrupted' || output.status === 'error')
+    ) {
+      const isAbortError =
+        output.status === 'interrupted' ||
+        (output.error?.includes('aborted') ?? false);
+      if (isAbortError) {
+        wasInterrupted = true;
+      }
+    }
+
+    // Save suspend state if interrupted and we have session info
+    if (wasInterrupted && lastSessionId && lastAssistantUuid) {
+      // Only save if not already saved by streaming callback
+      if (!deps.queue.getSuspendedTaskId(task.chat_jid)) {
+        saveSuspendedTask({
+          group_folder: task.group_folder,
+          task_id: task.id,
+          session_id: lastSessionId,
+          resume_at: lastAssistantUuid,
+          suspended_at: new Date().toISOString(),
+        });
+        setTaskStatus(task.id, 'suspended');
+        deps.queue.setSuspendedTaskId(task.chat_jid, task.id);
+        logger.info(
+          { taskId: task.id, groupFolder: task.group_folder, sessionId: lastSessionId },
+          'Task suspended for user message (from final output)',
+        );
+      }
+    }
+
+    if (wasInterrupted) {
+      // Don't advance next_run or log as completed — task will resume
+      logger.info(
+        { taskId: task.id, durationMs: Date.now() - startTime },
+        'Task interrupted (will resume)',
+      );
+      return;
+    }
 
     if (output.status === 'error') {
       error = output.error || 'Unknown error';
@@ -274,6 +369,46 @@ export function startSchedulerLoop(deps: SchedulerDependencies): void {
   };
 
   loop();
+}
+
+/**
+ * Resume a previously suspended task.
+ * Validates that the task still exists and is in suspended state.
+ */
+export async function resumeSuspendedTask(
+  suspended: SuspendedTask,
+  deps: SchedulerDependencies,
+): Promise<void> {
+  const task = getTaskById(suspended.task_id);
+  if (!task || task.status !== 'suspended') {
+    logger.info(
+      { taskId: suspended.task_id, status: task?.status },
+      'Suspended task no longer valid, discarding',
+    );
+    clearSuspendedTask(suspended.task_id);
+    deps.queue.setSuspendedTaskId(suspended.group_folder, null);
+    return;
+  }
+
+  setTaskStatus(task.id, 'resuming');
+  logger.info(
+    { taskId: task.id, groupFolder: suspended.group_folder },
+    'Resuming suspended task',
+  );
+
+  await runTask(task, deps, {
+    sessionId: suspended.session_id,
+    resumeAt: suspended.resume_at,
+  });
+
+  // Only clear suspend state if the task wasn't re-suspended during resume.
+  // If runTask was interrupted again, it already saved new suspend state —
+  // clearing here would lose it.
+  const currentTask = getTaskById(suspended.task_id);
+  if (currentTask?.status !== 'suspended') {
+    clearSuspendedTask(suspended.task_id);
+    deps.queue.setSuspendedTaskId(suspended.group_folder, null);
+  }
 }
 
 /** @internal - for tests only. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,8 +64,16 @@ export interface ScheduledTask {
   next_run: string | null;
   last_run: string | null;
   last_result: string | null;
-  status: 'active' | 'paused' | 'completed';
+  status: 'active' | 'paused' | 'completed' | 'suspended' | 'resuming';
   created_at: string;
+}
+
+export interface SuspendedTask {
+  group_folder: string;
+  task_id: string;
+  session_id: string;
+  resume_at: string; // lastAssistantUuid
+  suspended_at: string;
 }
 
 export interface TaskRunLog {


### PR DESCRIPTION
## Problem

When a scheduled task is running and the user sends a message, the user has to wait until the task finishes — which can take minutes. This is the biggest UX gap in NanoClaw: a personal assistant that can't respond to you because it's busy with a background job.

## Solution

Interrupt the running task, respond to the user, then resume the task from where it left off.

### How it works

1. **User sends message during task** → host writes `_interrupt` sentinel to IPC directory
2. **Agent detects interrupt** → aborts gracefully via `AbortController`, emits `status: 'interrupted'` with session ID and resume position (`lastAssistantUuid`)
3. **Host saves suspend state** → `suspended_tasks` table (one per user, enforced by unique index)
4. **User message is processed** → normal message flow
5. **After user conversation ends** → `drainGroup()` picks up suspended task and resumes via `resumeSuspendedTask()`
6. **Task resumes** → same session, same resume position, continues from where it left off

### Key design decisions

- **One suspended task per user** — if a second task needs to suspend, it replaces the first (UNIQUE index on user)
- **Hard-kill timer** (5s default) — if the agent doesn't exit gracefully after interrupt, the container is killed
- **Drain priority** — messages > suspended tasks > scheduled tasks (user always wins)
- **Startup recovery** — `recoverSuspendedTasks()` on startup resumes tasks from prior crashes
- **Idle-warm shortcut** — if the task container is idle-waiting (finished work, waiting for close timer), skip the interrupt and just close it immediately

### Files changed

| File | What |
|------|------|
| `src/types.ts` | `SuspendedTask` interface, expanded task status union |
| `src/db.ts` | `suspended_tasks` table + CRUD functions |
| `src/config.ts` | `INTERRUPT_HARD_KILL_DELAY` env var |
| `src/group-queue.ts` | Suspend state tracking, interrupt methods, drain priority |
| `src/container-runner.ts` | `'interrupted'` status, `lastAssistantUuid`, `resumeAt` in I/O types |
| `container/agent-runner/src/index.ts` | `_interrupt` sentinel, `AbortController` integration, abort error handling |
| `src/task-scheduler.ts` | `resumeSuspendedTask()`, interrupt detection in `runTask()` |
| `src/index.ts` | Message-time task suspension, startup recovery |

## Testing

Battle-tested on a production instance with 10+ scheduled tasks per day. Key scenarios verified:
- User message during active task → task suspends, user gets response, task resumes
- User message during idle-warm task → task closes, user gets response
- NanoClaw restart with suspended task → task resumes on startup
- Rapid user messages during task → only one suspend, no duplicates
- Task completes normally (no interrupt) → no suspend state created

## Depends on

- #1219 (agent-runner abort handling) — this PR includes that fix as well for completeness