### PR TITLE
refactor: replace Agent SDK with Claude Code CLI in container agent-runner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Personal Claude assistant. See [README.md](README.md) for philosophy and setup. 
 
 ## Quick Context
 
-Single Node.js process with skill-based channel system. Channels (WhatsApp, Telegram, Slack, Discord, Gmail) are skills that self-register at startup. Messages route to Claude Agent SDK running in containers (Linux VMs). Each group has isolated filesystem and memory.
+Single Node.js process with skill-based channel system. Channels (WhatsApp, Telegram, Slack, Discord, Gmail) are skills that self-register at startup. Messages route to Claude Code CLI running in containers (Linux VMs). Each group has isolated filesystem and memory.
 
 ## Key Files
 
@@ -41,6 +41,19 @@ npm run dev          # Run with hot reload
 npm run build        # Compile TypeScript
 ./container/build.sh # Rebuild agent container
 ```
+
+### Deploying container changes
+
+When `container/agent-runner/src/` is modified, the per-group source copies must be cleared so the host re-copies the latest source on next container spawn. Skipping this step causes containers to run stale code.
+
+```bash
+./container/build.sh                          # 1. Rebuild image
+rm -r data/sessions/*/agent-runner-src        # 2. Clear stale per-group source copies
+systemctl --user restart nanoclaw             # 3. Restart service (Linux)
+# launchctl kickstart -k gui/$(id -u)/com.nanoclaw  # (macOS)
+```
+
+**Why the rm step is needed:** Each group gets a writable copy of `container/agent-runner/src/` at `data/sessions/<group>/agent-runner-src/`, mounted into the container at `/app/src`. The host only copies source when this directory doesn't exist yet. Skills (e.g. `/add-gmail`) may also add custom code there per-group. Deleting forces a fresh copy from the latest source on next spawn.
 
 Service management:
 ```bash

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,5 +1,5 @@
 # NanoClaw Agent Container
-# Runs Claude Agent SDK in isolated Linux VM with browser automation
+# Runs Claude Code CLI in isolated Linux VM with browser automation
 
 FROM node:22-slim
 
@@ -55,7 +55,7 @@ RUN mkdir -p /workspace/group /workspace/global /workspace/extra /workspace/ipc/
 # Container input (prompt, group info) is passed via stdin JSON.
 # Credentials are injected by the host's credential proxy — never passed here.
 # Follow-up messages arrive via IPC files in /workspace/ipc/input/
-RUN printf '#!/bin/bash\nset -e\ncd /app && npx tsc --outDir /tmp/dist 2>&1 >&2\nln -s /app/node_modules /tmp/dist/node_modules\nchmod -R a-w /tmp/dist\ncat > /tmp/input.json\nnode /tmp/dist/index.js < /tmp/input.json\n' > /app/entrypoint.sh && chmod +x /app/entrypoint.sh
+RUN printf '#!/bin/bash\nset -e\ncd /app && npx tsc --outDir /tmp/dist 2>&1 >&2\nln -s /app/node_modules /tmp/dist/node_modules\nchmod -R a-w /tmp/dist\ncat > /tmp/input.json\nexec node /tmp/dist/index.js < /tmp/input.json\n' > /app/entrypoint.sh && chmod +x /app/entrypoint.sh
 
 # Set ownership to node user (non-root) for writable directories
 RUN chown -R node:node /workspace && chmod 777 /home/node

--- a/container/agent-runner/package-lock.json
+++ b/container/agent-runner/package-lock.json
@@ -15,7 +15,8 @@
       },
       "devDependencies": {
         "@types/node": "^22.10.7",
-        "typescript": "^5.7.3"
+        "typescript": "^5.7.3",
+        "vitest": "^4.1.0"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
@@ -39,6 +40,40 @@
       },
       "peerDependencies": {
         "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
+      "integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
+      "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@hono/node-server": {
@@ -357,6 +392,13 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.26.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
@@ -397,6 +439,348 @@
         }
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@oxc-project/runtime": {
+      "version": "0.115.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.115.0.tgz",
+      "integrity": "sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.115.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.115.0.tgz",
+      "integrity": "sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-J7Zk3kLYFsLtuH6U+F4pS2sYVzac0qkjcO5QxHS7OS7yZu2LRs+IXo+uvJ/mvpyUljDJ3LROZPoQfgBIpCMhdQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-iwtmmghy8nhfRGeNAIltcNXzD0QMNaaA5U/NyZc1Ia4bxrzFByNMDoppoC+hl7cDiUq5/1CnFthpT9n+UtfFyg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-DLFYI78SCiZr5VvdEplsVC2Vx53lnA4/Ga5C65iyldMVaErr86aiqCoNBLl92PXPfDtUYjUh+xFFor40ueNs4Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.9.tgz",
+      "integrity": "sha512-CsjTmTwd0Hri6iTw/DRMK7kOZ7FwAkrO4h8YWKoX/kcj833e4coqo2wzIFywtch/8Eb5enQ/lwLM7w6JX1W5RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.9.tgz",
+      "integrity": "sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.9.tgz",
+      "integrity": "sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.9.tgz",
+      "integrity": "sha512-rgFN6sA/dyebil3YTlL2evvi/M+ivhfnyxec7AccTpRPccno/rPoNlqybEZQBkcbZu8Hy+eqNJCqfBR8P7Pg8g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.9.tgz",
+      "integrity": "sha512-lHVNUG/8nlF1IQk1C0Ci574qKYyty2goMiPlRqkC5R+3LkXDkL5Dhx8ytbxq35m+pkHVIvIxviD+TWLdfeuadA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.9.tgz",
+      "integrity": "sha512-G0oA4+w1iY5AGi5HcDTxWsoxF509hrFIPB2rduV5aDqS9FtDg1CAfa7V34qImbjfhIcA8C+RekocJZA96EarwQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.9.tgz",
+      "integrity": "sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.7.tgz",
@@ -405,6 +789,119 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
+      "integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
+      "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
+      "integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
+      "integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.0",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
+      "integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
+      "integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
+      "integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/accepts": {
@@ -451,6 +948,16 @@
         "ajv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/body-parser": {
@@ -515,6 +1022,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
@@ -536,6 +1053,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -624,6 +1148,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -671,6 +1205,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -688,6 +1229,16 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -717,6 +1268,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -802,6 +1363,24 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -839,6 +1418,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -1025,6 +1619,267 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/luxon": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
@@ -1032,6 +1887,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/math-intrinsics": {
@@ -1095,6 +1960,25 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -1124,6 +2008,17 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -1174,6 +2069,33 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
@@ -1181,6 +2103,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/proxy-addr": {
@@ -1242,6 +2193,40 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.9.tgz",
+      "integrity": "sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.115.0",
+        "@rolldown/pluginutils": "1.0.0-rc.9"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.9",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.9",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.9",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.9",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.9",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.9",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.9",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.9",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.9",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.9",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.9"
       }
     },
     "node_modules/router": {
@@ -1410,6 +2395,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1417,6 +2426,57 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/toidentifier": {
@@ -1427,6 +2487,14 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/type-is": {
       "version": "2.0.1",
@@ -1481,6 +2549,167 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.0.tgz",
+      "integrity": "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/runtime": "0.115.0",
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.9",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.0.0-alpha.31",
+        "esbuild": "^0.27.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
+      "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.0",
+        "@vitest/mocker": "4.1.0",
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/runner": "4.1.0",
+        "@vitest/snapshot": "4.1.0",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.0",
+        "@vitest/browser-preview": "4.1.0",
+        "@vitest/browser-webdriverio": "4.1.0",
+        "@vitest/ui": "4.1.0",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -1494,6 +2723,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {

--- a/container/agent-runner/package.json
+++ b/container/agent-runner/package.json
@@ -6,16 +6,18 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.76",
     "@modelcontextprotocol/sdk": "^1.12.1",
     "cron-parser": "^5.0.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.7",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "vitest": "^4.1.0"
   }
 }

--- a/container/agent-runner/src/claude-backend.ts
+++ b/container/agent-runner/src/claude-backend.ts
@@ -1,0 +1,229 @@
+/**
+ * Claude Code CLI adapter — drop-in replacement for @anthropic-ai/claude-agent-sdk.
+ *
+ * Re-exports the query() function and associated types with the same interface
+ * as the SDK, but internally spawns the `claude` CLI binary instead.
+ *
+ * This module exists to keep index.ts structurally identical to upstream (main),
+ * isolating all SDK→CLI translation here. When upstream modifies index.ts,
+ * merges apply cleanly — only this adapter needs updating if the CLI interface changes.
+ */
+
+import path from 'path';
+import { spawn, ChildProcess } from 'child_process';
+import { fileURLToPath } from 'url';
+import {
+  type StreamJsonMessage,
+  buildCliArgs,
+  parseStreamJson,
+  writeMcpConfig,
+  writeHooksSettings,
+  AsyncChannel,
+} from './cli-utils.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// ── SDK-compatible type re-exports ───────────────────────────────────────────
+
+export type HookCallback = (
+  input: unknown,
+  toolUseId: string | undefined,
+  context: unknown,
+) => Promise<Record<string, unknown>>;
+
+export interface PreCompactHookInput {
+  transcript_path: string;
+  session_id: string;
+}
+
+/**
+ * Message yielded by query() — compatible with SDK message type casts in index.ts.
+ * All properties used in index.ts casts must be declared here (even as optional)
+ * so TypeScript's type assertion overlap check succeeds.
+ */
+export interface QueryMessage {
+  type: string;
+  subtype?: string;
+  session_id?: string;
+  uuid?: string;
+  result?: string;
+  task_id?: string;
+  status?: string;
+  summary?: string;
+  message?: { role?: string; content?: unknown };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+}
+
+// ── Internal types ───────────────────────────────────────────────────────────
+
+interface McpServerConfig {
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+}
+
+interface QueryOptions {
+  cwd: string;
+  additionalDirectories?: string[];
+  resume?: string;
+  resumeSessionAt?: string;
+  systemPrompt?: { type: string; preset: string; append: string };
+  allowedTools: string[];
+  env: Record<string, string | undefined>;
+  permissionMode: string;
+  allowDangerouslySkipPermissions: boolean;
+  settingSources: string[];
+  mcpServers: Record<string, McpServerConfig>;
+  hooks?: Record<string, Array<{ hooks: HookCallback[] }>>;
+}
+
+interface SDKUserMessage {
+  type: 'user';
+  message: { role: 'user'; content: string };
+  parent_tool_use_id: null;
+  session_id: string;
+}
+
+// ── SIGTERM handling ─────────────────────────────────────────────────────────
+
+let globalActiveChild: ChildProcess | null = null;
+
+process.on('SIGTERM', () => {
+  console.error('[claude-backend] Received SIGTERM, propagating to child CLI process');
+  globalActiveChild?.kill('SIGTERM');
+  setTimeout(() => process.exit(0), 5000);
+});
+
+// ── query() adapter ──────────────────────────────────────────────────────────
+
+/**
+ * SDK-compatible query function that spawns the Claude CLI instead of using the SDK.
+ *
+ * Accepts the same input shape as the SDK's query() and yields messages
+ * in the same format. The caller (index.ts) doesn't need to know which
+ * backend is being used.
+ *
+ * Behavioral differences from SDK:
+ * - Follow-up messages pushed to the stream during CLI execution are queued
+ *   and processed as separate CLI invocations with --resume (SDK injects them
+ *   into the active conversation mid-turn).
+ * - stream.end() kills the active CLI process (SDK winds down gracefully).
+ * - resumeSessionAt is accepted but ignored (CLI doesn't support it).
+ */
+export async function* query(input: {
+  prompt: AsyncIterable<SDKUserMessage>;
+  options: QueryOptions;
+}): AsyncGenerator<QueryMessage> {
+  const { prompt: stream, options } = input;
+
+  // ── One-time setup ──
+
+  const mcpConfigPath = writeMcpConfig(options.mcpServers);
+
+  if (options.hooks?.PreCompact) {
+    const precompactScriptPath = path.join(__dirname, 'precompact-hook.js');
+    writeHooksSettings(precompactScriptPath);
+  }
+
+  let sessionId = options.resume;
+
+  // Build environment for CLI processes (filter out undefined values)
+  const cliEnv: Record<string, string> = {};
+  for (const [k, v] of Object.entries(options.env)) {
+    if (v !== undefined) cliEnv[k] = v;
+  }
+
+  // ── Stream consumption ──
+  // Consume the prompt async iterable in background. Messages are queued
+  // and processed one-at-a-time as separate CLI invocations with --resume.
+
+  const messageQueue: string[] = [];
+  let streamDone = false;
+  let waitResolve: (() => void) | null = null;
+  let activeChild: ChildProcess | null = null;
+
+  const consumeStream = async () => {
+    for await (const userMessage of stream) {
+      const text = typeof userMessage.message.content === 'string'
+        ? userMessage.message.content
+        : String(userMessage.message.content);
+      messageQueue.push(text);
+      waitResolve?.();
+      waitResolve = null;
+    }
+    streamDone = true;
+    activeChild?.kill('SIGTERM');
+    waitResolve?.();
+    waitResolve = null;
+  };
+  consumeStream();
+
+  // Wait for first message
+  while (messageQueue.length === 0 && !streamDone) {
+    await new Promise<void>(r => { waitResolve = r; });
+  }
+
+  // ── Main loop: process queued messages as CLI invocations ──
+
+  while (messageQueue.length > 0) {
+    // Collect all pending messages into a single prompt
+    const promptText = messageQueue.splice(0).join('\n');
+
+    const args = buildCliArgs({
+      prompt: promptText,
+      sessionId,
+      mcpConfigPath,
+      systemPromptAppend: options.systemPrompt?.append,
+      additionalDirectories: options.additionalDirectories,
+      allowedTools: options.allowedTools,
+    });
+
+    const child = spawn('claude', args, {
+      cwd: options.cwd,
+      env: cliEnv,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    activeChild = child;
+    globalActiveChild = child;
+    child.stdin!.end();
+
+    // Stream messages in real-time via async channel
+    const channel = new AsyncChannel<QueryMessage>();
+    const exitPromise = parseStreamJson(child, (msg) => {
+      channel.push(msg);
+    }).then((code) => {
+      channel.close();
+      return code;
+    }).catch((err) => {
+      channel.close();
+      throw err;
+    });
+
+    for await (const msg of channel) {
+      // Track session ID internally for --resume on follow-up messages
+      if (msg.type === 'system' && msg.subtype === 'init' && msg.session_id) {
+        sessionId = msg.session_id;
+      }
+      yield msg;
+    }
+
+    const exitCode = await exitPromise;
+    activeChild = null;
+    globalActiveChild = null;
+
+    if (exitCode !== 0 && !streamDone) {
+      throw new Error(`claude CLI exited with code ${exitCode}`);
+    }
+
+    // If stream ended during CLI execution, stop
+    if (streamDone && messageQueue.length === 0) break;
+
+    // Wait for next message or stream end
+    if (messageQueue.length === 0 && !streamDone) {
+      await new Promise<void>(r => { waitResolve = r; });
+      if (streamDone && messageQueue.length === 0) break;
+    }
+  }
+}

--- a/container/agent-runner/src/cli-utils.test.ts
+++ b/container/agent-runner/src/cli-utils.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect } from 'vitest';
+import { EventEmitter, Readable } from 'stream';
+import type { ChildProcess } from 'child_process';
+import {
+  buildCliArgs,
+  parseStreamJson,
+  mapAllowedTools,
+  type StreamJsonMessage,
+} from './cli-utils.js';
+
+describe('mapAllowedTools', () => {
+  it('replaces SDK-only tools with Agent', () => {
+    const tools = mapAllowedTools([
+      'Bash', 'Read',
+      'Task', 'TaskOutput', 'TaskStop',
+      'TeamCreate', 'TeamDelete', 'SendMessage',
+    ]);
+    expect(tools).toContain('Bash');
+    expect(tools).toContain('Read');
+    expect(tools).toContain('Agent');
+    expect(tools).not.toContain('Task');
+    expect(tools).not.toContain('TaskOutput');
+    expect(tools).not.toContain('TaskStop');
+    expect(tools).not.toContain('TeamCreate');
+    expect(tools).not.toContain('TeamDelete');
+    expect(tools).not.toContain('SendMessage');
+  });
+
+  it('does not add Agent if no SDK-only tools present', () => {
+    const tools = mapAllowedTools(['Bash', 'Read', 'Write']);
+    expect(tools).toEqual(['Bash', 'Read', 'Write']);
+    expect(tools).not.toContain('Agent');
+  });
+
+  it('does not duplicate Agent if already present', () => {
+    const tools = mapAllowedTools(['Agent', 'Task', 'Bash']);
+    expect(tools.filter(t => t === 'Agent')).toHaveLength(1);
+  });
+
+  it('preserves non-SDK tools', () => {
+    const tools = mapAllowedTools([
+      'Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep',
+      'WebSearch', 'WebFetch', 'TodoWrite', 'ToolSearch',
+      'Skill', 'NotebookEdit', 'mcp__nanoclaw__*',
+    ]);
+    expect(tools).toEqual([
+      'Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep',
+      'WebSearch', 'WebFetch', 'TodoWrite', 'ToolSearch',
+      'Skill', 'NotebookEdit', 'mcp__nanoclaw__*',
+    ]);
+  });
+});
+
+describe('buildCliArgs', () => {
+  it('builds basic args for a new session', () => {
+    const args = buildCliArgs({
+      prompt: 'hello',
+      mcpConfigPath: '/tmp/mcp.json',
+      allowedTools: ['Bash', 'Read'],
+    });
+    const pIdx = args.indexOf('-p');
+    expect(pIdx).toBeGreaterThan(-1);
+    expect(args[pIdx + 1]).toBe('hello');
+    expect(args).toContain('--output-format');
+    expect(args).toContain('stream-json');
+    expect(args).toContain('--verbose');
+    expect(args).toContain('--dangerously-skip-permissions');
+    expect(args).toContain('--mcp-config');
+    expect(args).toContain('/tmp/mcp.json');
+    expect(args).toContain('--allowedTools');
+    expect(args).toContain('Bash');
+    expect(args).toContain('Read');
+  });
+
+  it('maps SDK tools to CLI tools via allowedTools', () => {
+    const args = buildCliArgs({
+      prompt: 'hello',
+      mcpConfigPath: '/tmp/mcp.json',
+      allowedTools: ['Bash', 'Task', 'TeamCreate', 'SendMessage'],
+    });
+    expect(args).toContain('Agent');
+    expect(args).not.toContain('Task');
+    expect(args).not.toContain('TeamCreate');
+    expect(args).not.toContain('SendMessage');
+  });
+
+  it('includes --resume when sessionId is provided', () => {
+    const args = buildCliArgs({
+      prompt: 'hello',
+      sessionId: 'session-123',
+      mcpConfigPath: '/tmp/mcp.json',
+      allowedTools: [],
+    });
+    const resumeIdx = args.indexOf('--resume');
+    expect(resumeIdx).toBeGreaterThan(-1);
+    expect(args[resumeIdx + 1]).toBe('session-123');
+  });
+
+  it('does not include --resume when sessionId is undefined', () => {
+    const args = buildCliArgs({
+      prompt: 'hello',
+      mcpConfigPath: '/tmp/mcp.json',
+      allowedTools: [],
+    });
+    expect(args).not.toContain('--resume');
+  });
+
+  it('includes --append-system-prompt when systemPromptAppend is provided', () => {
+    const args = buildCliArgs({
+      prompt: 'hello',
+      mcpConfigPath: '/tmp/mcp.json',
+      systemPromptAppend: 'system instructions',
+      allowedTools: [],
+    });
+    const idx = args.indexOf('--append-system-prompt');
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe('system instructions');
+  });
+
+  it('does not include --append-system-prompt when not provided', () => {
+    const args = buildCliArgs({
+      prompt: 'hello',
+      mcpConfigPath: '/tmp/mcp.json',
+      allowedTools: [],
+    });
+    expect(args).not.toContain('--append-system-prompt');
+  });
+
+  it('includes --add-dir for each additional directory', () => {
+    const args = buildCliArgs({
+      prompt: 'hello',
+      mcpConfigPath: '/tmp/mcp.json',
+      additionalDirectories: ['/extra/a', '/extra/b'],
+      allowedTools: [],
+    });
+    const firstIdx = args.indexOf('--add-dir');
+    expect(firstIdx).toBeGreaterThan(-1);
+    expect(args[firstIdx + 1]).toBe('/extra/a');
+    const secondIdx = args.indexOf('--add-dir', firstIdx + 1);
+    expect(secondIdx).toBeGreaterThan(-1);
+    expect(args[secondIdx + 1]).toBe('/extra/b');
+  });
+
+  it('puts prompt as -p flag value', () => {
+    const args = buildCliArgs({
+      prompt: 'my prompt',
+      sessionId: 'sid',
+      mcpConfigPath: '/tmp/mcp.json',
+      systemPromptAppend: 'sys',
+      additionalDirectories: ['/extra/x'],
+      allowedTools: ['Bash'],
+    });
+    const pIdx = args.indexOf('-p');
+    expect(pIdx).toBe(0);
+    expect(args[pIdx + 1]).toBe('my prompt');
+  });
+});
+
+describe('parseStreamJson', () => {
+  function createMockChild(lines: string[]): ChildProcess {
+    const stdout = new Readable({ read() {} });
+    const stderr = new Readable({ read() {} });
+    const child = new EventEmitter() as unknown as ChildProcess;
+    child.stdout = stdout;
+    child.stderr = stderr;
+    child.stdin = null as unknown as ChildProcess['stdin'];
+
+    // Emit lines asynchronously, then close
+    setTimeout(() => {
+      for (const line of lines) {
+        stdout.push(line + '\n');
+      }
+      stdout.push(null);
+      stderr.push(null);
+      (child as EventEmitter).emit('close', 0);
+    }, 10);
+
+    return child;
+  }
+
+  it('parses system/init message and extracts session_id', async () => {
+    const initMsg = JSON.stringify({ type: 'system', subtype: 'init', session_id: 'abc-123' });
+    const child = createMockChild([initMsg]);
+    const messages: StreamJsonMessage[] = [];
+    await parseStreamJson(child, (msg) => messages.push(msg));
+    expect(messages).toHaveLength(1);
+    expect(messages[0].type).toBe('system');
+    expect(messages[0].subtype).toBe('init');
+    expect(messages[0].session_id).toBe('abc-123');
+  });
+
+  it('parses result message', async () => {
+    const resultMsg = JSON.stringify({ type: 'result', subtype: 'success', result: 'Hello!', session_id: 'abc' });
+    const child = createMockChild([resultMsg]);
+    const messages: StreamJsonMessage[] = [];
+    await parseStreamJson(child, (msg) => messages.push(msg));
+    expect(messages).toHaveLength(1);
+    expect(messages[0].type).toBe('result');
+    expect(messages[0].result).toBe('Hello!');
+  });
+
+  it('parses multiple messages in sequence', async () => {
+    const lines = [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 's1' }),
+      JSON.stringify({ type: 'assistant', uuid: 'u1', message: { content: [{ type: 'text', text: 'Hi' }] } }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'Done' }),
+    ];
+    const child = createMockChild(lines);
+    const messages: StreamJsonMessage[] = [];
+    await parseStreamJson(child, (msg) => messages.push(msg));
+    expect(messages).toHaveLength(3);
+    expect(messages.map(m => m.type)).toEqual(['system', 'assistant', 'result']);
+  });
+
+  it('skips malformed JSON lines', async () => {
+    const lines = [
+      'not valid json',
+      JSON.stringify({ type: 'result', result: 'ok' }),
+    ];
+    const child = createMockChild(lines);
+    const messages: StreamJsonMessage[] = [];
+    await parseStreamJson(child, (msg) => messages.push(msg));
+    expect(messages).toHaveLength(1);
+    expect(messages[0].result).toBe('ok');
+  });
+
+  it('handles chunked data across buffer boundaries', async () => {
+    const stdout = new Readable({ read() {} });
+    const stderr = new Readable({ read() {} });
+    const child = new EventEmitter() as unknown as ChildProcess;
+    child.stdout = stdout;
+    child.stderr = stderr;
+    child.stdin = null as unknown as ChildProcess['stdin'];
+
+    const fullLine = JSON.stringify({ type: 'result', result: 'test' });
+    // Split in the middle of the JSON
+    const part1 = fullLine.slice(0, 10);
+    const part2 = fullLine.slice(10) + '\n';
+
+    setTimeout(() => {
+      stdout.push(part1);
+      stdout.push(part2);
+      stdout.push(null);
+      stderr.push(null);
+      (child as EventEmitter).emit('close', 0);
+    }, 10);
+
+    const messages: StreamJsonMessage[] = [];
+    await parseStreamJson(child, (msg) => messages.push(msg));
+    expect(messages).toHaveLength(1);
+    expect(messages[0].result).toBe('test');
+  });
+
+  it('returns exit code from child process', async () => {
+    const stdout = new Readable({ read() {} });
+    const stderr = new Readable({ read() {} });
+    const child = new EventEmitter() as unknown as ChildProcess;
+    child.stdout = stdout;
+    child.stderr = stderr;
+    child.stdin = null as unknown as ChildProcess['stdin'];
+
+    setTimeout(() => {
+      stdout.push(null);
+      stderr.push(null);
+      (child as EventEmitter).emit('close', 42);
+    }, 10);
+
+    const exitCode = await parseStreamJson(child, () => {});
+    expect(exitCode).toBe(42);
+  });
+
+  it('rejects on child process error', async () => {
+    const stdout = new Readable({ read() {} });
+    const stderr = new Readable({ read() {} });
+    const child = new EventEmitter() as unknown as ChildProcess;
+    child.stdout = stdout;
+    child.stderr = stderr;
+    child.stdin = null as unknown as ChildProcess['stdin'];
+
+    setTimeout(() => {
+      (child as EventEmitter).emit('error', new Error('spawn failed'));
+    }, 10);
+
+    await expect(parseStreamJson(child, () => {})).rejects.toThrow('spawn failed');
+  });
+
+  it('skips empty lines', async () => {
+    const lines = ['', JSON.stringify({ type: 'result', result: 'ok' }), ''];
+    const child = createMockChild(lines);
+    const messages: StreamJsonMessage[] = [];
+    await parseStreamJson(child, (msg) => messages.push(msg));
+    expect(messages).toHaveLength(1);
+  });
+});

--- a/container/agent-runner/src/cli-utils.ts
+++ b/container/agent-runner/src/cli-utils.ts
@@ -1,0 +1,227 @@
+/**
+ * CLI utilities for Claude Code CLI integration.
+ * Low-level functions for building CLI args, parsing NDJSON streams,
+ * writing MCP and hooks configuration.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { ChildProcess } from 'child_process';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+/** A single NDJSON message from `claude --output-format stream-json` */
+export interface StreamJsonMessage {
+  type: string;
+  subtype?: string;
+  session_id?: string;
+  uuid?: string;
+  result?: string;
+  message?: {
+    role?: string;
+    content?: string | Array<{ type: string; text?: string }>;
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+}
+
+// ── Tool mapping ─────────────────────────────────────────────────────────────
+
+/** SDK tool names that don't exist in CLI (replaced by Agent) */
+const SDK_ONLY_TOOLS = new Set([
+  'Task', 'TaskOutput', 'TaskStop',
+  'TeamCreate', 'TeamDelete', 'SendMessage',
+]);
+
+/**
+ * Map SDK-style allowed tools to CLI tool names.
+ * Replaces SDK-specific tools (Task/Teams) with their CLI equivalent (Agent).
+ */
+export function mapAllowedTools(sdkTools: string[]): string[] {
+  const tools: string[] = [];
+  let needsAgent = false;
+
+  for (const tool of sdkTools) {
+    if (SDK_ONLY_TOOLS.has(tool)) {
+      needsAgent = true;
+    } else {
+      tools.push(tool);
+    }
+  }
+
+  if (needsAgent && !tools.includes('Agent')) {
+    tools.push('Agent');
+  }
+
+  return tools;
+}
+
+// ── CLI argument builder ─────────────────────────────────────────────────────
+
+export interface BuildCliArgsOptions {
+  prompt: string;
+  sessionId?: string;
+  mcpConfigPath: string;
+  systemPromptAppend?: string;
+  additionalDirectories?: string[];
+  allowedTools: string[];
+}
+
+/**
+ * Build CLI argument array from SDK-style options.
+ */
+export function buildCliArgs(opts: BuildCliArgsOptions): string[] {
+  const args: string[] = [
+    '-p', opts.prompt,
+    '--output-format', 'stream-json',
+    '--verbose',
+    '--dangerously-skip-permissions',
+    '--mcp-config', opts.mcpConfigPath,
+  ];
+
+  const cliTools = mapAllowedTools(opts.allowedTools);
+  if (cliTools.length > 0) {
+    args.push('--allowedTools', ...cliTools);
+  }
+
+  if (opts.additionalDirectories) {
+    for (const dir of opts.additionalDirectories) {
+      args.push('--add-dir', dir);
+    }
+  }
+
+  if (opts.systemPromptAppend) {
+    args.push('--append-system-prompt', opts.systemPromptAppend);
+  }
+
+  if (opts.sessionId) {
+    args.push('--resume', opts.sessionId);
+  }
+
+  return args;
+}
+
+// ── NDJSON stream parser ─────────────────────────────────────────────────────
+
+/**
+ * Parse NDJSON stream from a child process stdout.
+ * Calls onMessage for each complete JSON line.
+ */
+export function parseStreamJson(
+  child: ChildProcess,
+  onMessage: (msg: StreamJsonMessage) => void,
+): Promise<number> {
+  return new Promise((resolve, reject) => {
+    let buffer = '';
+
+    child.stdout!.on('data', (chunk: Buffer) => {
+      buffer += chunk.toString();
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          onMessage(JSON.parse(line) as StreamJsonMessage);
+        } catch {
+          console.error(`[claude-backend] Failed to parse stream-json line: ${line.slice(0, 200)}`);
+        }
+      }
+    });
+
+    child.stderr!.on('data', (chunk: Buffer) => {
+      console.error(`[claude-cli] ${chunk.toString().trim()}`);
+    });
+
+    child.on('close', (code) => resolve(code ?? 1));
+    child.on('error', reject);
+  });
+}
+
+// ── MCP config ───────────────────────────────────────────────────────────────
+
+/**
+ * Write MCP server configuration file for --mcp-config flag.
+ */
+export function writeMcpConfig(
+  mcpServers: Record<string, { command: string; args: string[]; env: Record<string, string> }>,
+): string {
+  const configPath = '/tmp/mcp-config.json';
+  fs.writeFileSync(configPath, JSON.stringify({ mcpServers }));
+  return configPath;
+}
+
+// ── CLI hooks settings ───────────────────────────────────────────────────────
+
+/**
+ * Write CLI hooks settings to ~/.claude/settings.json.
+ * Translates SDK-style in-process hooks to CLI external command hooks.
+ */
+export function writeHooksSettings(precompactScriptPath: string): void {
+  const settingsDir = '/home/node/.claude';
+  fs.mkdirSync(settingsDir, { recursive: true });
+  const settingsPath = path.join(settingsDir, 'settings.json');
+
+  let settings: Record<string, unknown> = {};
+  try {
+    if (fs.existsSync(settingsPath)) {
+      settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+    }
+  } catch { /* start fresh */ }
+
+  settings.hooks = {
+    PreCompact: [{
+      hooks: [{
+        type: 'command',
+        command: `node ${precompactScriptPath}`,
+      }],
+    }],
+  };
+
+  fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+}
+
+// ── Async channel ────────────────────────────────────────────────────────────
+
+/**
+ * Simple async channel for converting callback-based message reception
+ * to an async iterable (enables real-time message yielding from CLI output).
+ */
+export class AsyncChannel<T> {
+  private queue: T[] = [];
+  private waiting: ((result: IteratorResult<T>) => void) | null = null;
+  private closed = false;
+
+  push(item: T): void {
+    if (this.closed) return;
+    if (this.waiting) {
+      const resolve = this.waiting;
+      this.waiting = null;
+      resolve({ value: item, done: false });
+    } else {
+      this.queue.push(item);
+    }
+  }
+
+  close(): void {
+    this.closed = true;
+    if (this.waiting) {
+      const resolve = this.waiting;
+      this.waiting = null;
+      resolve({ value: undefined as unknown as T, done: true });
+    }
+  }
+
+  async *[Symbol.asyncIterator](): AsyncGenerator<T> {
+    while (true) {
+      if (this.queue.length > 0) {
+        yield this.queue.shift()!;
+        continue;
+      }
+      if (this.closed) return;
+      const result = await new Promise<IteratorResult<T>>(r => { this.waiting = r; });
+      if (result.done) return;
+      yield result.value;
+    }
+  }
+}

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -16,7 +16,7 @@
 
 import fs from 'fs';
 import path from 'path';
-import { query, HookCallback, PreCompactHookInput } from '@anthropic-ai/claude-agent-sdk';
+import { query, HookCallback, PreCompactHookInput } from './claude-backend.js';
 import { fileURLToPath } from 'url';
 
 interface ContainerInput {
@@ -484,6 +484,11 @@ async function main(): Promise<void> {
   // Credentials are injected by the host's credential proxy via ANTHROPIC_BASE_URL.
   // No real secrets exist in the container environment.
   const sdkEnv: Record<string, string | undefined> = { ...process.env };
+
+  // Pass assistant name via env so the standalone precompact-hook script can use it
+  if (containerInput.assistantName) {
+    sdkEnv.NANOCLAW_ASSISTANT_NAME = containerInput.assistantName;
+  }
 
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
   const mcpServerPath = path.join(__dirname, 'ipc-mcp-stdio.js');

--- a/container/agent-runner/src/precompact-hook.test.ts
+++ b/container/agent-runner/src/precompact-hook.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseTranscript,
+  formatTranscriptMarkdown,
+  sanitizeFilename,
+  generateFallbackName,
+  type ParsedMessage,
+} from './precompact-hook.js';
+
+describe('parseTranscript', () => {
+  it('parses user and assistant messages from NDJSON', () => {
+    const content = [
+      JSON.stringify({ type: 'user', message: { role: 'user', content: 'Hello' } }),
+      JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'Hi there' }] } }),
+    ].join('\n');
+
+    const messages = parseTranscript(content);
+    expect(messages).toEqual([
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi there' },
+    ]);
+  });
+
+  it('handles array content blocks for user messages', () => {
+    const content = JSON.stringify({
+      type: 'user',
+      message: { role: 'user', content: [{ text: 'Part 1' }, { text: ' Part 2' }] },
+    });
+    const messages = parseTranscript(content);
+    expect(messages).toEqual([{ role: 'user', content: 'Part 1 Part 2' }]);
+  });
+
+  it('filters out non-text assistant content blocks', () => {
+    const content = JSON.stringify({
+      type: 'assistant',
+      message: { content: [
+        { type: 'tool_use', id: 'tu_1', name: 'Bash', input: {} },
+        { type: 'text', text: 'Done!' },
+      ] },
+    });
+    const messages = parseTranscript(content);
+    expect(messages).toEqual([{ role: 'assistant', content: 'Done!' }]);
+  });
+
+  it('skips malformed JSON lines', () => {
+    const content = 'not-json\n' + JSON.stringify({ type: 'user', message: { content: 'ok' } });
+    const messages = parseTranscript(content);
+    expect(messages).toEqual([{ role: 'user', content: 'ok' }]);
+  });
+
+  it('skips empty lines', () => {
+    const content = '\n\n' + JSON.stringify({ type: 'user', message: { content: 'hello' } }) + '\n\n';
+    const messages = parseTranscript(content);
+    expect(messages).toHaveLength(1);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(parseTranscript('')).toEqual([]);
+  });
+
+  it('skips messages with empty text', () => {
+    const content = JSON.stringify({ type: 'user', message: { content: '' } });
+    expect(parseTranscript(content)).toEqual([]);
+  });
+
+  it('skips system messages', () => {
+    const content = JSON.stringify({ type: 'system', subtype: 'init', session_id: 'abc' });
+    expect(parseTranscript(content)).toEqual([]);
+  });
+});
+
+describe('formatTranscriptMarkdown', () => {
+  const messages: ParsedMessage[] = [
+    { role: 'user', content: 'Hello' },
+    { role: 'assistant', content: 'Hi!' },
+  ];
+
+  it('generates markdown with title', () => {
+    const md = formatTranscriptMarkdown(messages, 'Test Chat');
+    expect(md).toContain('# Test Chat');
+    expect(md).toContain('**User**: Hello');
+    expect(md).toContain('**Assistant**: Hi!');
+  });
+
+  it('uses custom assistant name', () => {
+    const md = formatTranscriptMarkdown(messages, null, 'Claw');
+    expect(md).toContain('**Claw**: Hi!');
+  });
+
+  it('uses fallback title when none provided', () => {
+    const md = formatTranscriptMarkdown(messages, null);
+    expect(md).toContain('# Conversation');
+  });
+
+  it('truncates long content at 2000 chars', () => {
+    const longMsg: ParsedMessage[] = [
+      { role: 'user', content: 'x'.repeat(3000) },
+    ];
+    const md = formatTranscriptMarkdown(longMsg, null);
+    expect(md).toContain('x'.repeat(2000) + '...');
+    expect(md).not.toContain('x'.repeat(2001));
+  });
+});
+
+describe('sanitizeFilename', () => {
+  it('lowercases and replaces non-alphanumeric chars', () => {
+    expect(sanitizeFilename('Hello World!')).toBe('hello-world');
+  });
+
+  it('trims leading/trailing dashes', () => {
+    expect(sanitizeFilename('---test---')).toBe('test');
+  });
+
+  it('truncates to 50 chars', () => {
+    const long = 'a'.repeat(60);
+    expect(sanitizeFilename(long).length).toBe(50);
+  });
+
+  it('handles unicode characters', () => {
+    expect(sanitizeFilename('대화 내용 정리')).toBe('');
+  });
+});
+
+describe('generateFallbackName', () => {
+  it('uses HH:MM format', () => {
+    const date = new Date(2026, 2, 18, 14, 5);
+    expect(generateFallbackName(date)).toBe('conversation-1405');
+  });
+
+  it('zero-pads single digit hours/minutes', () => {
+    const date = new Date(2026, 0, 1, 3, 7);
+    expect(generateFallbackName(date)).toBe('conversation-0307');
+  });
+});

--- a/container/agent-runner/src/precompact-hook.ts
+++ b/container/agent-runner/src/precompact-hook.ts
@@ -1,0 +1,201 @@
+/**
+ * Standalone PreCompact hook script for Claude Code CLI.
+ *
+ * Called by Claude Code before context compaction.
+ * Reads hook input JSON from stdin, archives the transcript to
+ * /workspace/group/conversations/, and outputs a response to stdout.
+ *
+ * Exit codes:
+ *   0 — success, compaction proceeds
+ *   2 — blocking error, compaction is prevented
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+export interface PreCompactInput {
+  session_id: string;
+  transcript_path: string;
+  cwd: string;
+  hook_event_name: string;
+  trigger: string;
+  custom_instructions: string;
+}
+
+export interface ParsedMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+interface SessionEntry {
+  sessionId: string;
+  fullPath: string;
+  summary: string;
+  firstPrompt: string;
+}
+
+interface SessionsIndex {
+  entries: SessionEntry[];
+}
+
+export function getSessionSummary(sessionId: string, transcriptPath: string): string | null {
+  const projectDir = path.dirname(transcriptPath);
+  const indexPath = path.join(projectDir, 'sessions-index.json');
+
+  if (!fs.existsSync(indexPath)) {
+    return null;
+  }
+
+  try {
+    const index: SessionsIndex = JSON.parse(fs.readFileSync(indexPath, 'utf-8'));
+    const entry = index.entries.find(e => e.sessionId === sessionId);
+    if (entry?.summary) {
+      return entry.summary;
+    }
+  } catch {
+    // ignore
+  }
+
+  return null;
+}
+
+export function sanitizeFilename(summary: string): string {
+  return summary
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 50);
+}
+
+export function generateFallbackName(now: Date = new Date()): string {
+  return `conversation-${now.getHours().toString().padStart(2, '0')}${now.getMinutes().toString().padStart(2, '0')}`;
+}
+
+export function parseTranscript(content: string): ParsedMessage[] {
+  const messages: ParsedMessage[] = [];
+
+  for (const line of content.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const entry = JSON.parse(line);
+      if (entry.type === 'user' && entry.message?.content) {
+        const text = typeof entry.message.content === 'string'
+          ? entry.message.content
+          : entry.message.content.map((c: { text?: string }) => c.text || '').join('');
+        if (text) messages.push({ role: 'user', content: text });
+      } else if (entry.type === 'assistant' && entry.message?.content) {
+        const textParts = entry.message.content
+          .filter((c: { type: string }) => c.type === 'text')
+          .map((c: { text: string }) => c.text);
+        const text = textParts.join('');
+        if (text) messages.push({ role: 'assistant', content: text });
+      }
+    } catch {
+      // skip malformed lines
+    }
+  }
+
+  return messages;
+}
+
+export function formatTranscriptMarkdown(messages: ParsedMessage[], title?: string | null, assistantName?: string): string {
+  const now = new Date();
+  const formatDateTime = (d: Date) => d.toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true
+  });
+
+  const lines: string[] = [];
+  lines.push(`# ${title || 'Conversation'}`);
+  lines.push('');
+  lines.push(`Archived: ${formatDateTime(now)}`);
+  lines.push('');
+  lines.push('---');
+  lines.push('');
+
+  for (const msg of messages) {
+    const sender = msg.role === 'user' ? 'User' : (assistantName || 'Assistant');
+    const content = msg.content.length > 2000
+      ? msg.content.slice(0, 2000) + '...'
+      : msg.content;
+    lines.push(`**${sender}**: ${content}`);
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+export function archiveTranscript(input: PreCompactInput, assistantName?: string): void {
+  const { transcript_path: transcriptPath, session_id: sessionId } = input;
+
+  if (!transcriptPath || !fs.existsSync(transcriptPath)) {
+    log('No transcript found for archiving');
+    return;
+  }
+
+  const content = fs.readFileSync(transcriptPath, 'utf-8');
+  const messages = parseTranscript(content);
+
+  if (messages.length === 0) {
+    log('No messages to archive');
+    return;
+  }
+
+  const summary = getSessionSummary(sessionId, transcriptPath);
+  const name = summary ? sanitizeFilename(summary) : generateFallbackName();
+
+  const conversationsDir = '/workspace/group/conversations';
+  fs.mkdirSync(conversationsDir, { recursive: true });
+
+  const date = new Date().toISOString().split('T')[0];
+  const filename = `${date}-${name}.md`;
+  const filePath = path.join(conversationsDir, filename);
+
+  const markdown = formatTranscriptMarkdown(messages, summary, assistantName);
+  fs.writeFileSync(filePath, markdown);
+
+  log(`Archived conversation to ${filePath}`);
+}
+
+function log(message: string): void {
+  console.error(`[precompact-hook] ${message}`);
+}
+
+async function main(): Promise<void> {
+  const chunks: string[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk.toString());
+  }
+  const rawInput = chunks.join('');
+
+  let input: PreCompactInput;
+  try {
+    input = JSON.parse(rawInput);
+  } catch {
+    log('Failed to parse stdin JSON');
+    process.stdout.write(JSON.stringify({ continue: true }));
+    process.exit(0);
+  }
+
+  const assistantName = process.env.NANOCLAW_ASSISTANT_NAME;
+
+  try {
+    archiveTranscript(input, assistantName);
+    process.stdout.write(JSON.stringify({ continue: true }));
+    process.exit(0);
+  } catch (err) {
+    log(`Archive failed: ${err instanceof Error ? err.message : String(err)}`);
+    // Exit code 2 = blocking error → prevent compaction to avoid data loss
+    process.stdout.write(JSON.stringify({ continue: false }));
+    process.exit(2);
+  }
+}
+
+// Only run main when executed directly (not imported for tests)
+const isDirectRun = process.argv[1]?.endsWith('precompact-hook.js');
+if (isDirectRun) {
+  main();
+}


### PR DESCRIPTION
## Summary

Replaces `@anthropic-ai/claude-agent-sdk` with Claude Code CLI in the container agent-runner to address TOS compliance concerns raised in #1224.

- **Drop-in CLI adapter** (`claude-backend.ts`): spawns the `claude` CLI binary instead of using the SDK, keeping `index.ts` structurally identical to upstream for clean merges
- **CLI utilities** (`cli-utils.ts`): helper functions for CLI interaction
- **Pre-compact hook** (`precompact-hook.ts`): handles context compaction during long-running agent sessions
- **Dependency change**: removed `@anthropic-ai/claude-agent-sdk`, added `vitest` for testing
- **Dockerfile**: updated entrypoint to use `exec node` for cleaner process management
- **CLAUDE.md**: added container deployment guide (clearing per-group source copies)

## Test plan

- [x] TypeScript build passes (`npm run build`)
- [x] No merge conflicts with upstream/main
- [ ] Unit tests pass (`vitest` in `container/agent-runner/`)
- [ ] Container builds successfully (`./container/build.sh`)
- [ ] Agent responds correctly via Telegram after deployment

Closes #1224