### PR TITLE
feat: add GitHub Copilot SDK as alternative AI backend

### DIFF
--- a/container/agent-runner/package-lock.json
+++ b/container/agent-runner/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.76",
+        "@github/copilot-sdk": "^0.2.0",
         "@modelcontextprotocol/sdk": "^1.12.1",
         "cron-parser": "^5.0.0",
         "zod": "^4.0.0"
@@ -39,6 +40,133 @@
       },
       "peerDependencies": {
         "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@github/copilot": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.10.tgz",
+      "integrity": "sha512-RpHYMXYpyAgQLYQ3MB8ubV8zMn/zDatwaNmdxcC8ws7jqM+Ojy7Dz4KFKzyT0rCrWoUCAEBXsXoPbP0LY0FgLw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "bin": {
+        "copilot": "npm-loader.js"
+      },
+      "optionalDependencies": {
+        "@github/copilot-darwin-arm64": "1.0.10",
+        "@github/copilot-darwin-x64": "1.0.10",
+        "@github/copilot-linux-arm64": "1.0.10",
+        "@github/copilot-linux-x64": "1.0.10",
+        "@github/copilot-win32-arm64": "1.0.10",
+        "@github/copilot-win32-x64": "1.0.10"
+      }
+    },
+    "node_modules/@github/copilot-darwin-arm64": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.10.tgz",
+      "integrity": "sha512-MNlzwkTQ9iUgHQ+2Z25D0KgYZDEl4riEa1Z4/UCNpHXmmBiIY8xVRbXZTNMB69cnagjQ5Z8D2QM2BjI0kqeFPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-darwin-x64": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.10.tgz",
+      "integrity": "sha512-zAQBCbEue/n4xHBzE9T03iuupVXvLtu24MDMeXXtIC0d4O+/WV6j1zVJrp9Snwr0MBWYH+wUrV74peDDdd1VOQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-arm64": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.10.tgz",
+      "integrity": "sha512-7mJ3uLe7ITyRi2feM1rMLQ5d0bmUGTUwV1ZxKZwSzWCYmuMn05pg4fhIUdxZZZMkLbOl3kG/1J7BxMCTdS2w7A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-x64": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.10.tgz",
+      "integrity": "sha512-66NPaxroRScNCs6TZGX3h1RSKtzew0tcHBkj4J1AHkgYLjNHMdjjBwokGtKeMxzYOCAMBbmJkUDdNGkqsKIKUA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-sdk": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.2.0.tgz",
+      "integrity": "sha512-fCEpD9W9xqcaCAJmatyNQ1PkET9P9liK2P4Vk0raDFoMXcvpIdqewa5JQeKtWCBUsN/HCz7ExkkFP8peQuo+DA==",
+      "license": "MIT",
+      "dependencies": {
+        "@github/copilot": "^1.0.10",
+        "vscode-jsonrpc": "^8.2.1",
+        "zod": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@github/copilot-win32-arm64": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.10.tgz",
+      "integrity": "sha512-WC5M+M75sxLn4lvZ1wPA1Lrs/vXFisPXJPCKbKOMKqzwMLX/IbuybTV4dZDIyGEN591YmOdRIylUF0tVwO8Zmw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-arm64": "copilot.exe"
+      }
+    },
+    "node_modules/@github/copilot-win32-x64": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.10.tgz",
+      "integrity": "sha512-tUfIwyamd0zpm9DVTtbjIWF6j3zrA5A5IkkiuRgsy0HRJPQpeAV7ZYaHEZteHrynaULpl1Gn/Dq0IB4hYc4QtQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-x64": "copilot.exe"
       }
     },
     "node_modules/@hono/node-server": {
@@ -1479,6 +1607,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
+      "integrity": "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/which": {

--- a/container/agent-runner/package.json
+++ b/container/agent-runner/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.76",
+    "@github/copilot-sdk": "^0.2.0",
     "@modelcontextprotocol/sdk": "^1.12.1",
     "cron-parser": "^5.0.0",
     "zod": "^4.0.0"

--- a/container/agent-runner/src/copilot-query.ts
+++ b/container/agent-runner/src/copilot-query.ts
@@ -1,0 +1,221 @@
+/**
+ * GitHub Copilot SDK query adapter for NanoClaw
+ *
+ * Provides a query interface compatible with the agent-runner's main loop,
+ * using the GitHub Copilot SDK instead of the Anthropic Claude Agent SDK.
+ *
+ * The Copilot SDK supports MCP servers, tools, session resumption, and streaming,
+ * enabling feature parity with the Claude integration.
+ */
+
+import {
+  CopilotClient,
+  approveAll,
+  type SessionEvent,
+  type SessionConfig,
+  type MCPServerConfig,
+} from '@github/copilot-sdk';
+import fs from 'fs';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface ContainerInput {
+  prompt: string;
+  sessionId?: string;
+  groupFolder: string;
+  chatJid: string;
+  isMain: boolean;
+  isScheduledTask?: boolean;
+  assistantName?: string;
+}
+
+interface ContainerOutput {
+  status: 'success' | 'error';
+  result: string | null;
+  newSessionId?: string;
+  error?: string;
+}
+
+interface CopilotQueryResult {
+  newSessionId?: string;
+  closedDuringQuery: boolean;
+}
+
+type WriteOutputFn = (output: ContainerOutput) => void;
+type LogFn = (message: string) => void;
+type ShouldCloseFn = () => boolean;
+type DrainIpcFn = () => string[];
+
+// ---------------------------------------------------------------------------
+// Copilot client singleton (reused across queries within one container run)
+// ---------------------------------------------------------------------------
+
+let copilotClient: CopilotClient | null = null;
+
+function getCopilotClient(): CopilotClient {
+  if (!copilotClient) {
+    copilotClient = new CopilotClient({
+      autoStart: true,
+      logLevel: 'error',
+    });
+  }
+  return copilotClient;
+}
+
+export async function stopCopilotClient(): Promise<void> {
+  if (copilotClient) {
+    try {
+      await copilotClient.stop();
+    } catch {
+      // ignore stop errors
+    }
+    copilotClient = null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Query implementation
+// ---------------------------------------------------------------------------
+
+export async function runCopilotQuery(
+  prompt: string,
+  sessionId: string | undefined,
+  mcpServerPath: string,
+  containerInput: ContainerInput,
+  _sdkEnv: Record<string, string | undefined>,
+  writeOutput: WriteOutputFn,
+  log: LogFn,
+  shouldClose: ShouldCloseFn,
+  drainIpcInput: DrainIpcFn,
+  ipcPollMs: number,
+): Promise<CopilotQueryResult> {
+  const client = getCopilotClient();
+
+  // Log authentication method
+  if (process.env.GITHUB_TOKEN) {
+    log('Copilot auth: using GITHUB_TOKEN env var');
+  } else if (fs.existsSync('/home/node/.copilot')) {
+    log('Copilot auth: using OAuth credentials from ~/.copilot/');
+  } else {
+    log('Warning: No Copilot authentication found (set GITHUB_TOKEN or run copilot auth login)');
+  }
+
+  // Build MCP server config matching what Claude gets
+  const mcpServers: Record<string, MCPServerConfig> = {
+    nanoclaw: {
+      type: 'local',
+      tools: ['*'],
+      command: 'node',
+      args: [mcpServerPath],
+      env: {
+        NANOCLAW_CHAT_JID: containerInput.chatJid,
+        NANOCLAW_GROUP_FOLDER: containerInput.groupFolder,
+        NANOCLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
+      },
+    },
+  };
+
+  // Load global CLAUDE.md as system context
+  const globalClaudeMdPath = '/workspace/global/CLAUDE.md';
+  let systemMessage: string | undefined;
+  if (!containerInput.isMain && fs.existsSync(globalClaudeMdPath)) {
+    systemMessage = fs.readFileSync(globalClaudeMdPath, 'utf-8');
+  }
+
+  // Build session config
+  const model = process.env.COPILOT_MODEL || 'gpt-4.1';
+  const sessionConfig: SessionConfig = {
+    model,
+    streaming: true,
+    mcpServers,
+    onPermissionRequest: approveAll,
+    ...(systemMessage ? { systemMessage: { content: systemMessage } } : {}),
+  };
+
+  log(`Creating Copilot session (model: ${model}, resume: ${sessionId || 'new'})`);
+
+  // Create or resume session
+  const session = sessionId
+    ? await client.resumeSession(sessionId, { model, onPermissionRequest: approveAll })
+    : await client.createSession(sessionConfig);
+
+  const newSessionId = session.sessionId;
+  log(`Copilot session ready: ${newSessionId}`);
+
+  // Track IPC polling and close sentinel
+  let ipcPolling = true;
+  let closedDuringQuery = false;
+
+  const pollIpcDuringQuery = () => {
+    if (!ipcPolling) return;
+    if (shouldClose()) {
+      log('Close sentinel detected during Copilot query');
+      closedDuringQuery = true;
+      ipcPolling = false;
+      return;
+    }
+    const messages = drainIpcInput();
+    for (const text of messages) {
+      log(`Piping IPC message into Copilot session (${text.length} chars)`);
+      session.send({ prompt: text }).catch((err: Error) => {
+        log(`Failed to pipe IPC message: ${err.message}`);
+      });
+    }
+    setTimeout(pollIpcDuringQuery, ipcPollMs);
+  };
+  setTimeout(pollIpcDuringQuery, ipcPollMs);
+
+  // Send prompt and collect response via events
+  return new Promise<CopilotQueryResult>((resolve, reject) => {
+    let resultEmitted = false;
+
+    session.on((event: SessionEvent) => {
+      if (event.type === 'assistant.message') {
+        const content = event.data.content || '';
+        if (content) {
+          log(`Copilot result (${content.length} chars): ${content.slice(0, 200)}`);
+          writeOutput({
+            status: 'success',
+            result: content,
+            newSessionId,
+          });
+          resultEmitted = true;
+        }
+      } else if (event.type === 'assistant.message_delta') {
+        // Streaming delta — logged but not emitted as separate output.
+        // The final assistant.message contains the full content.
+      } else if (event.type === 'session.idle') {
+        ipcPolling = false;
+
+        if (!resultEmitted) {
+          // Session completed without emitting a result (e.g. tool-only turn)
+          writeOutput({
+            status: 'success',
+            result: null,
+            newSessionId,
+          });
+        }
+
+        resolve({ newSessionId, closedDuringQuery });
+      } else if (event.type === 'session.error') {
+        ipcPolling = false;
+        const errorMsg = event.data.message || 'Copilot session error';
+        log(`Copilot error: ${errorMsg}`);
+        writeOutput({
+          status: 'error',
+          result: null,
+          newSessionId,
+          error: errorMsg,
+        });
+        resolve({ newSessionId, closedDuringQuery });
+      }
+    });
+
+    session.send({ prompt }).catch((err: Error) => {
+      ipcPolling = false;
+      reject(err);
+    });
+  });
+}

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -18,6 +18,7 @@ import fs from 'fs';
 import path from 'path';
 import { query, HookCallback, PreCompactHookInput } from '@anthropic-ai/claude-agent-sdk';
 import { fileURLToPath } from 'url';
+import { runCopilotQuery, stopCopilotClient } from './copilot-query.js';
 
 interface ContainerInput {
   prompt: string;
@@ -57,6 +58,12 @@ interface SDKUserMessage {
 const IPC_INPUT_DIR = '/workspace/ipc/input';
 const IPC_INPUT_CLOSE_SENTINEL = path.join(IPC_INPUT_DIR, '_close');
 const IPC_POLL_MS = 500;
+
+/**
+ * Which SDK to use for agent queries.
+ * Set via NANOCLAW_SDK env var: 'claude' (default) or 'copilot'.
+ */
+const SDK_BACKEND = (process.env.NANOCLAW_SDK || 'claude').toLowerCase();
 
 /**
  * Push-based async iterable for streaming user messages to the SDK.
@@ -507,11 +514,22 @@ async function main(): Promise<void> {
 
   // Query loop: run query → wait for IPC message → run new query → repeat
   let resumeAt: string | undefined;
+  log(`Using SDK backend: ${SDK_BACKEND}`);
   try {
     while (true) {
       log(`Starting query (session: ${sessionId || 'new'}, resumeAt: ${resumeAt || 'latest'})...`);
 
-      const queryResult = await runQuery(prompt, sessionId, mcpServerPath, containerInput, sdkEnv, resumeAt);
+      let queryResult: { newSessionId?: string; lastAssistantUuid?: string; closedDuringQuery: boolean };
+
+      if (SDK_BACKEND === 'copilot') {
+        queryResult = await runCopilotQuery(
+          prompt, sessionId, mcpServerPath, containerInput, sdkEnv,
+          writeOutput, log, shouldClose, drainIpcInput, IPC_POLL_MS,
+        );
+      } else {
+        queryResult = await runQuery(prompt, sessionId, mcpServerPath, containerInput, sdkEnv, resumeAt);
+      }
+
       if (queryResult.newSessionId) {
         sessionId = queryResult.newSessionId;
       }
@@ -552,6 +570,10 @@ async function main(): Promise<void> {
       error: errorMessage
     });
     process.exit(1);
+  } finally {
+    if (SDK_BACKEND === 'copilot') {
+      await stopCopilotClient();
+    }
   }
 }
 

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -200,6 +200,16 @@ function buildVolumeMounts(
     readonly: false,
   });
 
+  // Mount Copilot CLI OAuth credentials if available (from `copilot auth login`)
+  const copilotAuthDir = path.join(process.env.HOME || '/root', '.copilot');
+  if (fs.existsSync(copilotAuthDir)) {
+    mounts.push({
+      hostPath: copilotAuthDir,
+      containerPath: '/home/node/.copilot',
+      readonly: true,
+    });
+  }
+
   // Additional mounts validated against external allowlist (tamper-proof from containers)
   if (group.containerConfig?.additionalMounts) {
     const validatedMounts = validateAdditionalMounts(
@@ -236,6 +246,22 @@ async function buildContainerArgs(
       { containerName },
       'OneCLI gateway not reachable — container will have no credentials',
     );
+  }
+
+  // Pass GITHUB_TOKEN for GitHub Copilot SDK and gh CLI
+  const githubToken = process.env.GITHUB_TOKEN;
+  if (githubToken) {
+    args.push('-e', `GITHUB_TOKEN=${githubToken}`);
+  }
+
+  // Pass SDK backend selection and Copilot model for container agents
+  const nanoclavSdk = process.env.NANOCLAW_SDK;
+  if (nanoclavSdk) {
+    args.push('-e', `NANOCLAW_SDK=${nanoclavSdk}`);
+  }
+  const copilotModel = process.env.COPILOT_MODEL;
+  if (copilotModel) {
+    args.push('-e', `COPILOT_MODEL=${copilotModel}`);
   }
 
   // Runtime-specific args for host gateway resolution


### PR DESCRIPTION
## Summary

- Adds native `@github/copilot-sdk` integration to the agent-runner alongside the existing Anthropic Claude Agent SDK
- Container agents can run on Copilot models (GPT-4.1, etc.) by setting `NANOCLAW_SDK=copilot`
- Supports both `GITHUB_TOKEN` and Copilot OAuth (`~/.copilot/`) authentication

Closes #1350

## Changes

- **`container/agent-runner/src/copilot-query.ts`** — New Copilot SDK query adapter with MCP server support, session resumption, streaming, and IPC message piping
- **`container/agent-runner/src/index.ts`** — SDK backend selection via `NANOCLAW_SDK` env var, dispatches to either Claude or Copilot query function
- **`container/agent-runner/package.json`** — Added `@github/copilot-sdk` dependency
- **`src/container-runner.ts`** — Passes `GITHUB_TOKEN`, `NANOCLAW_SDK`, `COPILOT_MODEL` env vars into containers; mounts `~/.copilot/` OAuth credentials (read-only)

## Configuration

```bash
# .env
NANOCLAW_SDK=copilot          # Select Copilot backend (default: claude)
COPILOT_MODEL=gpt-4.1         # Optional model override
GITHUB_TOKEN=ghp_...          # Auth option 1: token with copilot scope
# Auth option 2: run `copilot auth login` on host (OAuth, no token needed)
```

## Test plan

- [ ] `npm run build` passes
- [ ] `cd container/agent-runner && npx tsc --noEmit` passes
- [ ] `./container/build.sh` succeeds
- [ ] With `NANOCLAW_SDK=copilot` set, agent responds using Copilot model
- [ ] MCP tools (send_message, schedule_task) work with Copilot backend
- [ ] Session resumption works across container restarts
- [ ] Default behavior unchanged when `NANOCLAW_SDK` is unset (Claude)