### PR TITLE
fix(apple-container): three runtime bugs that break first-time setup

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -76,17 +76,6 @@ function buildVolumeMounts(
       readonly: true,
     });
 
-    // Shadow .env so the agent cannot read secrets from the mounted project root.
-    // Credentials are injected by the credential proxy, never exposed to containers.
-    const envFile = path.join(projectRoot, '.env');
-    if (fs.existsSync(envFile)) {
-      mounts.push({
-        hostPath: '/dev/null',
-        containerPath: '/workspace/project/.env',
-        readonly: true,
-      });
-    }
-
     // Main also gets its group folder as the working directory
     mounts.push({
       hostPath: groupDir,

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -12,10 +12,12 @@ import { logger } from './logger.js';
 export const CONTAINER_RUNTIME_BIN = 'container';
 
 /** Hostname containers use to reach the host machine. */
-export const CONTAINER_HOST_GATEWAY = 'host.docker.internal';
+export const CONTAINER_HOST_GATEWAY =
+  process.env.CONTAINER_HOST_GATEWAY || detectHostGateway();
 
 /**
  * Address the credential proxy binds to.
+ * Apple Container (macOS): bind to bridge100 IP (192.168.64.1) — containers route through it.
  * Docker Desktop (macOS): 127.0.0.1 — the VM routes host.docker.internal to loopback.
  * Docker (Linux): bind to the docker0 bridge IP so only containers can reach it,
  *   falling back to 0.0.0.0 if the interface isn't found.
@@ -23,8 +25,35 @@ export const CONTAINER_HOST_GATEWAY = 'host.docker.internal';
 export const PROXY_BIND_HOST =
   process.env.CREDENTIAL_PROXY_HOST || detectProxyBindHost();
 
+function getAppleContainerBridgeIP(): string | undefined {
+  const ifaces = os.networkInterfaces();
+  const bridge100 = ifaces['bridge100'];
+  if (bridge100) {
+    const ipv4 = bridge100.find((a) => a.family === 'IPv4');
+    if (ipv4) return ipv4.address;
+  }
+  return undefined;
+}
+
+function detectHostGateway(): string {
+  if (os.platform() === 'darwin') {
+    // Apple Container: host is reachable at the bridge100 IP from inside the VM
+    const bridge = getAppleContainerBridgeIP();
+    if (bridge) return bridge;
+    // Docker Desktop: host.docker.internal is injected into /etc/hosts automatically
+    return 'host.docker.internal';
+  }
+  return 'host.docker.internal';
+}
+
 function detectProxyBindHost(): string {
-  if (os.platform() === 'darwin') return '127.0.0.1';
+  if (os.platform() === 'darwin') {
+    // Apple Container: bind to bridge100 so containers can reach the proxy
+    const bridge = getAppleContainerBridgeIP();
+    if (bridge) return bridge;
+    // Docker Desktop: loopback is sufficient (host.docker.internal routes there)
+    return '127.0.0.1';
+  }
 
   // WSL uses Docker Desktop (same VM routing as macOS) — loopback is correct.
   // Check /proc filesystem, not env vars — WSL_DISTRO_NAME isn't set under systemd.


### PR DESCRIPTION
## Summary

Found and fixed three bugs in the `skill/apple-container` branch that cause setup to fail completely on a fresh macOS install.

- **Remove `/dev/null` host mount** from `container-runner.ts` — Apple Container (VirtioFS) only supports directory mounts, not file/device mounts. Every container start crashed with `path '/dev/null' is not a directory`. The Dockerfile entrypoint already handles `.env` shadowing inside the VM via `mount --bind` (running as root), so this host-side mount is redundant.
- **Fix `CONTAINER_HOST_GATEWAY`** — `host.docker.internal` is a Docker-specific hostname that Apple Container VMs don't have in `/etc/hosts`. The host is at the `bridge100` interface IP (`192.168.64.1`). Now auto-detected; falls back to `host.docker.internal` for Docker Desktop.
- **Fix `PROXY_BIND_HOST`** — The credential proxy was binding to `127.0.0.1`, which isn't reachable from Apple Container VMs on `192.168.64.0/24`. Now binds to the `bridge100` IP when present; falls back to `127.0.0.1` for Docker Desktop.

## Test plan

- [x] Fresh macOS setup with Apple Container — all three issues reproduced without this fix, resolved with it
- [x] Container starts successfully, `.env` is hidden from agent (verified `mount --bind` works inside VM)
- [x] Credential proxy reachable from inside container at `192.168.64.1:3001`
- [x] Build clean, existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)