### PR TITLE
skill: add /add-telegram-voice-transcription

### DIFF
--- a/.claude/skills/add-telegram-voice-transcription/SKILL.md
+++ b/.claude/skills/add-telegram-voice-transcription/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: add-telegram-voice-transcription
+description: Add voice message transcription to Telegram channel using a local Whisper transcription service. Triggers on "telegram voice", "voice transcription", "transcribe voice".
+---
+
+# Add Telegram Voice Transcription
+
+This skill adds automatic voice message transcription to NanoClaw's Telegram channel using a local Whisper transcription service. When a voice message arrives, it is downloaded from the Telegram API, sent to the local transcription service, and delivered to the agent as `[Voice message]: <transcript>`.
+
+## Phase 1: Pre-flight
+
+### Check if already applied
+
+Read `.nanoclaw/state.yaml`. If `add-telegram-voice-transcription` is in `applied_skills`, skip to Phase 3 (Configure). The code changes are already in place.
+
+Also check if `src/channels/telegram.ts` already contains `transcribeVoice`. If it does, the changes are already applied.
+
+### Requirements
+
+- `TELEGRAM_BOT_TOKEN` must be set in `.env` (Telegram channel must be configured)
+- A local Whisper transcription service must be running (default: `http://localhost:8765`)
+- The transcription service must expose `POST /api/transcribe-sync` (multipart form, field `file`) returning `{"text": "transcript"}`
+- Health check at `GET /health` returning `{"status": "ok"}`
+
+### Setting up the transcription service
+
+The recommended service is [local_video_transcriber](https://github.com/Jimbo1167/local_video_transcriber), which runs faster-whisper locally.
+
+**With Docker:**
+```bash
+git clone https://github.com/Jimbo1167/local_video_transcriber.git
+cd local_video_transcriber
+docker compose up -d
+```
+The service will be available at `http://localhost:8000`. Set `TRANSCRIPTION_URL=http://localhost:8000` in `.env` if using the default Docker port.
+
+**Without Docker:**
+```bash
+git clone https://github.com/Jimbo1167/local_video_transcriber.git
+cd local_video_transcriber
+python3 -m venv .venv
+.venv/bin/pip install -r requirements.txt
+.venv/bin/python scripts/model_server.py --host 0.0.0.0 --port 8765
+```
+
+The first startup downloads the Whisper model (~1.5GB) and takes a few minutes. Subsequent starts are fast.
+
+Any service implementing the same API (`POST /api/transcribe-sync` returning `{"text": "..."}` and `GET /health`) will work.
+
+## Phase 2: Apply Code Changes
+
+### Initialize skills system (if needed)
+
+If `.nanoclaw/` directory doesn't exist yet:
+
+```bash
+npx tsx scripts/apply-skill.ts --init
+```
+
+### Apply the skill
+
+```bash
+npx tsx scripts/apply-skill.ts .claude/skills/add-telegram-voice-transcription
+```
+
+This deterministically:
+- Adds `transcribeVoice()` helper function to `src/channels/telegram.ts`
+- Adds `TRANSCRIPTION_URL` constant to `src/channels/telegram.ts`
+- Replaces the voice message placeholder handler with a full transcription handler
+- Adds a transcription service health check in the `connect()` method
+
+If the apply reports merge conflicts, read the intent file:
+- `modify/src/channels/telegram.ts.intent.md` — what changed and invariants
+
+### Validate
+
+```bash
+npm run build
+```
+
+Build must be clean before proceeding.
+
+## Phase 3: Configure
+
+### Transcription service URL
+
+Optionally set `TRANSCRIPTION_URL` in `.env` if the transcription service is not at the default address:
+
+```bash
+TRANSCRIPTION_URL=http://localhost:8765
+```
+
+The default is `http://localhost:8765` and does not need to be set unless the service runs elsewhere.
+
+### Build and restart
+
+```bash
+npm run build
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw  # macOS
+# Linux: systemctl --user restart nanoclaw
+```
+
+## Phase 4: Verify
+
+### Test with a voice message
+
+Tell the user:
+
+> Send a voice message in any registered Telegram chat. The agent should receive it as `[Voice message]: <transcript>` and respond to its content.
+
+### Check logs if needed
+
+```bash
+tail -f logs/nanoclaw.log | grep -i voice
+```
+
+Look for:
+- `Voice message processed` with `transcribed: true` — successful transcription
+- `Transcription service returned error` — service returned non-OK HTTP status
+- `Voice transcription failed` — network or timeout error
+- `Voice message download/transcription failed` — Telegram file download failed
+- `Transcription service is not reachable` — health check failed at startup (warning only)
+
+## Troubleshooting
+
+### Voice messages show "[Voice message -- transcription unavailable]"
+
+1. Check the transcription service is running: `curl http://localhost:8765/health`
+2. Check `TRANSCRIPTION_URL` in `.env` matches the actual service address
+3. Restart NanoClaw after changing `.env`
+
+### Transcription service health check warning at startup
+
+This is non-blocking. The bot will still start and attempt transcription when voice messages arrive. The service may have started after NanoClaw.
+
+### Transcription takes too long
+
+The handler has a 2-minute timeout. If transcriptions consistently time out, check the service's resource usage and consider running it on a faster machine or with a smaller Whisper model.
+
+### Agent doesn't respond to voice messages
+
+Verify the chat is registered and the agent is running. Voice transcription only runs for registered groups (same as all other message types).
+
+## Removal
+
+1. Revert `src/channels/telegram.ts` to restore the original voice handler line: `this.bot.on('message:voice', (ctx) => storeNonText(ctx, '[Voice message]'));`
+2. Remove the `transcribeVoice` function and `TRANSCRIPTION_URL` constant
+3. Remove `TRANSCRIPTION_URL` from `.env` (if set)
+4. Remove `add-telegram-voice-transcription` from `.nanoclaw/state.yaml`
+5. Rebuild: `npm run build && launchctl kickstart -k gui/$(id -u)/com.nanoclaw`

--- a/.claude/skills/add-telegram-voice-transcription/manifest.yaml
+++ b/.claude/skills/add-telegram-voice-transcription/manifest.yaml
@@ -1,0 +1,15 @@
+skill: add-telegram-voice-transcription
+version: 1.0.0
+description: "Add voice message transcription to Telegram using local Whisper service"
+core_version: 1.2.10
+adds: []
+modifies:
+  - src/channels/telegram.ts
+structured:
+  npm_dependencies: {}
+  env_additions:
+    - TRANSCRIPTION_URL
+conflicts: []
+depends:
+  - add-telegram
+test: "npx vitest run -c /dev/null .claude/skills/add-telegram-voice-transcription/tests/telegram-voice-transcription.test.ts"

--- a/.claude/skills/add-telegram-voice-transcription/modify/src/channels/telegram.ts
+++ b/.claude/skills/add-telegram-voice-transcription/modify/src/channels/telegram.ts
@@ -1,0 +1,404 @@
+import https from 'https';
+import { Api, Bot } from 'grammy';
+
+import { ASSISTANT_NAME, TRIGGER_PATTERN } from '../config.js';
+import { readEnvFile } from '../env.js';
+import { logger } from '../logger.js';
+import { registerChannel, ChannelOpts } from './registry.js';
+import {
+  Channel,
+  OnChatMetadata,
+  OnInboundMessage,
+  RegisteredGroup,
+} from '../types.js';
+
+const TRANSCRIPTION_URL = process.env.TRANSCRIPTION_URL || 'http://localhost:8765';
+
+/**
+ * Transcribe a voice message buffer by posting it to the local transcription service.
+ * Returns the transcript text, or null if the service is unavailable.
+ */
+async function transcribeVoice(fileBuffer: Buffer, filename: string): Promise<string | null> {
+  try {
+    const boundary = '----FormBoundary' + Math.random().toString(36).slice(2);
+    const parts = [
+      `--${boundary}\r\n`,
+      `Content-Disposition: form-data; name="file"; filename="${filename}"\r\n`,
+      `Content-Type: audio/ogg\r\n\r\n`,
+    ];
+    const header = Buffer.from(parts.join(''));
+    const footer = Buffer.from(`\r\n--${boundary}--\r\n`);
+    const body = Buffer.concat([header, fileBuffer, footer]);
+
+    const resp = await fetch(`${TRANSCRIPTION_URL}/api/transcribe-sync`, {
+      method: 'POST',
+      headers: { 'Content-Type': `multipart/form-data; boundary=${boundary}` },
+      body,
+      signal: AbortSignal.timeout(120_000),
+    });
+
+    if (!resp.ok) {
+      logger.warn({ status: resp.status }, 'Transcription service returned error');
+      return null;
+    }
+
+    const data = await resp.json() as { text?: string };
+    return data.text?.trim() || null;
+  } catch (err) {
+    logger.warn({ err }, 'Voice transcription failed');
+    return null;
+  }
+}
+
+export interface TelegramChannelOpts {
+  onMessage: OnInboundMessage;
+  onChatMetadata: OnChatMetadata;
+  registeredGroups: () => Record<string, RegisteredGroup>;
+}
+
+/**
+ * Send a message with Telegram Markdown parse mode, falling back to plain text.
+ * Claude's output naturally matches Telegram's Markdown v1 format:
+ *   *bold*, _italic_, `code`, ```code blocks```, [links](url)
+ */
+async function sendTelegramMessage(
+  api: { sendMessage: Api['sendMessage'] },
+  chatId: string | number,
+  text: string,
+  options: { message_thread_id?: number } = {},
+): Promise<void> {
+  try {
+    await api.sendMessage(chatId, text, {
+      ...options,
+      parse_mode: 'Markdown',
+    });
+  } catch (err) {
+    // Fallback: send as plain text if Markdown parsing fails
+    logger.debug({ err }, 'Markdown send failed, falling back to plain text');
+    await api.sendMessage(chatId, text, options);
+  }
+}
+
+export class TelegramChannel implements Channel {
+  name = 'telegram';
+
+  private bot: Bot | null = null;
+  private opts: TelegramChannelOpts;
+  private botToken: string;
+
+  constructor(botToken: string, opts: TelegramChannelOpts) {
+    this.botToken = botToken;
+    this.opts = opts;
+  }
+
+  async connect(): Promise<void> {
+    this.bot = new Bot(this.botToken, {
+      client: {
+        baseFetchConfig: { agent: https.globalAgent, compress: true },
+      },
+    });
+
+    // Command to get chat ID (useful for registration)
+    this.bot.command('chatid', (ctx) => {
+      const chatId = ctx.chat.id;
+      const chatType = ctx.chat.type;
+      const chatName =
+        chatType === 'private'
+          ? ctx.from?.first_name || 'Private'
+          : (ctx.chat as any).title || 'Unknown';
+
+      ctx.reply(
+        `Chat ID: \`tg:${chatId}\`\nName: ${chatName}\nType: ${chatType}`,
+        { parse_mode: 'Markdown' },
+      );
+    });
+
+    // Command to check bot status
+    this.bot.command('ping', (ctx) => {
+      ctx.reply(`${ASSISTANT_NAME} is online.`);
+    });
+
+    // Telegram bot commands handled above — skip them in the general handler
+    // so they don't also get stored as messages. All other /commands flow through.
+    const TELEGRAM_BOT_COMMANDS = new Set(['chatid', 'ping']);
+
+    this.bot.on('message:text', async (ctx) => {
+      if (ctx.message.text.startsWith('/')) {
+        const cmd = ctx.message.text.slice(1).split(/[\s@]/)[0].toLowerCase();
+        if (TELEGRAM_BOT_COMMANDS.has(cmd)) return;
+      }
+
+      const chatJid = `tg:${ctx.chat.id}`;
+      let content = ctx.message.text;
+      const timestamp = new Date(ctx.message.date * 1000).toISOString();
+      const senderName =
+        ctx.from?.first_name ||
+        ctx.from?.username ||
+        ctx.from?.id.toString() ||
+        'Unknown';
+      const sender = ctx.from?.id.toString() || '';
+      const msgId = ctx.message.message_id.toString();
+
+      // Determine chat name
+      const chatName =
+        ctx.chat.type === 'private'
+          ? senderName
+          : (ctx.chat as any).title || chatJid;
+
+      // Translate Telegram @bot_username mentions into TRIGGER_PATTERN format.
+      // Telegram @mentions (e.g., @andy_ai_bot) won't match TRIGGER_PATTERN
+      // (e.g., ^@Andy\b), so we prepend the trigger when the bot is @mentioned.
+      const botUsername = ctx.me?.username?.toLowerCase();
+      if (botUsername) {
+        const entities = ctx.message.entities || [];
+        const isBotMentioned = entities.some((entity) => {
+          if (entity.type === 'mention') {
+            const mentionText = content
+              .substring(entity.offset, entity.offset + entity.length)
+              .toLowerCase();
+            return mentionText === `@${botUsername}`;
+          }
+          return false;
+        });
+        if (isBotMentioned && !TRIGGER_PATTERN.test(content)) {
+          content = `@${ASSISTANT_NAME} ${content}`;
+        }
+      }
+
+      // Store chat metadata for discovery
+      const isGroup =
+        ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
+      this.opts.onChatMetadata(
+        chatJid,
+        timestamp,
+        chatName,
+        'telegram',
+        isGroup,
+      );
+
+      // Only deliver full message for registered groups
+      const group = this.opts.registeredGroups()[chatJid];
+      if (!group) {
+        logger.debug(
+          { chatJid, chatName },
+          'Message from unregistered Telegram chat',
+        );
+        return;
+      }
+
+      // Deliver message — startMessageLoop() will pick it up
+      this.opts.onMessage(chatJid, {
+        id: msgId,
+        chat_jid: chatJid,
+        sender,
+        sender_name: senderName,
+        content,
+        timestamp,
+        is_from_me: false,
+      });
+
+      logger.info(
+        { chatJid, chatName, sender: senderName },
+        'Telegram message stored',
+      );
+    });
+
+    // Handle non-text messages with placeholders so the agent knows something was sent
+    const storeNonText = (ctx: any, placeholder: string) => {
+      const chatJid = `tg:${ctx.chat.id}`;
+      const group = this.opts.registeredGroups()[chatJid];
+      if (!group) return;
+
+      const timestamp = new Date(ctx.message.date * 1000).toISOString();
+      const senderName =
+        ctx.from?.first_name ||
+        ctx.from?.username ||
+        ctx.from?.id?.toString() ||
+        'Unknown';
+      const caption = ctx.message.caption ? ` ${ctx.message.caption}` : '';
+
+      const isGroup =
+        ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
+      this.opts.onChatMetadata(
+        chatJid,
+        timestamp,
+        undefined,
+        'telegram',
+        isGroup,
+      );
+      this.opts.onMessage(chatJid, {
+        id: ctx.message.message_id.toString(),
+        chat_jid: chatJid,
+        sender: ctx.from?.id?.toString() || '',
+        sender_name: senderName,
+        content: `${placeholder}${caption}`,
+        timestamp,
+        is_from_me: false,
+      });
+    };
+
+    this.bot.on('message:photo', (ctx) => storeNonText(ctx, '[Photo]'));
+    this.bot.on('message:video', (ctx) => storeNonText(ctx, '[Video]'));
+
+    // Voice messages: download OGG, transcribe via local service, pass transcript to agent
+    this.bot.on('message:voice', async (ctx) => {
+      const chatJid = `tg:${ctx.chat.id}`;
+      const group = this.opts.registeredGroups()[chatJid];
+      if (!group) return;
+
+      let content = '[Voice message]';
+      try {
+        const file = await ctx.api.getFile(ctx.message.voice.file_id);
+        const url = `https://api.telegram.org/file/bot${this.botToken}/` + file.file_path;
+        const resp = await fetch(url);
+        if (!resp.ok) throw new Error(`Download failed: ${resp.status}`);
+        const buffer = Buffer.from(await resp.arrayBuffer());
+
+        const transcript = await transcribeVoice(buffer, `voice_${ctx.message.message_id}.ogg`);
+        if (transcript) {
+          content = `[Voice message]: ${transcript}`;
+        } else {
+          content = '[Voice message — transcription unavailable]';
+        }
+      } catch (err) {
+        logger.error({ chatJid, err }, 'Voice message download/transcription failed');
+        content = '[Voice message — transcription unavailable]';
+      }
+
+      const timestamp = new Date(ctx.message.date * 1000).toISOString();
+      const senderName =
+        ctx.from?.first_name ||
+        ctx.from?.username ||
+        ctx.from?.id?.toString() ||
+        'Unknown';
+      const caption = ctx.message.caption ? ` ${ctx.message.caption}` : '';
+      const isGroup = ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
+      this.opts.onChatMetadata(chatJid, timestamp, undefined, 'telegram', isGroup);
+      this.opts.onMessage(chatJid, {
+        id: ctx.message.message_id.toString(),
+        chat_jid: chatJid,
+        sender: ctx.from?.id?.toString() || '',
+        sender_name: senderName,
+        content: `${content}${caption}`,
+        timestamp,
+        is_from_me: false,
+      });
+
+      logger.info({ chatJid, transcribed: content.startsWith('[Voice message]:') }, 'Voice message processed');
+    });
+
+    this.bot.on('message:audio', (ctx) => storeNonText(ctx, '[Audio]'));
+    this.bot.on('message:document', (ctx) => {
+      const name = ctx.message.document?.file_name || 'file';
+      storeNonText(ctx, `[Document: ${name}]`);
+    });
+    this.bot.on('message:sticker', (ctx) => {
+      const emoji = ctx.message.sticker?.emoji || '';
+      storeNonText(ctx, `[Sticker ${emoji}]`);
+    });
+    this.bot.on('message:location', (ctx) => storeNonText(ctx, '[Location]'));
+    this.bot.on('message:contact', (ctx) => storeNonText(ctx, '[Contact]'));
+
+    // Handle errors gracefully
+    this.bot.catch((err) => {
+      logger.error({ err: err.message }, 'Telegram bot error');
+    });
+
+    // Start polling — returns a Promise that resolves when started
+    return new Promise<void>((resolve) => {
+      this.bot!.start({
+        onStart: async (botInfo) => {
+          logger.info(
+            { username: botInfo.username, id: botInfo.id },
+            'Telegram bot connected',
+          );
+          console.log(`\n  Telegram bot: @${botInfo.username}`);
+          console.log(
+            `  Send /chatid to the bot to get a chat's registration ID\n`,
+          );
+
+          // Check transcription service health (non-blocking)
+          try {
+            const healthResp = await fetch(`${TRANSCRIPTION_URL}/health`, {
+              signal: AbortSignal.timeout(3000),
+            });
+            if (healthResp.ok) {
+              logger.info('Transcription service is reachable');
+            } else {
+              logger.warn('Transcription service returned non-OK status');
+            }
+          } catch {
+            logger.warn('Transcription service is not reachable — voice messages will use fallback');
+          }
+
+          resolve();
+        },
+      });
+    });
+  }
+
+  async sendMessage(jid: string, text: string): Promise<void> {
+    if (!this.bot) {
+      logger.warn('Telegram bot not initialized');
+      return;
+    }
+
+    try {
+      const numericId = jid.replace(/^tg:/, '');
+
+      // Telegram has a 4096 character limit per message — split if needed
+      const MAX_LENGTH = 4096;
+      if (text.length <= MAX_LENGTH) {
+        await sendTelegramMessage(this.bot.api, numericId, text);
+      } else {
+        for (let i = 0; i < text.length; i += MAX_LENGTH) {
+          await sendTelegramMessage(
+            this.bot.api,
+            numericId,
+            text.slice(i, i + MAX_LENGTH),
+          );
+        }
+      }
+      logger.info({ jid, length: text.length }, 'Telegram message sent');
+    } catch (err) {
+      logger.error({ jid, err }, 'Failed to send Telegram message');
+    }
+  }
+
+  isConnected(): boolean {
+    return this.bot !== null;
+  }
+
+  ownsJid(jid: string): boolean {
+    return jid.startsWith('tg:');
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.bot) {
+      this.bot.stop();
+      this.bot = null;
+      logger.info('Telegram bot stopped');
+    }
+  }
+
+  async setTyping(jid: string, isTyping: boolean): Promise<void> {
+    if (!this.bot || !isTyping) return;
+    try {
+      const numericId = jid.replace(/^tg:/, '');
+      await this.bot.api.sendChatAction(numericId, 'typing');
+    } catch (err) {
+      logger.debug({ jid, err }, 'Failed to send Telegram typing indicator');
+    }
+  }
+}
+
+registerChannel('telegram', (opts: ChannelOpts) => {
+  const envVars = readEnvFile(['TELEGRAM_BOT_TOKEN']);
+  const token =
+    process.env.TELEGRAM_BOT_TOKEN || envVars.TELEGRAM_BOT_TOKEN || '';
+  if (!token) {
+    logger.warn('Telegram: TELEGRAM_BOT_TOKEN not set');
+    return null;
+  }
+  return new TelegramChannel(token, opts);
+});

--- a/.claude/skills/add-telegram-voice-transcription/modify/src/channels/telegram.ts.intent.md
+++ b/.claude/skills/add-telegram-voice-transcription/modify/src/channels/telegram.ts.intent.md
@@ -1,0 +1,58 @@
+# Intent: src/channels/telegram.ts modifications
+
+## What changed
+
+Added voice message transcription support using a local Whisper transcription service.
+
+## Key sections
+
+### TRANSCRIPTION_URL constant
+- Added after the imports, before the `sendTelegramMessage` function
+- Reads from `process.env.TRANSCRIPTION_URL`, defaults to `http://localhost:8765`
+
+### transcribeVoice() helper function
+- Added as a module-level async function, before the `TelegramChannel` class
+- Takes a `Buffer` and `filename`, returns `string | null`
+- Constructs a multipart/form-data request manually (no external dependencies)
+- Posts to `${TRANSCRIPTION_URL}/api/transcribe-sync`
+- 2-minute timeout via `AbortSignal.timeout(120_000)`
+- Returns trimmed transcript text on success, `null` on any failure
+- Logs warnings on failure but never throws
+
+### Voice message handler replacement
+- Replaced: `this.bot.on('message:voice', (ctx) => storeNonText(ctx, '[Voice message]'));`
+- New handler follows the same pattern as the `message:photo` handler:
+  1. Extracts thread/topic ID and chat JID
+  2. Checks for registered group (returns early if not registered)
+  3. Downloads voice file from Telegram API using `ctx.api.getFile()` + fetch
+  4. Calls `transcribeVoice()` with the downloaded buffer
+  5. Formats content as `[Voice message]: <transcript>` on success
+  6. Falls back to `[Voice message -- transcription unavailable]` on failure
+  7. Stores via `onChatMetadata` and `onMessage` (same as photo handler)
+  8. Logs result with `transcribed` boolean
+
+### Health check in connect()
+- Added inside the `onStart` callback, just before `resolve()`
+- Fetches `${TRANSCRIPTION_URL}/health` with 3-second timeout
+- Logs info on success, warns on failure
+- Non-blocking: does not prevent bot from starting
+
+## Invariants
+
+- All existing message handlers are preserved unchanged (text, photo, video, audio, document, sticker, location, contact)
+- The `storeNonText` helper function is preserved unchanged
+- Bot commands registration (`setMyCommands`) is preserved unchanged
+- All existing imports are preserved
+- The `sendTelegramMessage`, `initBotPool`, `sendPoolMessage` functions are unchanged
+- The `TelegramChannel` class interface is unchanged (same constructor, same methods)
+- The `registerChannel` call at the bottom is unchanged
+
+## Must-keep
+
+- All existing `this.bot.on(...)` handlers
+- The `storeNonText` helper and all its callers
+- The `onStart` callback structure including bot commands registration
+- The `sendTelegramMessage` markdown-with-fallback function
+- The bot pool functions (`initBotPool`, `sendPoolMessage`)
+- All class methods (`sendMessage`, `sendImage`, `isConnected`, `ownsJid`, `disconnect`, `setTyping`, `sendDraft`)
+- The `registerChannel` factory at the bottom of the file

--- a/.claude/skills/add-telegram-voice-transcription/tests/telegram-voice-transcription.test.ts
+++ b/.claude/skills/add-telegram-voice-transcription/tests/telegram-voice-transcription.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const SKILL_DIR = path.resolve(__dirname, '..');
+
+describe('add-telegram-voice-transcription skill', () => {
+  describe('SKILL.md', () => {
+    it('exists', () => {
+      expect(fs.existsSync(path.join(SKILL_DIR, 'SKILL.md'))).toBe(true);
+    });
+
+    it('has correct frontmatter', () => {
+      const content = fs.readFileSync(path.join(SKILL_DIR, 'SKILL.md'), 'utf8');
+      expect(content).toMatch(/^---/);
+      expect(content).toContain('name: add-telegram-voice-transcription');
+      expect(content).toContain('description:');
+    });
+  });
+
+  describe('manifest.yaml', () => {
+    it('exists', () => {
+      expect(fs.existsSync(path.join(SKILL_DIR, 'manifest.yaml'))).toBe(true);
+    });
+
+    it('has correct skill name', () => {
+      const content = fs.readFileSync(path.join(SKILL_DIR, 'manifest.yaml'), 'utf8');
+      expect(content).toContain('skill: add-telegram-voice-transcription');
+    });
+
+    it('lists telegram.ts as modified', () => {
+      const content = fs.readFileSync(path.join(SKILL_DIR, 'manifest.yaml'), 'utf8');
+      expect(content).toContain('src/channels/telegram.ts');
+    });
+
+    it('lists TRANSCRIPTION_URL as env addition', () => {
+      const content = fs.readFileSync(path.join(SKILL_DIR, 'manifest.yaml'), 'utf8');
+      expect(content).toContain('TRANSCRIPTION_URL');
+    });
+
+    it('depends on add-telegram', () => {
+      const content = fs.readFileSync(path.join(SKILL_DIR, 'manifest.yaml'), 'utf8');
+      expect(content).toContain('add-telegram');
+    });
+  });
+
+  describe('modify/src/channels/telegram.ts', () => {
+    const modifiedPath = path.join(SKILL_DIR, 'modify', 'src', 'channels', 'telegram.ts');
+
+    it('exists', () => {
+      expect(fs.existsSync(modifiedPath)).toBe(true);
+    });
+
+    const content = fs.readFileSync(
+      path.join(SKILL_DIR, 'modify', 'src', 'channels', 'telegram.ts'),
+      'utf8',
+    );
+
+    it('contains TRANSCRIPTION_URL constant', () => {
+      expect(content).toContain('const TRANSCRIPTION_URL');
+      expect(content).toContain("process.env.TRANSCRIPTION_URL || 'http://localhost:8765'");
+    });
+
+    it('contains transcribeVoice function', () => {
+      expect(content).toContain('async function transcribeVoice(');
+      expect(content).toContain('fileBuffer: Buffer');
+      expect(content).toContain('/api/transcribe-sync');
+    });
+
+    it('contains voice handler with transcription logic', () => {
+      expect(content).toContain("this.bot.on('message:voice', async (ctx)");
+      expect(content).toContain('await transcribeVoice(buffer');
+      expect(content).toContain('[Voice message]:');
+      expect(content).toContain('transcription unavailable');
+    });
+
+    it('contains health check logic', () => {
+      expect(content).toContain('Transcription service is reachable');
+      expect(content).toContain(`\${TRANSCRIPTION_URL}/health`);
+      expect(content).toContain('AbortSignal.timeout(3000)');
+    });
+
+    it('preserves message:text handler', () => {
+      expect(content).toContain("this.bot.on('message:text'");
+    });
+
+    it('preserves message:photo handler', () => {
+      expect(content).toContain("this.bot.on('message:photo'");
+    });
+
+    it('preserves message:video handler', () => {
+      expect(content).toContain("this.bot.on('message:video'");
+    });
+
+    it('preserves message:audio handler', () => {
+      expect(content).toContain("this.bot.on('message:audio'");
+    });
+
+    it('preserves message:document handler', () => {
+      expect(content).toContain("this.bot.on('message:document'");
+    });
+
+    it('preserves message:sticker handler', () => {
+      expect(content).toContain("this.bot.on('message:sticker'");
+    });
+
+    it('preserves message:location handler', () => {
+      expect(content).toContain("this.bot.on('message:location'");
+    });
+
+    it('preserves message:contact handler', () => {
+      expect(content).toContain("this.bot.on('message:contact'");
+    });
+
+    it('preserves storeNonText helper', () => {
+      expect(content).toContain('const storeNonText');
+    });
+
+    it('preserves sendTelegramMessage function', () => {
+      expect(content).toContain('async function sendTelegramMessage(');
+    });
+
+    it('preserves registerChannel call', () => {
+      expect(content).toContain("registerChannel('telegram'");
+    });
+  });
+
+  describe('intent file', () => {
+    it('exists for modified telegram.ts', () => {
+      expect(
+        fs.existsSync(
+          path.join(SKILL_DIR, 'modify', 'src', 'channels', 'telegram.ts.intent.md'),
+        ),
+      ).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds voice message transcription to the Telegram channel using a local Whisper transcription service
- When a voice message arrives, downloads the OGG from Telegram, POSTs to a local transcription service, and delivers `[Voice message]: <transcript>` to the agent
- Graceful fallback to `[Voice message — transcription unavailable]` when service is unreachable
- Non-blocking health check on startup (logs warning if service is down)

## Transcription service

Uses [local_video_transcriber](https://github.com/Jimbo1167/local_video_transcriber) — runs faster-whisper locally. Setup is `git clone` + `docker compose up` (or run directly with Python). No API keys needed, no cloud dependencies. The Whisper model downloads automatically on first run.

Any service implementing `POST /api/transcribe-sync` (multipart form, returns `{"text": "..."}`) and `GET /health` will work.

## Skill type

Code modification — modifies `src/channels/telegram.ts` (depends on `add-telegram`)

## Testing

- [x] Skill tests pass (24/24)
- [x] Build passes after apply on clean upstream + add-telegram
- [x] Manual QA: voice messages transcribed successfully via Telegram
- [x] Graceful degradation verified: service down → fallback message, no crash

## Dependencies

- Depends on: `add-telegram`

## New environment variables

- `TRANSCRIPTION_URL` (optional, defaults to `http://localhost:8765`)

## New npm packages

None