### PR TITLE
feat: add block-no-verify PreToolUse hook to prevent git hook bypass

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,1 +1,15 @@
-{}
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx block-no-verify@1.1.2"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

Adds `block-no-verify@1.1.2` as a PreToolUse Bash hook in `.claude/settings.json` to prevent Claude agents from bypassing git hooks via the hook-skip flag.

NanoClaw runs agents in isolated containers — this adds a complementary layer of enforcement inside the container: agents cannot silently skip pre-commit, commit-msg, or pre-push hooks.

The change is minimal: `.claude/settings.json` goes from `{}` to a single PreToolUse hook entry running `npx block-no-verify@1.1.2`. No source code changes, no new dependencies.

Closes #1270

---

_Disclosure: I am the author and maintainer of `block-no-verify`._
