### PR TITLE
fix: always sync agent-runner source on container spawn

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -190,7 +190,10 @@ function buildVolumeMounts(
     group.folder,
     'agent-runner-src',
   );
-  if (!fs.existsSync(groupAgentRunnerDir) && fs.existsSync(agentRunnerSrc)) {
+  // Always re-sync so upstream agent-runner changes (new IPC tools, fixes)
+  // propagate to per-group copies. Groups can still customize files —
+  // but upstream changes take precedence on each container spawn.
+  if (fs.existsSync(agentRunnerSrc)) {
     fs.cpSync(agentRunnerSrc, groupAgentRunnerDir, { recursive: true });
   }
   mounts.push({


### PR DESCRIPTION


<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Previously, agent-runner source was only copied to per-group directories on first run. Updates to agent-runner (new IPC tools, bug fixes) never propagated to existing groups until their agent-runner-src/ was manually deleted.

Now copies on every spawn so upstream changes take effect immediately.

## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
