### PR TITLE
fix: check slash commands before IPC drain in agent-runner

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -494,6 +494,13 @@ async function main(): Promise<void> {
   // Clean up stale _close sentinel from previous container runs
   try { fs.unlinkSync(IPC_INPUT_CLOSE_SENTINEL); } catch { /* ignore */ }
 
+  // --- Slash command handling ---
+  // Check BEFORE draining IPC or prepending task headers, so pending
+  // messages don't pollute the prompt and break the exact match.
+  const KNOWN_SESSION_COMMANDS = new Set(['/compact']);
+  const trimmedPrompt = containerInput.prompt.trim();
+  const isSessionSlashCommand = KNOWN_SESSION_COMMANDS.has(trimmedPrompt);
+
   // Build initial prompt (drain any pending IPC messages too)
   let prompt = containerInput.prompt;
   if (containerInput.isScheduledTask) {
@@ -504,13 +511,6 @@ async function main(): Promise<void> {
     log(`Draining ${pending.length} pending IPC messages into initial prompt`);
     prompt += '\n' + pending.join('\n');
   }
-
-  // --- Slash command handling ---
-  // Only known session slash commands are handled here. This prevents
-  // accidental interception of user prompts that happen to start with '/'.
-  const KNOWN_SESSION_COMMANDS = new Set(['/compact']);
-  const trimmedPrompt = prompt.trim();
-  const isSessionSlashCommand = KNOWN_SESSION_COMMANDS.has(trimmedPrompt);
 
   if (isSessionSlashCommand) {
     log(`Handling session command: ${trimmedPrompt}`);


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

Slash command detection (e.g. ⁠ /compact ⁠) runs after ⁠ drainIpcInput() ⁠ appends pending IPC messages to the prompt. This breaks the exact match against ⁠ KNOWN_SESSION_COMMANDS ⁠ when there are queued messages.

Fix: move the slash command check before the IPC drain and scheduled task header, using ⁠ containerInput.prompt ⁠ (the raw prompt) instead of the modified ⁠ prompt ⁠.