### PR TITLE
feat: add Paperclip HTTP adapter integration

### DIFF
--- a/.claude/skills/add-paperclip/SKILL.md
+++ b/.claude/skills/add-paperclip/SKILL.md
@@ -1,0 +1,317 @@
+---
+name: add-paperclip
+description: Register NanoClaw as an HTTP adapter agent in Paperclip. Receives issue heartbeats, routes them to the configured group, and lets the agent post comments back via paperclip-reporter.
+---
+
+# Add Paperclip Integration
+
+This skill wires NanoClaw into a Paperclip instance as an HTTP adapter agent. Paperclip sends issue heartbeats to NanoClaw's webhook; NanoClaw routes them to the configured group (typically a dedicated agent like k2) as task messages. The agent can post comments back to Paperclip runs using the included `paperclip-reporter` CLI helper.
+
+Authentication uses HS256 JWTs signed with `PAPERCLIP_AGENT_JWT_SECRET` — the same mechanism Paperclip's own adapter system uses.
+
+## Phase 1: Pre-flight
+
+### Check if already applied
+
+Check if `src/paperclip-webhook.ts` already exists. If it does, skip to Phase 3 (Configure).
+
+### Collect connection details
+
+Use `AskUserQuestion` to ask:
+
+> 1. What is the URL of your Paperclip instance? (default: `http://paperclip:3100`)
+> 2. What is your Paperclip agent JWT secret? (the HS256 signing secret configured in Paperclip for HTTP adapter agents)
+> 3. What is the agent ID registered in Paperclip? (e.g. `k2`)
+> 4. What is your Paperclip company ID?
+> 5. What Bearer token should Paperclip use to authenticate heartbeats to NanoClaw? (choose any secret string — this becomes `PAPERCLIP_WEBHOOK_SECRET`)
+> 6. What is the folder name of the group that should handle Paperclip tasks? (e.g. `k2` — must already be a registered group)
+
+### Test Paperclip API connectivity
+
+```bash
+curl -s <PAPERCLIP_URL>/api/issues | head -c 500
+```
+
+The response must be valid JSON. If connection is refused, verify Paperclip is running and reachable from the NanoClaw host.
+
+## Phase 2: Apply Code Changes
+
+### Write the webhook server
+
+Create `src/paperclip-webhook.ts` with exactly the following content:
+
+> (File already created by this skill — check git status. If missing, recreate from the skill source.)
+
+### Write the reporter helper
+
+Create `container/agent-runner/src/paperclip-reporter.ts` — the CLI helper k2 uses to post comments back to Paperclip runs.
+
+> (File already created by this skill — check git status. If missing, recreate from the skill source.)
+
+### Wire webhook server into src/index.ts
+
+Open `src/index.ts` and make two edits:
+
+**1. Add import** — after the `startSchedulerLoop` import, add:
+
+```typescript
+import { startPaperclipWebhookServer } from './paperclip-webhook.js';
+```
+
+**2. Start the server** — immediately after the `startCredentialProxy` block, add:
+
+```typescript
+// Start Paperclip webhook server if configured
+if (process.env.PAPERCLIP_WEBHOOK_SECRET || process.env.PAPERCLIP_GROUP_FOLDER) {
+  const paperclipPort = parseInt(process.env.PAPERCLIP_WEBHOOK_PORT ?? '3102', 10);
+  startPaperclipWebhookServer(paperclipPort, {
+    storeMessage,
+    enqueueGroup: (jid) => queue.enqueueMessageCheck(jid),
+    registeredGroups: () => registeredGroups,
+  });
+}
+```
+
+### Add env passthrough to src/container-runner.ts
+
+Open `src/container-runner.ts` and add the following blocks after the `OLLAMA_URL` block in `buildContainerArgs()`:
+
+```typescript
+  if (process.env.PAPERCLIP_URL) {
+    args.push('-e', `PAPERCLIP_URL=${process.env.PAPERCLIP_URL}`);
+  }
+  if (process.env.PAPERCLIP_AGENT_JWT_SECRET) {
+    args.push('-e', `PAPERCLIP_AGENT_JWT_SECRET=${process.env.PAPERCLIP_AGENT_JWT_SECRET}`);
+  }
+  if (process.env.PAPERCLIP_AGENT_ID) {
+    args.push('-e', `PAPERCLIP_AGENT_ID=${process.env.PAPERCLIP_AGENT_ID}`);
+  }
+  if (process.env.PAPERCLIP_COMPANY_ID) {
+    args.push('-e', `PAPERCLIP_COMPANY_ID=${process.env.PAPERCLIP_COMPANY_ID}`);
+  }
+```
+
+Note: `PAPERCLIP_WEBHOOK_SECRET` is intentionally not forwarded to containers — it is a host-side secret and the container agent does not need it.
+
+### Copy to per-group agent-runner
+
+Existing groups have a cached copy of the agent-runner source. Update them:
+
+```bash
+for dir in data/sessions/*/agent-runner-src; do
+  cp container/agent-runner/src/paperclip-reporter.ts "$dir/"
+done
+```
+
+### Build
+
+```bash
+npm run build
+./container/build.sh
+```
+
+Build must be clean before proceeding.
+
+## Phase 2b: Update container-runner.ts
+
+If this wasn't already done in Phase 2, verify the passthrough blocks are present:
+
+```bash
+grep -n "PAPERCLIP" src/container-runner.ts
+```
+
+Expected output: four lines for `PAPERCLIP_URL`, `PAPERCLIP_AGENT_JWT_SECRET`, `PAPERCLIP_AGENT_ID`, and `PAPERCLIP_COMPANY_ID`.
+
+## Phase 3: Configure
+
+### Configure environment variables
+
+On Unraid/Docker deployments: add each variable directly to the NanoClaw container template via the Unraid Docker UI (edit container → add variable).
+
+On standard Linux/macOS deployments: append to `.env` and sync:
+
+```bash
+PAPERCLIP_URL=http://paperclip:3100
+PAPERCLIP_AGENT_JWT_SECRET=<jwt-signing-secret-from-paperclip>
+PAPERCLIP_AGENT_ID=k2
+PAPERCLIP_COMPANY_ID=<your-company-id>
+PAPERCLIP_WEBHOOK_SECRET=<your-chosen-secret>
+PAPERCLIP_GROUP_FOLDER=k2
+# Optional — default is 3102:
+# PAPERCLIP_WEBHOOK_PORT=3102
+```
+
+Then sync:
+```bash
+cp .env data/env/env
+```
+
+Also add placeholder entries to `.env.example` if not already present:
+
+```bash
+PAPERCLIP_URL=
+PAPERCLIP_AGENT_JWT_SECRET=
+PAPERCLIP_AGENT_ID=
+PAPERCLIP_COMPANY_ID=
+PAPERCLIP_WEBHOOK_SECRET=
+PAPERCLIP_GROUP_FOLDER=
+PAPERCLIP_WEBHOOK_PORT=
+```
+
+### Expose the webhook port
+
+The webhook server listens on port 3102 (or `PAPERCLIP_WEBHOOK_PORT`). Ensure this port is accessible from Paperclip:
+
+- **Unraid/Docker**: add a port mapping `3102:3102` to the NanoClaw container template.
+- **macOS**: the port is available on the host directly; ensure firewall allows it.
+- **Linux**: open the port in iptables/ufw if needed: `ufw allow 3102`.
+
+If NanoClaw is on the same Docker network as Paperclip, no port exposure is needed — use the container name as the hostname.
+
+### Restart the service
+
+On Unraid/Docker:
+```bash
+docker restart NanoClaw
+```
+On standard Linux: `systemctl --user restart nanoclaw`
+On macOS: `launchctl kickstart -k gui/$(id -u)/com.nanoclaw`
+
+## Phase 4: Register in Paperclip
+
+### Register NanoClaw as an HTTP adapter agent
+
+In Paperclip, create a new HTTP adapter agent with the following settings:
+
+| Field | Value |
+|-------|-------|
+| Agent ID | `k2` (must match `PAPERCLIP_AGENT_ID`) |
+| Adapter type | HTTP |
+| Endpoint URL | `http://<nanoclaw-host>:3102/api/paperclip/heartbeat` |
+| Auth header | `Authorization: Bearer <PAPERCLIP_WEBHOOK_SECRET>` |
+
+The exact Paperclip UI path depends on your version — typically: **Settings → Agents → New Agent → HTTP Adapter**.
+
+Note the JWT signing secret shown during agent creation — this becomes `PAPERCLIP_AGENT_JWT_SECRET`.
+
+### Assign issues to the agent
+
+In Paperclip, assign an issue to `k2`. Paperclip will POST a heartbeat to NanoClaw:
+
+```json
+{
+  "agentId": "k2",
+  "runId": "run_abc123",
+  "context": {
+    "issueId": "ISSUE-42",
+    "title": "Fix the race condition in the auth middleware",
+    "body": "Users are occasionally seeing 401s on valid sessions...",
+    "labels": ["bug", "auth"]
+  }
+}
+```
+
+NanoClaw will:
+1. Authenticate the Bearer token
+2. Fetch full issue details from the Paperclip API (authenticated via HS256 JWT)
+3. Format the issue as a task message and store it in the database
+4. Enqueue the k2 group — the agent container starts and processes the task
+
+## Phase 5: Verify
+
+### Test the webhook manually
+
+```bash
+curl -s -X POST http://localhost:3102/api/paperclip/heartbeat \
+  -H "Authorization: Bearer <PAPERCLIP_WEBHOOK_SECRET>" \
+  -H "Content-Type: application/json" \
+  -d '{"agentId":"k2","runId":"test-run-001","context":{"issueId":"TEST-1","title":"Test issue","body":"This is a test."}}'
+```
+
+Expected response: `{"ok":true}`
+
+### Check the agent received the task
+
+The k2 group should activate and the agent should process the task message:
+
+```bash
+tail -f logs/nanoclaw.log | grep -i paperclip
+```
+
+Look for:
+- `Paperclip webhook server listening` — server started
+- `Paperclip task routed to group` — heartbeat processed
+- `Agent output:` — agent is working on the task
+
+### Test posting a comment back
+
+Inside the k2 container (or verify it works by running the compiled script directly):
+
+```bash
+PAPERCLIP_URL=http://paperclip:3100 \
+PAPERCLIP_AGENT_JWT_SECRET=<secret> \
+PAPERCLIP_AGENT_ID=k2 \
+PAPERCLIP_COMPANY_ID=<id> \
+  node dist/paperclip-reporter.js test-run-001 TEST-1 "Task received, starting work."
+```
+
+Expected: JSON response from Paperclip confirming the comment was created.
+
+## Troubleshooting
+
+### Webhook returns 401
+
+The `Authorization` header Paperclip is sending doesn't match `PAPERCLIP_WEBHOOK_SECRET`. Verify:
+1. `PAPERCLIP_WEBHOOK_SECRET` is set correctly in the NanoClaw environment
+2. Paperclip is configured to send `Bearer <secret>` (not just the raw secret)
+
+### `PAPERCLIP_GROUP_FOLDER does not match any registered group`
+
+The value of `PAPERCLIP_GROUP_FOLDER` doesn't match any registered group's folder field. Check:
+1. `echo $PAPERCLIP_GROUP_FOLDER` — confirm the value
+2. Run "list registered groups" from your main group to see folder names
+3. The folder must already be registered — use `/setup` or register it manually first
+
+### k2 doesn't respond to the task
+
+1. Confirm the group is registered: check the NanoClaw database or logs for group registration
+2. Check k2's group has `requiresTrigger: false` — Paperclip tasks come from `sender: 'paperclip'`, not from a trigger word
+3. Verify the webhook port is reachable: `curl http://localhost:3102/api/paperclip/heartbeat`
+4. Check logs: `grep -i paperclip logs/nanoclaw.log`
+
+### paperclip-reporter fails with "connection refused"
+
+`PAPERCLIP_URL` inside the container doesn't reach Paperclip. Check:
+1. Paperclip is running: `docker ps | grep paperclip`
+2. The NanoClaw agent container and Paperclip are on the same Docker network
+3. `PAPERCLIP_URL` passthrough is present in `src/container-runner.ts` (Phase 2b)
+4. If using `host.docker.internal`, switch to the container name or bridge IP on Linux
+
+### paperclip-reporter fails with JWT error
+
+Paperclip rejected the JWT. Verify:
+1. `PAPERCLIP_AGENT_JWT_SECRET` matches the secret configured for this agent in Paperclip
+2. `PAPERCLIP_AGENT_ID` matches the agent ID registered in Paperclip
+3. `PAPERCLIP_COMPANY_ID` is correct — check Paperclip's admin panel
+4. Container clock isn't drifting — JWTs expire after 5 minutes (`exp: iat + 300`)
+
+### Webhook server not starting
+
+Check that at least one of `PAPERCLIP_WEBHOOK_SECRET` or `PAPERCLIP_GROUP_FOLDER` is set — the server only starts when either is present. Check logs on startup for `Paperclip webhook server listening`.
+
+## Removal
+
+To remove the Paperclip integration:
+
+1. Delete `src/paperclip-webhook.ts` and `container/agent-runner/src/paperclip-reporter.ts`
+2. Remove the `startPaperclipWebhookServer` import and call block from `src/index.ts`
+3. Remove the `PAPERCLIP_URL`, `PAPERCLIP_AGENT_JWT_SECRET`, `PAPERCLIP_AGENT_ID`, and `PAPERCLIP_COMPANY_ID` passthrough blocks from `src/container-runner.ts`
+4. Remove `PAPERCLIP_*` variables from `.env` and sync: `cp .env data/env/env`
+5. Remove the port mapping from the container template (Unraid) or close the firewall port
+6. Rebuild: `npm run build && ./container/build.sh`
+7. Restart:
+```bash
+docker restart NanoClaw  # Unraid/Docker
+# macOS: launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+# Linux: systemctl --user restart nanoclaw
+```

--- a/container/agent-runner/src/paperclip-reporter.ts
+++ b/container/agent-runner/src/paperclip-reporter.ts
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * Paperclip Reporter — CLI helper for the container agent.
+ * Posts a comment back to a Paperclip run via the REST API.
+ *
+ * Usage:
+ *   node /app/dist/paperclip-reporter.js <runId> <issueId> <comment text...>
+ *
+ * Env:
+ *   PAPERCLIP_URL              Base URL of Paperclip (default: http://paperclip:3100)
+ *   PAPERCLIP_AGENT_JWT_SECRET  HS256 secret used to sign request JWTs
+ *   PAPERCLIP_AGENT_ID          Agent ID (JWT sub claim)
+ *   PAPERCLIP_COMPANY_ID        Company ID claim
+ *
+ * Example:
+ *   node /app/dist/paperclip-reporter.js run_abc123 ISSUE-42 "Done. Fixed the null pointer on line 42."
+ */
+
+import { createHmac } from 'crypto';
+
+function base64url(data: Buffer | string): string {
+  const buf = typeof data === 'string' ? Buffer.from(data) : data;
+  return buf.toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+}
+
+function makeJwt(
+  secret: string,
+  claims: Record<string, unknown>,
+): string {
+  const header = base64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payload = base64url(JSON.stringify(claims));
+  const sig = base64url(
+    createHmac('sha256', secret).update(`${header}.${payload}`).digest(),
+  );
+  return `${header}.${payload}.${sig}`;
+}
+
+const [, , runId, issueId, ...commentParts] = process.argv;
+const comment = commentParts.join(' ').trim();
+
+if (!runId || !issueId || !comment) {
+  console.error('Usage: paperclip-reporter <runId> <issueId> <comment text>');
+  process.exit(1);
+}
+
+const BASE = (process.env.PAPERCLIP_URL ?? 'http://paperclip:3100').replace(/\/$/, '');
+const jwtSecret = process.env.PAPERCLIP_AGENT_JWT_SECRET ?? '';
+const agentId = process.env.PAPERCLIP_AGENT_ID ?? '';
+const companyId = process.env.PAPERCLIP_COMPANY_ID ?? '';
+
+if (!jwtSecret) {
+  console.error('Error: PAPERCLIP_AGENT_JWT_SECRET is not set');
+  process.exit(1);
+}
+if (!agentId) {
+  console.error('Error: PAPERCLIP_AGENT_ID is not set');
+  process.exit(1);
+}
+
+const now = Math.floor(Date.now() / 1000);
+const token = makeJwt(jwtSecret, {
+  sub: agentId,
+  company_id: companyId,
+  adapter_type: 'http',
+  run_id: runId,
+  iat: now,
+  exp: now + 300,
+});
+
+try {
+  const res = await fetch(
+    `${BASE}/api/issues/${encodeURIComponent(issueId)}/comments`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ body: comment }),
+    },
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    console.error(`Paperclip API error ${res.status}: ${text}`);
+    process.exit(1);
+  }
+
+  const data = await res.json();
+  console.log(JSON.stringify(data, null, 2));
+} catch (err) {
+  console.error(
+    `Failed to post comment: ${err instanceof Error ? err.message : String(err)}`,
+  );
+  process.exit(1);
+}

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -238,6 +238,23 @@ function buildContainerArgs(
     args.push('-e', 'CLAUDE_CODE_OAUTH_TOKEN=placeholder');
   }
 
+  // Pass Paperclip connection details if configured
+  if (process.env.PAPERCLIP_URL) {
+    args.push('-e', `PAPERCLIP_URL=${process.env.PAPERCLIP_URL}`);
+  }
+  if (process.env.PAPERCLIP_AGENT_JWT_SECRET) {
+    args.push(
+      '-e',
+      `PAPERCLIP_AGENT_JWT_SECRET=${process.env.PAPERCLIP_AGENT_JWT_SECRET}`,
+    );
+  }
+  if (process.env.PAPERCLIP_AGENT_ID) {
+    args.push('-e', `PAPERCLIP_AGENT_ID=${process.env.PAPERCLIP_AGENT_ID}`);
+  }
+  if (process.env.PAPERCLIP_COMPANY_ID) {
+    args.push('-e', `PAPERCLIP_COMPANY_ID=${process.env.PAPERCLIP_COMPANY_ID}`);
+  }
+
   // Runtime-specific args for host gateway resolution
   args.push(...hostGatewayArgs());
 

--- a/src/paperclip-webhook.ts
+++ b/src/paperclip-webhook.ts
@@ -1,0 +1,223 @@
+/**
+ * Paperclip webhook receiver.
+ * Receives HTTP adapter heartbeats from Paperclip and routes issues
+ * to the configured agent group as task messages.
+ *
+ * Config:
+ *   PAPERCLIP_URL              Paperclip base URL (default: http://paperclip:3100)
+ *   PAPERCLIP_AGENT_JWT_SECRET  HS256 secret for signing API request JWTs
+ *   PAPERCLIP_AGENT_ID          Agent ID (JWT sub claim)
+ *   PAPERCLIP_COMPANY_ID        Company ID claim
+ *   PAPERCLIP_WEBHOOK_SECRET   Bearer token Paperclip sends on every heartbeat
+ *   PAPERCLIP_GROUP_FOLDER     Folder name of the group that handles Paperclip tasks
+ *   PAPERCLIP_WEBHOOK_PORT     Port to listen on (default: 3102)
+ */
+import { createHmac } from 'crypto';
+import { createServer, Server } from 'http';
+
+import { logger } from './logger.js';
+import { NewMessage, RegisteredGroup } from './types.js';
+
+export interface PaperclipWebhookDeps {
+  storeMessage: (msg: NewMessage) => void;
+  enqueueGroup: (chatJid: string) => void;
+  registeredGroups: () => Record<string, RegisteredGroup>;
+}
+
+interface HeartbeatPayload {
+  agentId?: string;
+  runId?: string;
+  context?: {
+    issueId?: string;
+    title?: string;
+    body?: string;
+    labels?: string[];
+    assignee?: string;
+    [key: string]: unknown;
+  };
+}
+
+function base64url(data: Buffer | string): string {
+  const buf = typeof data === 'string' ? Buffer.from(data) : data;
+  return buf
+    .toString('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+function makeJwt(secret: string, claims: Record<string, unknown>): string {
+  const header = base64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payload = base64url(JSON.stringify(claims));
+  const sig = base64url(
+    createHmac('sha256', secret).update(`${header}.${payload}`).digest(),
+  );
+  return `${header}.${payload}.${sig}`;
+}
+
+async function fetchIssue(
+  paperclipUrl: string,
+  jwtSecret: string,
+  agentId: string,
+  companyId: string,
+  runId: string,
+  issueId: string,
+): Promise<Record<string, unknown>> {
+  const now = Math.floor(Date.now() / 1000);
+  const token = makeJwt(jwtSecret, {
+    sub: agentId,
+    company_id: companyId,
+    adapter_type: 'http',
+    run_id: runId,
+    iat: now,
+    exp: now + 300,
+  });
+  const res = await fetch(
+    `${paperclipUrl}/api/issues/${encodeURIComponent(issueId)}`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    },
+  );
+  if (!res.ok) {
+    throw new Error(`Paperclip API ${res.status}: ${await res.text()}`);
+  }
+  return res.json() as Promise<Record<string, unknown>>;
+}
+
+export function startPaperclipWebhookServer(
+  port: number,
+  deps: PaperclipWebhookDeps,
+): Server {
+  const webhookSecret = process.env.PAPERCLIP_WEBHOOK_SECRET;
+  const paperclipUrl = (
+    process.env.PAPERCLIP_URL ?? 'http://paperclip:3100'
+  ).replace(/\/$/, '');
+  const jwtSecret = process.env.PAPERCLIP_AGENT_JWT_SECRET ?? '';
+  const agentId = process.env.PAPERCLIP_AGENT_ID ?? '';
+  const companyId = process.env.PAPERCLIP_COMPANY_ID ?? '';
+  const groupFolder = process.env.PAPERCLIP_GROUP_FOLDER ?? '';
+
+  const server = createServer((req, res) => {
+    if (req.method !== 'POST' || req.url !== '/api/paperclip/heartbeat') {
+      res.writeHead(404).end();
+      return;
+    }
+
+    // Authenticate
+    const authHeader = req.headers['authorization'] ?? '';
+    if (webhookSecret && authHeader !== `Bearer ${webhookSecret}`) {
+      logger.warn('Paperclip heartbeat: unauthorized request');
+      res.writeHead(401).end();
+      return;
+    }
+
+    const chunks: Buffer[] = [];
+    req.on('data', (c) => chunks.push(c));
+    req.on('end', () => {
+      // Respond immediately — processing is fire and forget
+      res
+        .writeHead(200, { 'Content-Type': 'application/json' })
+        .end('{"ok":true}');
+
+      (async () => {
+        let body: HeartbeatPayload;
+        try {
+          body = JSON.parse(Buffer.concat(chunks).toString());
+        } catch {
+          logger.warn('Paperclip heartbeat: invalid JSON body');
+          return;
+        }
+
+        const { runId, context } = body;
+        if (!runId) {
+          logger.warn('Paperclip heartbeat: missing runId');
+          return;
+        }
+
+        // Resolve the target group JID from PAPERCLIP_GROUP_FOLDER
+        const groups = deps.registeredGroups();
+        const entry = Object.entries(groups).find(
+          ([, g]) => g.folder === groupFolder,
+        );
+        if (!entry) {
+          logger.error(
+            { groupFolder },
+            'Paperclip heartbeat: PAPERCLIP_GROUP_FOLDER does not match any registered group',
+          );
+          return;
+        }
+        const [chatJid] = entry;
+
+        // Optionally fetch full issue details from Paperclip API
+        let issueData: Record<string, unknown> | null = null;
+        if (context?.issueId && jwtSecret && agentId) {
+          try {
+            issueData = await fetchIssue(
+              paperclipUrl,
+              jwtSecret,
+              agentId,
+              companyId,
+              runId,
+              context.issueId,
+            );
+          } catch (e) {
+            logger.warn(
+              { err: e },
+              'Paperclip heartbeat: failed to fetch issue details, using context payload',
+            );
+          }
+        }
+
+        const issue = issueData ?? context ?? {};
+        const issueId =
+          (issue.issueId as string | undefined) ?? context?.issueId ?? '';
+        const title =
+          (issue.title as string | undefined) ?? context?.title ?? '(no title)';
+        const body2 = (issue.body as string | undefined) ?? context?.body ?? '';
+        const rawLabels = (issue.labels ?? context?.labels ?? []) as string[];
+        const labels = rawLabels.join(', ');
+
+        const lines = [
+          `[Paperclip Task] Run: ${runId}`,
+          issueId ? `Issue: ${issueId} — ${title}` : `Task: ${title}`,
+          labels ? `Labels: ${labels}` : '',
+          '',
+          body2 || '(no description)',
+          '',
+          `To post a comment back: node /app/dist/paperclip-reporter.js ${runId} ${issueId} "<comment>"`,
+        ];
+        const taskText = lines
+          .filter((l) => l !== null)
+          .join('\n')
+          .trim();
+
+        const now = new Date().toISOString();
+        deps.storeMessage({
+          id: `paperclip-${runId}-${Date.now()}`,
+          chat_jid: chatJid,
+          sender: 'paperclip',
+          sender_name: 'Paperclip',
+          content: taskText,
+          timestamp: now,
+          is_from_me: false,
+          is_bot_message: false,
+        });
+
+        deps.enqueueGroup(chatJid);
+        logger.info(
+          { runId, issueId, chatJid },
+          'Paperclip task routed to group',
+        );
+      })();
+    });
+  });
+
+  server.listen(port, () => {
+    logger.info({ port }, 'Paperclip webhook server listening');
+  });
+
+  return server;
+}


### PR DESCRIPTION
## Summary

Adds support for registering NanoClaw as an HTTP adapter agent in a [Paperclip](https://github.com/paperclip-ai/paperclip) instance. When an issue is assigned to the agent in Paperclip, a heartbeat is POSTed to NanoClaw's webhook, which routes the task to the configured group for processing. The agent can post comments back to Paperclip issues via an included CLI helper.

- **`src/paperclip-webhook.ts`** — lightweight HTTP server (default port 3102) that receives Paperclip heartbeats, authenticates via `PAPERCLIP_WEBHOOK_SECRET`, fetches full issue details using a signed HS256 JWT, and routes the formatted task message to the configured group via the existing message queue
- **`container/agent-runner/src/paperclip-reporter.ts`** — CLI helper the container agent calls via Bash to post comments back: `node paperclip-reporter.js <runId> <issueId> "<comment>"`. Signs each request with a fresh HS256 JWT using `PAPERCLIP_AGENT_JWT_SECRET`
- **`src/container-runner.ts`** — env passthrough for `PAPERCLIP_URL`, `PAPERCLIP_AGENT_JWT_SECRET`, `PAPERCLIP_AGENT_ID`, `PAPERCLIP_COMPANY_ID`
- **`.claude/skills/add-paperclip/SKILL.md`** — full setup guide: Paperclip agent registration, env configuration, port exposure, verification steps, and troubleshooting

JWT auth uses HS256 with claims `sub=agentId`, `company_id`, `adapter_type=http`, `run_id`, `iat`, `exp` (+5 min), matching the Paperclip HTTP adapter spec.

The webhook server starts automatically when `PAPERCLIP_WEBHOOK_SECRET` or `PAPERCLIP_GROUP_FOLDER` is set (wired into `src/index.ts` by the `/add-paperclip` skill).

## Test plan

- [ ] Run `/add-paperclip` skill and follow Phase 1–5
- [ ] `curl -X POST http://localhost:3102/api/paperclip/heartbeat` with a valid Bearer token and heartbeat payload — expect `{"ok":true}` and the target group activating
- [ ] Confirm `paperclip-reporter.js` posts a comment to the correct issue endpoint
- [ ] Verify missing/invalid `PAPERCLIP_WEBHOOK_SECRET` returns 401
- [ ] Confirm `PAPERCLIP_WEBHOOK_SECRET` is not forwarded to agent containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)