### PR TITLE
feat: add write-protected system-prompt.md layer for every agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ groups/global/*
 .nanoclaw/
 
 agents-sdk-docs
+system-prompt.md

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -20,6 +20,34 @@ import { execFile } from 'child_process';
 import { query, HookCallback, PreCompactHookInput } from '@anthropic-ai/claude-agent-sdk';
 import { fileURLToPath } from 'url';
 
+/**
+ * Path where the host mounts system-prompt.md read-only inside the container.
+ *
+ * The file lives at the project root on the host (system-prompt.md) and is
+ * mounted read-only by container-runner.ts so agents have NO write access.
+ * Only the user (on the host) can change it. Its contents are prepended to
+ * every agent invocation's system prompt, for every group without exception.
+ */
+const SYSTEM_PROMPT_PATH = '/workspace/system-prompt.md';
+
+/**
+ * Read the user-controlled system prompt from the write-protected mount.
+ * Returns the file contents, or an empty string if the file is absent
+ * (so the system still works without the file, e.g. in tests).
+ */
+function readSystemPrompt(): string {
+  try {
+    if (fs.existsSync(SYSTEM_PROMPT_PATH)) {
+      return fs.readFileSync(SYSTEM_PROMPT_PATH, 'utf-8').trim();
+    }
+  } catch (err) {
+    console.error(
+      `[agent-runner] Failed to read system prompt: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  return '';
+}
+
 interface ContainerInput {
   prompt: string;
   sessionId?: string;
@@ -375,6 +403,13 @@ async function runQuery(
     globalClaudeMd = fs.readFileSync(globalClaudeMdPath, 'utf-8');
   }
 
+  // Build system prompt: the write-protected system-prompt.md always comes first
+  // (for every group including main), then the global CLAUDE.md for non-main groups.
+  // system-prompt.md is mounted read-only — agents cannot change it.
+  const systemPromptText = readSystemPrompt();
+  const parts = [systemPromptText, globalClaudeMd].filter(Boolean);
+  const systemPromptAppend = parts.join('\n\n') || undefined;
+
   // Discover additional directories mounted at /workspace/extra/*
   // These are passed to the SDK so their CLAUDE.md files are loaded automatically
   const extraDirs: string[] = [];
@@ -398,8 +433,8 @@ async function runQuery(
       additionalDirectories: extraDirs.length > 0 ? extraDirs : undefined,
       resume: sessionId,
       resumeSessionAt: resumeAt,
-      systemPrompt: globalClaudeMd
-        ? { type: 'preset' as const, preset: 'claude_code' as const, append: globalClaudeMd }
+      systemPrompt: systemPromptAppend
+        ? { type: 'preset' as const, preset: 'claude_code' as const, append: systemPromptAppend }
         : undefined,
       allowedTools: [
         'Bash',

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -220,6 +220,19 @@ function buildVolumeMounts(
     mounts.push(...validatedMounts);
   }
 
+  // System prompt file — always mounted read-only so agents cannot modify it.
+  // Only the user (on the host) can change its contents.
+  // The agent runner reads it at /workspace/system-prompt.md and prepends it
+  // to every invocation's system prompt.
+  const systemPromptFile = path.join(projectRoot, 'system-prompt.md');
+  if (fs.existsSync(systemPromptFile)) {
+    mounts.push({
+      hostPath: systemPromptFile,
+      containerPath: '/workspace/system-prompt.md',
+      readonly: true,
+    });
+  }
+
   return mounts;
 }
 

--- a/system-prompt.example.md
+++ b/system-prompt.example.md
@@ -1,0 +1,16 @@
+# System Prompt
+
+This file is mounted **read-only** inside every agent container at `/workspace/system-prompt.md`.
+Its contents are always prepended to every agent's system prompt, for every group, without exception.
+
+**Only the user can edit this file.** Agents have no write access to it — it is mounted read-only.
+Do not ask an agent to modify this file; make changes directly on the host.
+
+---
+
+Add your custom instructions below. Examples:
+
+- Ethical guidelines or constraints
+- Organization-specific rules
+- Default persona or tone
+- Always-on context the agent should be aware of


### PR DESCRIPTION
Introduces a user-controlled system-prompt.md that is prepended to the system prompt of every agent invocation, for every group, without exception.

How it works:
- `system-prompt.md` lives at the project root (gitignored — user-local)
- `container-runner.ts` mounts it read-only into containers at `/workspace/system-prompt.md`, so agents have no write access
- `agent-runner/src/index.ts` reads the file and prepends it before the group's CLAUDE.md in the systemPrompt.append field

This is an opt-in feature: if `system-prompt.md` is absent the system behaves exactly as before. A `system-prompt.example.md` template is included to help users get started.

Motivation: users may want to enforce immutable ethical guidelines, org-wide rules, or a default persona across all agents without having to add them to every group's CLAUDE.md.

<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description


## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
