### PR TITLE
fix: copy main CLAUDE.md template when registering a main group

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -295,7 +295,8 @@ nanoclaw/
 │       └── add-parallel/SKILL.md       # /add-parallel - Parallel agents
 │
 ├── groups/
-│   ├── CLAUDE.md                  # Global memory (all groups read this)
+│   ├── global/CLAUDE.md           # Global memory (all groups read this)
+│   ├── main/CLAUDE.md             # Starting memory for main channel
 │   ├── {channel}_main/             # Main control channel (e.g., whatsapp_main/)
 │   │   ├── CLAUDE.md              # Main channel memory
 │   │   └── logs/                  # Task execution logs

--- a/setup/register.ts
+++ b/setup/register.ts
@@ -116,6 +116,16 @@ export async function run(args: string[]): Promise<void> {
     recursive: true,
   });
 
+  // Copy main CLAUDE.md template into main group folder
+  if (parsed.isMain) {
+    const templatePath = path.join(projectRoot, 'groups', 'main', 'CLAUDE.md');
+    const destPath = path.join(projectRoot, 'groups', parsed.folder, 'CLAUDE.md');
+    if (fs.existsSync(templatePath) && !fs.existsSync(destPath)) {
+      fs.copyFileSync(templatePath, destPath);
+      logger.info({ dest: destPath }, 'Copied main CLAUDE.md template');
+    }
+  }
+
   // Update assistant name in CLAUDE.md files if different from default
   let nameUpdated = false;
   if (parsed.assistantName !== 'Andy') {


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description
Thanks for the awesome project! 

After walking through the `/setup` skill to completion. I found my `telegram_main` does not have `CLAUDE.md` (only logs) under `groups/telegram_main` 
This change make sure `CLAUDE.md` is copied from `groups/main` only if (1) the file does not exist, and (2) `isMain`
