### PR TITLE
chore: add GitHub Actions workflow to publish Docker image to GHCR

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -43,6 +43,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          file: container/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -37,13 +37,15 @@ RUN npm install -g agent-browser @anthropic-ai/claude-code
 WORKDIR /app
 
 # Copy package files first for better caching
-COPY agent-runner/package*.json ./
+COPY package*.json ./
 
 # Install dependencies
 RUN npm install
 
 # Copy source code
-COPY agent-runner/ ./
+COPY tsconfig.json ./
+COPY src/ src/
+COPY scripts/ scripts/
 
 # Build TypeScript
 RUN npm run build


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that automatically builds and publishes the Docker image to GitHub Container Registry (ghcr.io) on every push to main.

**What it does:**
- Builds the Docker image using `container/Dockerfile`
- Pushes to `ghcr.io/qwibitai/nanoclaw:latest` (and branch/version tags)
- Only pushes on main branch pushes (not on PRs)

**Why:**
Currently there is no published Docker image for NanoClaw. Users must clone the repo and build locally. This workflow enables users to pull a pre-built image directly:
```
docker pull ghcr.io/qwibitai/nanoclaw:latest
```

**Also fixes:**
- Updated `container/Dockerfile` COPY paths to match current repo structure (removed legacy `agent-runner/` prefix)