### PR TITLE
feat: add CS rankings skill (csrankings-query)

### DIFF
--- a/.claude/skills/add-cs-rankings/SKILL.md
+++ b/.claude/skills/add-cs-rankings/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: add-cs-rankings
+description: Add CS university rankings lookup to NanoClaw agents. Queries CSRankings.org for publication metrics by conference, country, and institution.
+---
+
+# Add CS Rankings
+
+Adds the `csrankings-query` CLI tool to all container agents, allowing them to look up computer science university rankings from [CSRankings.org](https://csrankings.org/). The tool supports filtering by conference, country, and output format (plain text or JSON). Cache persists between container restarts.
+
+## Phase 1: Pre-flight
+
+1. Check if `container/skills/cs-rankings/SKILL.md` exists — if yes, skip to Phase 3.
+2. Verify the container build toolchain works: `./container/build.sh` should be executable.
+
+## Phase 2: Apply Code Changes
+
+The changes are made directly (no branch merge required). The following files are modified:
+
+- `container/skills/cs-rankings/SKILL.md` — agent-facing skill documentation
+- `container/Dockerfile` — adds Python, uv, and csrankings-query installation
+- `src/container-runner.ts` — adds persistent cache mount for CSRankings data
+
+### Validate
+
+```bash
+npm run build
+```
+
+### Rebuild container
+
+```bash
+./container/build.sh
+```
+
+### Restart service
+
+```bash
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw  # macOS
+# Linux: systemctl --user restart nanoclaw
+```
+
+## Phase 3: Verify
+
+### Test the tool
+
+Ask the agent a question like:
+> "How does Stanford rank in NeurIPS and ICML publications?"
+
+The agent should use `csrankings-query` to look up the data and respond with publication counts.
+
+### Check cache persistence
+
+After the first query, the CSRankings data is cached in `data/csrankings-cache/`. Subsequent queries within 24 hours use cached data without network requests.
+
+## Troubleshooting
+
+### Agent says csrankings-query command not found
+
+Container needs rebuilding. Run `./container/build.sh` and restart the service.
+
+### Network errors fetching CSRankings data
+
+The tool fetches data from GitHub (CSRankings repository). If the container has no network access, the tool falls back to stale cache if available. Use `--refresh` to force a fresh fetch.
+
+### Cache not persisting
+
+Verify the mount exists: check that `data/csrankings-cache/` is created on the host and mounted to `/home/node/.cache/csrankings/` in the container.

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -24,6 +24,8 @@ RUN apt-get update && apt-get install -y \
     libxshmfence1 \
     curl \
     git \
+    python3 \
+    python3-venv \
     && rm -rf /var/lib/apt/lists/*
 
 # Set Chromium path for agent-browser
@@ -47,6 +49,12 @@ COPY agent-runner/ ./
 
 # Build TypeScript
 RUN npm run build
+
+# Install csrankings-query CLI via uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+ENV UV_TOOL_DIR=/usr/local/share/uv-tools
+ENV UV_TOOL_BIN_DIR=/usr/local/bin
+RUN uv tool install --from 'git+https://github.com/vzaliva/CSRankings-query' csrankings-query
 
 # Create workspace directories
 RUN mkdir -p /workspace/group /workspace/global /workspace/extra /workspace/ipc/messages /workspace/ipc/tasks /workspace/ipc/input

--- a/container/skills/cs-rankings/SKILL.md
+++ b/container/skills/cs-rankings/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: cs-rankings
+description: Query computer science university rankings from CSRankings.org — publication counts, global rank, by conference and country. Use whenever the user asks about CS university rankings, publication metrics, or academic conference standings.
+allowed-tools: Bash(csrankings-query:*)
+---
+
+# CS Rankings Query
+
+## Quick start
+
+```bash
+csrankings-query "Stanford" --conferences=NeurIPS,ICML,ICLR
+csrankings-query "MIT" --conferences=POPL,PLDI --json
+csrankings-query "ETH Zurich" --conferences=ICML,NeurIPS --country=CH
+```
+
+## Usage
+
+```
+csrankings-query <university_name> --conferences=<CONF1,CONF2,...> [options]
+```
+
+### Required arguments
+
+| Argument | Description |
+|----------|-------------|
+| `university_name` | Free-text name (fuzzy-matched against CSRankings database) |
+| `--conferences` | Comma-separated conference shorthands (e.g., `NeurIPS,ICML,ICLR,POPL`) |
+
+### Optional arguments
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--json` | flag | off | Output JSON instead of plain text |
+| `--country` | string | all | Filter by country (ISO alpha-2 code or name, e.g., `US`, `CH`, `Germany`) |
+| `--max-matches` | integer | unlimited | Fail if more than N institutions match (ambiguity guard) |
+| `--threshold` | float | 50 | Minimum fuzzy match score (0-100) |
+| `--refresh` | flag | off | Bypass cache, fetch fresh data from CSRankings |
+
+## Examples
+
+### Basic lookup
+
+```bash
+csrankings-query "Carnegie Mellon" --conferences=NeurIPS,ICML,ICLR
+```
+
+### JSON output for structured processing
+
+```bash
+csrankings-query "Berkeley" --conferences=ICML,NeurIPS --json
+```
+
+### Filter by country
+
+```bash
+csrankings-query "Technical University" --conferences=ICML,NeurIPS --country=DE
+```
+
+### Strict matching (fail if ambiguous)
+
+```bash
+csrankings-query "MIT" --conferences=POPL --max-matches=1
+```
+
+### Force fresh data
+
+```bash
+csrankings-query "Stanford" --conferences=NeurIPS --refresh
+```
+
+## Common conference shorthands
+
+### AI / Machine Learning
+`NeurIPS`, `ICML`, `ICLR`, `AAAI`, `IJCAI`
+
+### Systems
+`SOSP`, `OSDI`, `NSDI`, `EuroSys`, `ASPLOS`
+
+### Programming Languages
+`POPL`, `PLDI`, `OOPSLA`, `ICFP`
+
+### Security
+`CCS`, `Oakland` (IEEE S&P), `USENIX Security`, `NDSS`
+
+### Databases
+`SIGMOD`, `VLDB`, `ICDE`
+
+### Theory
+`STOC`, `FOCS`
+
+### Networking
+`SIGCOMM`, `NSDI`, `IMC`
+
+### HCI
+`CHI`, `UIST`
+
+### Computer Vision
+`CVPR`, `ICCV`, `ECCV`
+
+### NLP
+`ACL`, `EMNLP`, `NAACL`
+
+## Notes
+
+- **Always cite the source**: mention that rankings are from [CSRankings.org](https://csrankings.org/) in your response.
+- **Always use `--max-matches=5`** to catch ambiguous matches. The tool fuzzy-matches university names, so short or common queries (e.g., "MIT", "Technical University") may match multiple institutions. With `--max-matches=5`, the tool returns up to 5 matches — review them and clarify with the user if the intended institution is ambiguous.
+- Results show publication counts adjusted by author count (fractional counting).
+- The tool caches data for 24 hours. Use `--refresh` to force fresh data.
+- Low-confidence matches (score < 80) produce a warning.

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -163,6 +163,15 @@ function buildVolumeMounts(
     readonly: false,
   });
 
+  // Shared CSRankings cache (public data, safe to share across groups)
+  const csrankingsCacheDir = path.join(DATA_DIR, 'csrankings-cache');
+  fs.mkdirSync(csrankingsCacheDir, { recursive: true });
+  mounts.push({
+    hostPath: csrankingsCacheDir,
+    containerPath: '/home/node/.cache/csrankings',
+    readonly: false,
+  });
+
   // Per-group IPC namespace: each group gets its own IPC directory
   // This prevents cross-group privilege escalation via IPC
   const groupIpcDir = resolveGroupIpcPath(group.folder);


### PR DESCRIPTION
Add container agent skill to query university CS publication rankings from CSRankings.org. Installs csrankings-query via uv in the container image, with persistent cache mount across container restarts.

## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description


## For Skills

- [ X] I have not made any changes to source code
- [ X] My skill contains instructions for Claude to follow (not pre-built code)
- [ ] I tested this skill on a fresh clone
