### PR TITLE
fix(oauth): read token on every request to prevent overnight 401 errors

### DIFF
--- a/src/credential-proxy.test.ts
+++ b/src/credential-proxy.test.ts
@@ -1,17 +1,29 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import http from 'http';
 import type { AddressInfo } from 'net';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
 
 const mockEnv: Record<string, string> = {};
 vi.mock('./env.js', () => ({
-  readEnvFile: vi.fn(() => ({ ...mockEnv })),
+  readEnvFile: vi.fn((keys: string[]) => {
+    const result: Record<string, string> = {};
+    for (const key of keys) {
+      if (mockEnv[key]) result[key] = mockEnv[key];
+    }
+    return result;
+  }),
 }));
 
 vi.mock('./logger.js', () => ({
   logger: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
 }));
 
-import { startCredentialProxy } from './credential-proxy.js';
+import {
+  startCredentialProxy,
+  getFreshOAuthToken,
+} from './credential-proxy.js';
 
 function makeRequest(
   port: number,
@@ -115,6 +127,7 @@ describe('credential-proxy', () => {
       '{}',
     );
 
+    // getFreshOAuthToken() reads from .env since no credentials file exists
     expect(lastUpstreamHeaders['authorization']).toBe(
       'Bearer real-oauth-token',
     );
@@ -188,5 +201,146 @@ describe('credential-proxy', () => {
 
     expect(res.statusCode).toBe(502);
     expect(res.body).toBe('Bad Gateway');
+  });
+
+  it('OAuth mode picks up updated token between requests', async () => {
+    // Start with one token
+    proxyPort = await startProxy({
+      CLAUDE_CODE_OAUTH_TOKEN: 'token-v1',
+    });
+
+    await makeRequest(
+      proxyPort,
+      {
+        method: 'POST',
+        path: '/api/oauth/claude_cli/create_api_key',
+        headers: {
+          'content-type': 'application/json',
+          authorization: 'Bearer placeholder',
+        },
+      },
+      '{}',
+    );
+    expect(lastUpstreamHeaders['authorization']).toBe('Bearer token-v1');
+
+    // Simulate token refresh: update .env value
+    mockEnv['CLAUDE_CODE_OAUTH_TOKEN'] = 'token-v2';
+
+    await makeRequest(
+      proxyPort,
+      {
+        method: 'POST',
+        path: '/api/oauth/claude_cli/create_api_key',
+        headers: {
+          'content-type': 'application/json',
+          authorization: 'Bearer placeholder',
+        },
+      },
+      '{}',
+    );
+    // The proxy should have picked up the new token
+    expect(lastUpstreamHeaders['authorization']).toBe('Bearer token-v2');
+  });
+});
+
+describe('getFreshOAuthToken', () => {
+  const credDir = path.join(os.homedir(), '.claude');
+  const credFile = path.join(credDir, '.credentials.json');
+  let originalCredContent: string | null = null;
+
+  beforeEach(() => {
+    // Save original file if it exists
+    try {
+      originalCredContent = fs.readFileSync(credFile, 'utf-8');
+    } catch {
+      originalCredContent = null;
+    }
+    // Clear mock env
+    for (const key of Object.keys(mockEnv)) delete mockEnv[key];
+  });
+
+  afterEach(() => {
+    // Restore original file
+    if (originalCredContent !== null) {
+      fs.writeFileSync(credFile, originalCredContent);
+    } else {
+      try {
+        fs.unlinkSync(credFile);
+      } catch {
+        // File didn't exist, nothing to clean up
+      }
+    }
+  });
+
+  it('reads token from ~/.claude/.credentials.json when valid', () => {
+    fs.mkdirSync(credDir, { recursive: true });
+    const futureDate = new Date(Date.now() + 3600_000).toISOString();
+    fs.writeFileSync(
+      credFile,
+      JSON.stringify({
+        accessToken: 'cred-file-token',
+        refreshToken: 'refresh-xxx',
+        expiresAt: futureDate,
+      }),
+    );
+
+    const token = getFreshOAuthToken();
+    expect(token).toBe('cred-file-token');
+  });
+
+  it('falls back to .env when credentials file token is expired', () => {
+    fs.mkdirSync(credDir, { recursive: true });
+    const pastDate = new Date(Date.now() - 3600_000).toISOString();
+    fs.writeFileSync(
+      credFile,
+      JSON.stringify({
+        accessToken: 'expired-token',
+        refreshToken: 'refresh-xxx',
+        expiresAt: pastDate,
+      }),
+    );
+    mockEnv['CLAUDE_CODE_OAUTH_TOKEN'] = 'env-fallback-token';
+
+    const token = getFreshOAuthToken();
+    expect(token).toBe('env-fallback-token');
+  });
+
+  it('uses token optimistically when expiresAt is absent', () => {
+    fs.mkdirSync(credDir, { recursive: true });
+    fs.writeFileSync(
+      credFile,
+      JSON.stringify({
+        accessToken: 'no-expiry-token',
+        refreshToken: 'refresh-xxx',
+      }),
+    );
+
+    const token = getFreshOAuthToken();
+    expect(token).toBe('no-expiry-token');
+  });
+
+  it('falls back to .env when credentials file does not exist', () => {
+    // Ensure credentials file does not exist
+    try {
+      fs.unlinkSync(credFile);
+    } catch {
+      // Already absent
+    }
+    mockEnv['ANTHROPIC_AUTH_TOKEN'] = 'env-auth-token';
+
+    const token = getFreshOAuthToken();
+    expect(token).toBe('env-auth-token');
+  });
+
+  it('returns undefined when no token source is available', () => {
+    try {
+      fs.unlinkSync(credFile);
+    } catch {
+      // Already absent
+    }
+    // No mock env set
+
+    const token = getFreshOAuthToken();
+    expect(token).toBeUndefined();
   });
 });

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -9,10 +9,20 @@
  *             API key via /api/oauth/claude_cli/create_api_key.
  *             Proxy injects real OAuth token on that exchange request;
  *             subsequent requests carry the temp key which is valid as-is.
+ *
+ * OAuth token refresh (fixes #730):
+ *   When the proxy is in OAuth mode it now reads the token **on every
+ *   request** instead of caching it once at startup.  Resolution order:
+ *     1. ~/.claude/.credentials.json  (auto-refreshed by Claude CLI)
+ *     2. .env  CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_AUTH_TOKEN
+ *   This prevents overnight 401 errors caused by expired tokens.
  */
 import { createServer, Server } from 'http';
 import { request as httpsRequest } from 'https';
 import { request as httpRequest, RequestOptions } from 'http';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
 
 import { readEnvFile } from './env.js';
 import { logger } from './logger.js';
@@ -21,6 +31,63 @@ export type AuthMode = 'api-key' | 'oauth';
 
 export interface ProxyConfig {
   authMode: AuthMode;
+}
+
+/**
+ * Read the freshest OAuth token available on the host.
+ *
+ * Resolution order:
+ *   1. ~/.claude/.credentials.json  – written & auto-refreshed by the
+ *      Claude Code CLI.  The file contains `{ "accessToken": "…",
+ *      "refreshToken": "…", "expiresAt": "…" }`.
+ *   2. .env  CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_AUTH_TOKEN – static
+ *      fallback for setups that don't use the CLI on the host.
+ *
+ * Exported for testing.
+ */
+export function getFreshOAuthToken(): string | undefined {
+  // 1. Try ~/.claude/.credentials.json (auto-refreshed by Claude CLI)
+  const credPath = path.join(os.homedir(), '.claude', '.credentials.json');
+  try {
+    const raw = fs.readFileSync(credPath, 'utf-8');
+    const creds = JSON.parse(raw) as {
+      accessToken?: string;
+      expiresAt?: string;
+    };
+    if (creds.accessToken) {
+      // If expiresAt is present and the token is still valid (or will
+      // be valid for at least 60 s), use it.  If parsing fails or the
+      // field is absent, use the token optimistically — the CLI keeps
+      // it refreshed in the background.
+      if (creds.expiresAt) {
+        const expiresMs = new Date(creds.expiresAt).getTime();
+        if (expiresMs > Date.now() + 60_000) {
+          logger.debug('Using OAuth token from ~/.claude/.credentials.json');
+          return creds.accessToken;
+        }
+        // Token expired — fall through to .env
+        logger.warn(
+          'OAuth token in ~/.claude/.credentials.json is expired, falling back to .env',
+        );
+      } else {
+        // No expiresAt field — use optimistically
+        logger.debug(
+          'Using OAuth token from ~/.claude/.credentials.json (no expiresAt)',
+        );
+        return creds.accessToken;
+      }
+    }
+  } catch {
+    // File does not exist or is unreadable — expected when the CLI is
+    // not installed on the host.
+  }
+
+  // 2. Fallback: re-read .env on every call so manual edits are picked up
+  const secrets = readEnvFile([
+    'CLAUDE_CODE_OAUTH_TOKEN',
+    'ANTHROPIC_AUTH_TOKEN',
+  ]);
+  return secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.ANTHROPIC_AUTH_TOKEN;
 }
 
 export function startCredentialProxy(
@@ -35,8 +102,6 @@ export function startCredentialProxy(
   ]);
 
   const authMode: AuthMode = secrets.ANTHROPIC_API_KEY ? 'api-key' : 'oauth';
-  const oauthToken =
-    secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.ANTHROPIC_AUTH_TOKEN;
 
   const upstreamUrl = new URL(
     secrets.ANTHROPIC_BASE_URL || 'https://api.anthropic.com',
@@ -67,14 +132,17 @@ export function startCredentialProxy(
           delete headers['x-api-key'];
           headers['x-api-key'] = secrets.ANTHROPIC_API_KEY;
         } else {
-          // OAuth mode: replace placeholder Bearer token with the real one
-          // only when the container actually sends an Authorization header
-          // (exchange request + auth probes). Post-exchange requests use
-          // x-api-key only, so they pass through without token injection.
+          // OAuth mode: resolve a fresh token on every request so
+          // expired tokens are automatically replaced (#730).
           if (headers['authorization']) {
             delete headers['authorization'];
-            if (oauthToken) {
-              headers['authorization'] = `Bearer ${oauthToken}`;
+            const freshToken = getFreshOAuthToken();
+            if (freshToken) {
+              headers['authorization'] = `Bearer ${freshToken}`;
+            } else {
+              logger.warn(
+                'OAuth mode: no valid token available — request will likely fail with 401',
+              );
             }
           }
         }


### PR DESCRIPTION
## Summary

The credential proxy previously read `CLAUDE_CODE_OAUTH_TOKEN` **once at startup** and cached it for the lifetime of the process. Since Claude Code CLI OAuth tokens expire after a few hours, containers would fail with **401 every morning** — users had to manually restart nanoclaw daily.

## Problem

As reported in #730:

- `readEnvFile()` in `credential-proxy.ts` reads the `.env` file once at line 30–35 when the proxy starts
- The token is stored in a closure variable and never re-read
- Meanwhile, Claude Code CLI auto-refreshes tokens in `~/.claude/.credentials.json`
- The proxy does not know that file exists — stale token → 401

## Solution

Add a `getFreshOAuthToken()` function that resolves the freshest available OAuth token **on every request**:

### Resolution order
1. `~/.claude/.credentials.json` — written and auto-refreshed by Claude CLI. Contains `accessToken`, `refreshToken`, and `expiresAt`. Token is used if it has >60s of validity remaining.
2. `.env` `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_AUTH_TOKEN` — static fallback, re-read on every call so manual edits are picked up without restart.

### What changed
- **`credential-proxy.ts`**: Removed the cached `oauthToken` variable. In OAuth mode, the proxy now calls `getFreshOAuthToken()` per-request instead of using the startup-cached value.
- **New export**: `getFreshOAuthToken()` — reads `~/.claude/.credentials.json` with expiry check (60s buffer), falls back to `.env`.
- **`credential-proxy.test.ts`**: 6 new tests covering dynamic token refresh, credentials file reading, expiry fallback, and missing sources.

### What did NOT change
- API-key mode is completely unchanged.
- The `.env` reading logic in `env.ts` is unchanged.
- No new dependencies added.

## Tests

6 new tests added (all existing tests pass unchanged):

| Test | Description |
|------|-------------|
| `OAuth mode picks up updated token between requests` | Verifies token changes are reflected without restart |
| `reads token from ~/.claude/.credentials.json when valid` | Credentials file with future expiresAt |
| `falls back to .env when credentials file token is expired` | Expired credentials → .env fallback |
| `uses token optimistically when expiresAt is absent` | Missing expiresAt field |
| `falls back to .env when credentials file does not exist` | No credentials file → .env |
| `returns undefined when no token source is available` | No credentials file, no .env |

## Breaking Changes

None. The `getFreshOAuthToken()` export is additive. Existing behavior for API-key mode and OAuth mode is preserved — the only difference is that OAuth tokens are now always fresh.

Closes #730