### PR TITLE
Add pre-hook gate for scheduled tasks

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -7,6 +7,7 @@ import { isValidGroupFolder } from './group-folder.js';
 import { logger } from './logger.js';
 import {
   NewMessage,
+  PreHook,
   RegisteredGroup,
   ScheduledTask,
   TaskRunLog,
@@ -138,6 +139,15 @@ function createSchema(database: Database.Database): void {
     );
   } catch {
     /* columns already exist */
+  }
+
+  // Add pre_hook column if it doesn't exist (migration for existing DBs)
+  try {
+    database.exec(
+      `ALTER TABLE scheduled_tasks ADD COLUMN pre_hook TEXT`,
+    );
+  } catch {
+    /* column already exists */
   }
 }
 
@@ -363,13 +373,20 @@ export function getMessagesSince(
     .all(chatJid, sinceTimestamp, `${botPrefix}:%`, limit) as NewMessage[];
 }
 
+function parseTaskRow(row: any): ScheduledTask {
+  return {
+    ...row,
+    pre_hook: row.pre_hook ? (JSON.parse(row.pre_hook) as PreHook) : undefined,
+  };
+}
+
 export function createTask(
   task: Omit<ScheduledTask, 'last_run' | 'last_result'>,
 ): void {
   db.prepare(
     `
-    INSERT INTO scheduled_tasks (id, group_folder, chat_jid, prompt, schedule_type, schedule_value, context_mode, next_run, status, created_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO scheduled_tasks (id, group_folder, chat_jid, prompt, schedule_type, schedule_value, context_mode, pre_hook, next_run, status, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `,
   ).run(
     task.id,
@@ -379,6 +396,7 @@ export function createTask(
     task.schedule_type,
     task.schedule_value,
     task.context_mode || 'isolated',
+    task.pre_hook ? JSON.stringify(task.pre_hook) : null,
     task.next_run,
     task.status,
     task.created_at,
@@ -386,23 +404,26 @@ export function createTask(
 }
 
 export function getTaskById(id: string): ScheduledTask | undefined {
-  return db.prepare('SELECT * FROM scheduled_tasks WHERE id = ?').get(id) as
-    | ScheduledTask
-    | undefined;
+  const row = db
+    .prepare('SELECT * FROM scheduled_tasks WHERE id = ?')
+    .get(id) as any | undefined;
+  return row ? parseTaskRow(row) : undefined;
 }
 
 export function getTasksForGroup(groupFolder: string): ScheduledTask[] {
-  return db
+  const rows = db
     .prepare(
       'SELECT * FROM scheduled_tasks WHERE group_folder = ? ORDER BY created_at DESC',
     )
-    .all(groupFolder) as ScheduledTask[];
+    .all(groupFolder) as any[];
+  return rows.map(parseTaskRow);
 }
 
 export function getAllTasks(): ScheduledTask[] {
-  return db
+  const rows = db
     .prepare('SELECT * FROM scheduled_tasks ORDER BY created_at DESC')
-    .all() as ScheduledTask[];
+    .all() as any[];
+  return rows.map(parseTaskRow);
 }
 
 export function updateTask(
@@ -410,9 +431,13 @@ export function updateTask(
   updates: Partial<
     Pick<
       ScheduledTask,
-      'prompt' | 'schedule_type' | 'schedule_value' | 'next_run' | 'status'
+      | 'prompt'
+      | 'schedule_type'
+      | 'schedule_value'
+      | 'next_run'
+      | 'status'
     >
-  >,
+  > & { pre_hook?: ScheduledTask['pre_hook'] | null },
 ): void {
   const fields: string[] = [];
   const values: unknown[] = [];
@@ -437,6 +462,12 @@ export function updateTask(
     fields.push('status = ?');
     values.push(updates.status);
   }
+  if (updates.pre_hook !== undefined) {
+    fields.push('pre_hook = ?');
+    values.push(
+      updates.pre_hook ? JSON.stringify(updates.pre_hook) : null,
+    );
+  }
 
   if (fields.length === 0) return;
 
@@ -454,7 +485,7 @@ export function deleteTask(id: string): void {
 
 export function getDueTasks(): ScheduledTask[] {
   const now = new Date().toISOString();
-  return db
+  const rows = db
     .prepare(
       `
     SELECT * FROM scheduled_tasks
@@ -462,7 +493,8 @@ export function getDueTasks(): ScheduledTask[] {
     ORDER BY next_run
   `,
     )
-    .all(now) as ScheduledTask[];
+    .all(now) as any[];
+  return rows.map(parseTaskRow);
 }
 
 export function updateTaskAfterRun(

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -162,6 +162,7 @@ export async function processTaskIpc(
     schedule_type?: string;
     schedule_value?: string;
     context_mode?: string;
+    pre_hook?: { command: string; timeout_seconds?: number } | null;
     groupFolder?: string;
     chatJid?: string;
     targetJid?: string;
@@ -255,6 +256,28 @@ export async function processTaskIpc(
           data.context_mode === 'group' || data.context_mode === 'isolated'
             ? data.context_mode
             : 'isolated';
+
+        // Validate and normalize pre_hook if provided
+        let preHook: { command: string; timeout_seconds?: number } | undefined;
+        if (data.pre_hook) {
+          if (
+            typeof data.pre_hook.command !== 'string' ||
+            !data.pre_hook.command.trim()
+          ) {
+            logger.warn(
+              { taskId, pre_hook: data.pre_hook },
+              'Invalid pre_hook: command must be a non-empty string',
+            );
+            break;
+          }
+          preHook = {
+            command: data.pre_hook.command.trim(),
+            timeout_seconds: data.pre_hook.timeout_seconds
+              ? Math.min(Math.max(1, data.pre_hook.timeout_seconds), 300)
+              : undefined,
+          };
+        }
+
         createTask({
           id: taskId,
           group_folder: targetFolder,
@@ -263,6 +286,7 @@ export async function processTaskIpc(
           schedule_type: scheduleType,
           schedule_value: data.schedule_value,
           context_mode: contextMode,
+          pre_hook: preHook,
           next_run: nextRun,
           status: 'active',
           created_at: new Date().toISOString(),
@@ -359,6 +383,21 @@ export async function processTaskIpc(
             | 'once';
         if (data.schedule_value !== undefined)
           updates.schedule_value = data.schedule_value;
+        if (data.pre_hook !== undefined) {
+          if (data.pre_hook === null) {
+            updates.pre_hook = null;
+          } else if (
+            typeof data.pre_hook.command === 'string' &&
+            data.pre_hook.command.trim()
+          ) {
+            updates.pre_hook = {
+              command: data.pre_hook.command.trim(),
+              timeout_seconds: data.pre_hook.timeout_seconds
+                ? Math.min(Math.max(1, data.pre_hook.timeout_seconds), 300)
+                : undefined,
+            };
+          }
+        }
 
         // Recompute next_run if schedule changed
         if (data.schedule_type || data.schedule_value) {

--- a/src/pre-hook.test.ts
+++ b/src/pre-hook.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { runPreHook } from './pre-hook.js';
+
+describe('runPreHook', () => {
+  it('exit 0 returns proceed', async () => {
+    const result = await runPreHook({ command: 'exit 0' });
+    expect(result.action).toBe('proceed');
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('exit 10 returns skip', async () => {
+    const result = await runPreHook({ command: 'exit 10' });
+    expect(result.action).toBe('skip');
+    expect(result.exitCode).toBe(10);
+  });
+
+  it('exit 1 returns error', async () => {
+    const result = await runPreHook({ command: 'exit 1' });
+    expect(result.action).toBe('error');
+    expect(result.exitCode).toBe(1);
+  });
+
+  it('exit 42 returns error', async () => {
+    const result = await runPreHook({ command: 'exit 42' });
+    expect(result.action).toBe('error');
+    expect(result.exitCode).toBe(42);
+  });
+
+  it('captures stdout', async () => {
+    const result = await runPreHook({ command: 'echo hello' });
+    expect(result.action).toBe('proceed');
+    expect(result.stdout.trim()).toBe('hello');
+  });
+
+  it('captures stderr on error', async () => {
+    const result = await runPreHook({ command: 'echo err >&2; exit 1' });
+    expect(result.action).toBe('error');
+    expect(result.stderr.trim()).toBe('err');
+  });
+
+  it('returns error on timeout', async () => {
+    const result = await runPreHook({ command: 'sleep 10', timeout_seconds: 1 });
+    expect(result.action).toBe('error');
+    expect(result.exitCode).toBe(-1);
+    expect(result.stderr).toContain('timed out');
+  });
+
+  it('clamps timeout to 300s max', async () => {
+    // Just verify it doesn't throw — the 999s timeout is clamped to 300s
+    const result = await runPreHook({
+      command: 'exit 0',
+      timeout_seconds: 999,
+    });
+    expect(result.action).toBe('proceed');
+  });
+
+  it('tracks duration', async () => {
+    const result = await runPreHook({ command: 'exit 0' });
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/src/pre-hook.ts
+++ b/src/pre-hook.ts
@@ -1,0 +1,67 @@
+import { execFile } from 'child_process';
+
+import { PreHook } from './types.js';
+
+export interface PreHookResult {
+  action: 'proceed' | 'skip' | 'error';
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  durationMs: number;
+}
+
+const MAX_TIMEOUT_S = 300;
+const DEFAULT_TIMEOUT_S = 30;
+const MAX_BUFFER = 64 * 1024;
+
+export function runPreHook(hook: PreHook): Promise<PreHookResult> {
+  const timeoutMs =
+    Math.min(hook.timeout_seconds ?? DEFAULT_TIMEOUT_S, MAX_TIMEOUT_S) * 1000;
+  const start = Date.now();
+
+  return new Promise((resolve) => {
+    execFile(
+      '/bin/sh',
+      ['-c', hook.command],
+      { timeout: timeoutMs, maxBuffer: MAX_BUFFER, killSignal: 'SIGKILL' },
+      (error, stdout, stderr) => {
+        const durationMs = Date.now() - start;
+
+        if (!error) {
+          resolve({
+            action: 'proceed',
+            exitCode: 0,
+            stdout,
+            stderr,
+            durationMs,
+          });
+          return;
+        }
+
+        // Timeout — error.killed is true when the process was killed by timeout
+        if (error.killed) {
+          resolve({
+            action: 'error',
+            exitCode: -1,
+            stdout: stdout || '',
+            stderr: `preHook timed out after ${Math.ceil(timeoutMs / 1000)}s`,
+            durationMs,
+          });
+          return;
+        }
+
+        const err = error as Error & { code?: number | string };
+        const exitCode =
+          typeof err.code === 'number' ? err.code : 1;
+
+        resolve({
+          action: exitCode === 10 ? 'skip' : 'error',
+          exitCode,
+          stdout: stdout || '',
+          stderr: stderr || '',
+          durationMs,
+        });
+      },
+    );
+  });
+}

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -19,6 +19,7 @@ import {
 import { GroupQueue } from './group-queue.js';
 import { resolveGroupFolderPath } from './group-folder.js';
 import { logger } from './logger.js';
+import { runPreHook } from './pre-hook.js';
 import { RegisteredGroup, ScheduledTask } from './types.js';
 
 /**
@@ -127,6 +128,57 @@ async function runTask(
       error: `Group not found: ${task.group_folder}`,
     });
     return;
+  }
+
+  // Run preHook gate if configured
+  if (task.pre_hook) {
+    logger.info(
+      { taskId: task.id, command: task.pre_hook.command },
+      'Running preHook',
+    );
+    const hookResult = await runPreHook(task.pre_hook);
+    logger.info(
+      {
+        taskId: task.id,
+        action: hookResult.action,
+        exitCode: hookResult.exitCode,
+        durationMs: hookResult.durationMs,
+      },
+      'preHook completed',
+    );
+
+    if (hookResult.action === 'skip') {
+      logTaskRun({
+        task_id: task.id,
+        run_at: new Date().toISOString(),
+        duration_ms: hookResult.durationMs,
+        status: 'skipped',
+        result: `preHook skipped (exit 10): ${hookResult.stdout}`.slice(0, 500),
+        error: null,
+      });
+      const nextRun = computeNextRun(task);
+      updateTaskAfterRun(task.id, nextRun, 'Skipped by preHook');
+      return;
+    }
+
+    if (hookResult.action === 'error') {
+      const errorMsg =
+        `preHook failed (exit ${hookResult.exitCode}): ${hookResult.stderr || hookResult.stdout}`.slice(
+          0,
+          500,
+        );
+      logTaskRun({
+        task_id: task.id,
+        run_at: new Date().toISOString(),
+        duration_ms: hookResult.durationMs,
+        status: 'error',
+        result: null,
+        error: errorMsg,
+      });
+      const nextRun = computeNextRun(task);
+      updateTaskAfterRun(task.id, nextRun, `Error: ${errorMsg}`);
+      return;
+    }
   }
 
   // Update tasks snapshot for container to read (filtered by group)

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,11 @@ export interface NewMessage {
   is_bot_message?: boolean;
 }
 
+export interface PreHook {
+  command: string;
+  timeout_seconds?: number; // Default 30, max 300
+}
+
 export interface ScheduledTask {
   id: string;
   group_folder: string;
@@ -61,6 +66,7 @@ export interface ScheduledTask {
   schedule_type: 'cron' | 'interval' | 'once';
   schedule_value: string;
   context_mode: 'group' | 'isolated';
+  pre_hook?: PreHook;
   next_run: string | null;
   last_run: string | null;
   last_result: string | null;
@@ -72,7 +78,7 @@ export interface TaskRunLog {
   task_id: string;
   run_at: string;
   duration_ms: number;
-  status: 'success' | 'error';
+  status: 'success' | 'error' | 'skipped';
   result: string | null;
   error: string | null;
 }


### PR DESCRIPTION
## Summary

Closes #1348

Adds an optional `pre_hook` field to scheduled tasks that runs a shell command on the host before spawning the agent container. The hook's exit code determines whether to proceed, skip, or abort.

- **Exit 0** → proceed with agent execution
- **Exit 10** → skip (not counted as failure)
- **Any other** → error (counted as failure)

Inspired by [openclaw/openclaw#49415](https://github.com/openclaw/openclaw/pull/49415) / [#49370](https://github.com/openclaw/openclaw/issues/49370).

### Changes

- `src/types.ts`: New `PreHook` interface, added `pre_hook` to `ScheduledTask`, added `'skipped'` to `TaskRunLog.status`
- `src/pre-hook.ts`: New `runPreHook()` function using `execFile('/bin/sh', '-c')` with configurable timeout (default 30s, max 300s), stdout/stderr capture (64KB cap)
- `src/db.ts`: Column migration, JSON serialization/deserialization for `pre_hook`, updated CRUD functions
- `src/task-scheduler.ts`: PreHook gate in `runTask()` — runs after group validation, before container spawn; skip/error log properly and recurring tasks still get next_run computed
- `src/ipc.ts`: `schedule_task` and `update_task` handlers pass through `pre_hook` with validation (null clears)
- `src/pre-hook.test.ts`: 9 unit tests (exit 0/10/1/42, stdout/stderr capture, timeout, clamp, duration)

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test` passes (228 tests, 9 new)
- [ ] Manual: create task with `pre_hook: { command: "exit 0" }` → task runs normally
- [ ] Manual: create task with `pre_hook: { command: "exit 10" }` → task skipped, no error
- [ ] Manual: create task with `pre_hook: { command: "exit 1" }` → task errors