### PR TITLE
security: fix command injection, read-only agent src, proxy bind, remote-control auth, min task interval

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -2,7 +2,7 @@
  * Container Runner for NanoClaw
  * Spawns agent execution in containers and handles IPC
  */
-import { ChildProcess, exec, spawn } from 'child_process';
+import { ChildProcess, execFile, spawn } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 
@@ -23,7 +23,6 @@ import {
   CONTAINER_RUNTIME_BIN,
   hostGatewayArgs,
   readonlyMountArgs,
-  stopContainer,
 } from './container-runtime.js';
 import { detectAuthMode } from './credential-proxy.js';
 import { validateAdditionalMounts } from './mount-security.js';
@@ -175,29 +174,22 @@ function buildVolumeMounts(
     readonly: false,
   });
 
-  // Copy agent-runner source into a per-group writable location so agents
-  // can customize it (add tools, change behavior) without affecting other
-  // groups. Recompiled on container startup via entrypoint.sh.
+  // Mount agent-runner source read-only. Mounting it writable would allow a
+  // prompt-injected agent to persist malicious code that survives container
+  // restarts (the entrypoint recompiles /app/src on every startup).
   const agentRunnerSrc = path.join(
     projectRoot,
     'container',
     'agent-runner',
     'src',
   );
-  const groupAgentRunnerDir = path.join(
-    DATA_DIR,
-    'sessions',
-    group.folder,
-    'agent-runner-src',
-  );
-  if (!fs.existsSync(groupAgentRunnerDir) && fs.existsSync(agentRunnerSrc)) {
-    fs.cpSync(agentRunnerSrc, groupAgentRunnerDir, { recursive: true });
+  if (fs.existsSync(agentRunnerSrc)) {
+    mounts.push({
+      hostPath: agentRunnerSrc,
+      containerPath: '/app/src',
+      readonly: true,
+    });
   }
-  mounts.push({
-    hostPath: groupAgentRunnerDir,
-    containerPath: '/app/src',
-    readonly: false,
-  });
 
   // Additional mounts validated against external allowlist (tamper-proof from containers)
   if (group.containerConfig?.additionalMounts) {
@@ -413,7 +405,7 @@ export async function runContainerAgent(
         { group: group.name, containerName },
         'Container timeout, stopping gracefully',
       );
-      exec(stopContainer(containerName), { timeout: 15000 }, (err) => {
+      execFile(CONTAINER_RUNTIME_BIN, ['stop', containerName], { timeout: 15000 }, (err) => {
         if (err) {
           logger.warn(
             { group: group.name, containerName, err },

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -2,7 +2,7 @@
  * Container runtime abstraction for NanoClaw.
  * All runtime-specific logic lives here so swapping runtimes means changing one file.
  */
-import { execSync } from 'child_process';
+import { execSync, spawnSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 
@@ -37,7 +37,14 @@ function detectProxyBindHost(): string {
     const ipv4 = docker0.find((a) => a.family === 'IPv4');
     if (ipv4) return ipv4.address;
   }
-  return '0.0.0.0';
+  // docker0 not found — fall back to loopback. Containers may not reach the
+  // proxy, but binding to 0.0.0.0 would expose the credential proxy to the
+  // local network. Set CREDENTIAL_PROXY_HOST explicitly if needed.
+  logger.warn(
+    'docker0 interface not found; credential proxy binding to 127.0.0.1. ' +
+    'Set CREDENTIAL_PROXY_HOST to the docker bridge IP if containers cannot reach the proxy.',
+  );
+  return '127.0.0.1';
 }
 
 /** CLI args needed for the container to resolve the host gateway. */
@@ -110,7 +117,7 @@ export function cleanupOrphans(): void {
     const orphans = output.trim().split('\n').filter(Boolean);
     for (const name of orphans) {
       try {
-        execSync(stopContainer(name), { stdio: 'pipe' });
+        spawnSync(CONTAINER_RUNTIME_BIN, ['stop', name], { stdio: 'pipe' });
       } catch {
         /* already stopped */
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -509,6 +509,16 @@ async function main(): Promise<void> {
       return;
     }
 
+    // Only the account owner (messages sent from the device itself) may start
+    // remote control. Any other member of the main group is denied.
+    if (!msg.is_from_me) {
+      logger.warn(
+        { chatJid, sender: msg.sender },
+        'Remote control rejected: sender is not the account owner',
+      );
+      return;
+    }
+
     const channel = findChannel(channels, chatJid);
     if (!channel) return;
 

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -228,10 +228,11 @@ export async function processTaskIpc(
           }
         } else if (scheduleType === 'interval') {
           const ms = parseInt(data.schedule_value, 10);
-          if (isNaN(ms) || ms <= 0) {
+          const MIN_INTERVAL_MS = 60_000;
+          if (isNaN(ms) || ms < MIN_INTERVAL_MS) {
             logger.warn(
-              { scheduleValue: data.schedule_value },
-              'Invalid interval',
+              { scheduleValue: data.schedule_value, minMs: MIN_INTERVAL_MS },
+              'Invalid interval: must be at least 60000ms (1 minute)',
             );
             break;
           }
@@ -382,8 +383,15 @@ export async function processTaskIpc(
             }
           } else if (updatedTask.schedule_type === 'interval') {
             const ms = parseInt(updatedTask.schedule_value, 10);
-            if (!isNaN(ms) && ms > 0) {
+            const MIN_INTERVAL_MS = 60_000;
+            if (!isNaN(ms) && ms >= MIN_INTERVAL_MS) {
               updates.next_run = new Date(Date.now() + ms).toISOString();
+            } else {
+              logger.warn(
+                { taskId: data.taskId, value: updatedTask.schedule_value, minMs: MIN_INTERVAL_MS },
+                'Invalid interval in task update: must be at least 60000ms (1 minute)',
+              );
+              break;
             }
           }
         }


### PR DESCRIPTION
## Summary

Five security fixes found during a local audit:

- **Command injection** (`container-runtime.ts`, `container-runner.ts`): `exec(stopContainer())` and `execSync(stopContainer())` passed container names through a shell string. Replaced with `execFile`/`spawnSync` with explicit arg arrays — no shell involved.

- **Persistent code injection via writable `/app/src`** (`container-runner.ts`): `/app/src` was mounted writable, so a prompt-injected agent could write code that `entrypoint.sh` recompiles and executes on next container start, surviving restarts. Now mounted read-only. The per-group copy is dropped; all groups share the canonical source.

- **Credential proxy exposed on `0.0.0.0`** (`container-runtime.ts`): When `docker0` wasn't found on Linux, the proxy fell back to `0.0.0.0`, making it reachable from the LAN. Now falls back to `127.0.0.1` with a logged warning. Users can override with `CREDENTIAL_PROXY_HOST` if their setup requires a different bridge IP.

- **Remote control open to all main-group members** (`index.ts`): `/remote-control` only checked `group.isMain`, not who the sender was. Any member of the main group could hijack a remote control session. Now requires `msg.is_from_me` — only messages from the account owner are accepted.

- **Unbounded task interval** (`ipc.ts`): Interval tasks had no minimum, so an agent or attacker could create a 1ms-interval task causing continuous container spawning and unbounded API spend. Minimum enforced at 60,000ms (1 minute) for both `schedule_task` and `update_task`.

## Test plan

- [ ] Confirm `npm run build` passes with no TypeScript errors
- [ ] Verify containers still start and stop correctly (timeout path uses `execFile`)
- [ ] On Linux without `docker0`, confirm proxy logs the warning and binds to `127.0.0.1`
- [ ] Confirm `/remote-control` sent by another group member is silently rejected
- [ ] Confirm scheduling a task with interval `<60000` is rejected with a log warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)