### PR TITLE
feat: add Rovo Dev as alternative agent backend

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -112,7 +112,17 @@ Run `npx tsx setup/index.ts --step container -- --runtime <chosen>` and parse th
 
 **If TEST_OK=false but BUILD_OK=true:** The image built but won't run. Check logs — common cause is runtime not fully started. Wait a moment and retry the test.
 
-## 4. Claude Authentication (No Script)
+## 4. Agent Backend Authentication (No Script)
+
+First, determine which agent backend to use. Check environment results for `AGENT_BACKEND` and `ACLI`.
+
+If AGENT_BACKEND is already set in `.env`, confirm with user: keep or reconfigure?
+
+If not yet configured, AskUserQuestion: Which agent backend do you want to use?
+- **Claude** — uses Claude Agent SDK (requires Claude Pro/Max subscription or Anthropic API key)
+- **Rovo Dev** — uses Atlassian Rovo Dev CLI (requires Atlassian account with Rovo Dev access)
+
+### 4a. Claude Backend
 
 If HAS_ENV=true from step 2, read `.env` and check for `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY`. If present, confirm with user: keep or reconfigure?
 
@@ -121,6 +131,41 @@ AskUserQuestion: Claude subscription (Pro/Max) vs Anthropic API key?
 **Subscription:** Tell user to run `claude setup-token` in another terminal, copy the token, add `CLAUDE_CODE_OAUTH_TOKEN=<token>` to `.env`. Do NOT collect the token in chat.
 
 **API key:** Tell user to add `ANTHROPIC_API_KEY=<key>` to `.env`.
+
+Ensure `AGENT_BACKEND=claude` is set in `.env` (or omit it — claude is the default).
+
+### 4b. Rovo Dev Backend
+
+**Step 1: Check `acli` CLI**
+
+If ACLI=not_found from step 2:
+- macOS: `brew tap atlassian/acli && brew install acli`
+- Linux: download from `https://acli.atlassian.com/linux/1.3.14-stable/acli_1.3.14-stable_linux_amd64.tar.gz`, extract to `/usr/local/bin/acli`
+- Verify: `acli --version`
+
+**Step 2: Authenticate**
+
+If ROVODEV_AUTH=not_authenticated from step 2:
+- Tell user to run `acli rovodev auth login` in their terminal. This opens a browser for Atlassian OAuth. Wait for them to confirm authentication is complete.
+- Verify: `acli rovodev auth status` should show `✓ Authenticated`
+
+If ROVODEV_AUTH=authenticated: already configured, continue.
+
+**Step 3: Site URL**
+
+AskUserQuestion: What is your Atlassian site URL? (e.g., `https://yourteam.atlassian.net`)
+
+Add to `.env`:
+```
+AGENT_BACKEND=rovodev
+ROVODEV_SITE_URL=<site_url>
+```
+
+**Step 4: Verify**
+
+Run a quick test: `acli rovodev serve 19999 --non-interactive --disable-session-token --site-url <site_url>` — wait for healthcheck, then `POST /shutdown`. If it starts successfully, Rovo Dev is properly configured.
+
+**Optional:** AskUserQuestion: Do you want to override the default model? If yes, add `ROVODEV_MODEL=<model>` to `.env`. Available models can be checked via `GET /v3/agent-models` after starting serve.
 
 ## 5. Set Up Channels
 
@@ -198,7 +243,7 @@ Run `npx tsx setup/index.ts --step verify` and parse the status block.
 **If STATUS=failed, fix each:**
 - SERVICE=stopped → `npm run build`, then restart: `launchctl kickstart -k gui/$(id -u)/com.nanoclaw` (macOS) or `systemctl --user restart nanoclaw` (Linux) or `bash start-nanoclaw.sh` (WSL nohup)
 - SERVICE=not_found → re-run step 7
-- CREDENTIALS=missing → re-run step 4
+- CREDENTIALS=missing → re-run step 4 (choose the correct backend: Claude or Rovo Dev)
 - CHANNEL_AUTH shows `not_found` for any channel → re-invoke that channel's skill (e.g. `/add-telegram`)
 - REGISTERED_GROUPS=0 → re-invoke the channel skills from step 5
 - MOUNT_ALLOWLIST=missing → `npx tsx setup/index.ts --step mounts -- --empty`
@@ -210,6 +255,8 @@ Tell user to test: send a message in their registered chat. Show: `tail -f logs/
 **Service not starting:** Check `logs/nanoclaw.error.log`. Common: wrong Node path (re-run step 7), missing `.env` (step 4), missing channel credentials (re-invoke channel skill).
 
 **Container agent fails ("Claude Code process exited with code 1"):** Ensure the container runtime is running — `open -a Docker` (macOS Docker), `container system start` (Apple Container), or `sudo systemctl start docker` (Linux). Check container logs in `groups/main/logs/container-*.log`.
+
+**Rovo Dev backend fails to authenticate in container:** Check `acli rovodev auth status` on the host. If authenticated, ensure `.env` has `ROVODEV_SITE_URL` set (required when you have multiple Atlassian sites). The host extracts the API token from the macOS keychain automatically — on Linux, set `ROVODEV_API_TOKEN` manually in `.env`.
 
 **No response to messages:** Check trigger pattern. Main channel doesn't need prefix. Check DB: `npx tsx setup/index.ts --step verify`. Check `logs/nanoclaw.log`.
 

--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,9 @@
 
+# Agent backend: "claude" (default) or "rovodev"
+# AGENT_BACKEND=claude
+
+# Rovo Dev model override (optional, only used when AGENT_BACKEND=rovodev)
+# ROVODEV_MODEL=anthropic:claude-sonnet-4
+
+# Rovo Dev site URL (required if you have multiple Atlassian sites)
+# ROVODEV_SITE_URL=https://yoursite.atlassian.net

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -33,6 +33,15 @@ ENV PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium
 # Install agent-browser and claude-code globally
 RUN npm install -g agent-browser @anthropic-ai/claude-code
 
+# Install acli (Atlassian CLI) for rovodev backend support
+RUN ARCH=$(dpkg --print-architecture) && \
+    if [ "$ARCH" = "amd64" ]; then ACLI_ARCH="amd64"; \
+    elif [ "$ARCH" = "arm64" ]; then ACLI_ARCH="arm64"; \
+    else echo "Unsupported arch: $ARCH" && exit 1; fi && \
+    curl -fsSL "https://acli.atlassian.com/linux/1.3.14-stable/acli_1.3.14-stable_linux_${ACLI_ARCH}.tar.gz" \
+    | tar -xz --strip-components=1 -C /usr/local/bin && \
+    chmod +x /usr/local/bin/acli
+
 # Create app directory
 WORKDIR /app
 

--- a/container/agent-runner/src/backend-types.ts
+++ b/container/agent-runner/src/backend-types.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared types for agent backends (Claude SDK, Rovo Dev, etc.)
+ */
+
+export interface ContainerInput {
+  prompt: string;
+  sessionId?: string;
+  groupFolder: string;
+  chatJid: string;
+  isMain: boolean;
+  isScheduledTask?: boolean;
+  assistantName?: string;
+}
+
+export interface ContainerOutput {
+  status: 'success' | 'error';
+  result: string | null;
+  newSessionId?: string;
+  error?: string;
+}
+
+export interface BackendResult {
+  newSessionId?: string;
+  lastAssistantUuid?: string;
+  closedDuringQuery: boolean;
+}
+
+export type RunQueryFn = (
+  prompt: string,
+  sessionId: string | undefined,
+  mcpServerPath: string,
+  containerInput: ContainerInput,
+  sdkEnv: Record<string, string | undefined>,
+  resumeAt?: string,
+) => Promise<BackendResult>;

--- a/container/agent-runner/src/claude-backend.ts
+++ b/container/agent-runner/src/claude-backend.ts
@@ -1,0 +1,299 @@
+/**
+ * Claude Agent SDK Backend
+ * Extracted from index.ts — runs queries via @anthropic-ai/claude-agent-sdk
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { query, HookCallback, PreCompactHookInput } from '@anthropic-ai/claude-agent-sdk';
+import type { ContainerInput, BackendResult } from './backend-types.js';
+import { MessageStream, writeOutput, log, shouldClose, drainIpcInput } from './shared.js';
+
+const IPC_POLL_MS = 500;
+
+interface SessionsIndex {
+  entries: Array<{
+    sessionId: string;
+    fullPath: string;
+    summary: string;
+    firstPrompt: string;
+  }>;
+}
+
+interface ParsedMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+function getSessionSummary(sessionId: string, transcriptPath: string): string | null {
+  const projectDir = path.dirname(transcriptPath);
+  const indexPath = path.join(projectDir, 'sessions-index.json');
+
+  if (!fs.existsSync(indexPath)) {
+    log(`Sessions index not found at ${indexPath}`);
+    return null;
+  }
+
+  try {
+    const index: SessionsIndex = JSON.parse(fs.readFileSync(indexPath, 'utf-8'));
+    const entry = index.entries.find(e => e.sessionId === sessionId);
+    if (entry?.summary) {
+      return entry.summary;
+    }
+  } catch (err) {
+    log(`Failed to read sessions index: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  return null;
+}
+
+function createPreCompactHook(assistantName?: string): HookCallback {
+  return async (input, _toolUseId, _context) => {
+    const preCompact = input as PreCompactHookInput;
+    const transcriptPath = preCompact.transcript_path;
+    const sessionId = preCompact.session_id;
+
+    if (!transcriptPath || !fs.existsSync(transcriptPath)) {
+      log('No transcript found for archiving');
+      return {};
+    }
+
+    try {
+      const content = fs.readFileSync(transcriptPath, 'utf-8');
+      const messages = parseTranscript(content);
+
+      if (messages.length === 0) {
+        log('No messages to archive');
+        return {};
+      }
+
+      const summary = getSessionSummary(sessionId, transcriptPath);
+      const name = summary ? sanitizeFilename(summary) : generateFallbackName();
+
+      const conversationsDir = '/workspace/group/conversations';
+      fs.mkdirSync(conversationsDir, { recursive: true });
+
+      const date = new Date().toISOString().split('T')[0];
+      const filename = `${date}-${name}.md`;
+      const filePath = path.join(conversationsDir, filename);
+
+      const markdown = formatTranscriptMarkdown(messages, summary, assistantName);
+      fs.writeFileSync(filePath, markdown);
+
+      log(`Archived conversation to ${filePath}`);
+    } catch (err) {
+      log(`Failed to archive transcript: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    return {};
+  };
+}
+
+function sanitizeFilename(summary: string): string {
+  return summary
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 50);
+}
+
+function generateFallbackName(): string {
+  const time = new Date();
+  return `conversation-${time.getHours().toString().padStart(2, '0')}${time.getMinutes().toString().padStart(2, '0')}`;
+}
+
+function parseTranscript(content: string): ParsedMessage[] {
+  const messages: ParsedMessage[] = [];
+
+  for (const line of content.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const entry = JSON.parse(line);
+      if (entry.type === 'user' && entry.message?.content) {
+        const text = typeof entry.message.content === 'string'
+          ? entry.message.content
+          : entry.message.content.map((c: { text?: string }) => c.text || '').join('');
+        if (text) messages.push({ role: 'user', content: text });
+      } else if (entry.type === 'assistant' && entry.message?.content) {
+        const textParts = entry.message.content
+          .filter((c: { type: string }) => c.type === 'text')
+          .map((c: { text: string }) => c.text);
+        const text = textParts.join('');
+        if (text) messages.push({ role: 'assistant', content: text });
+      }
+    } catch {
+    }
+  }
+
+  return messages;
+}
+
+function formatTranscriptMarkdown(messages: ParsedMessage[], title?: string | null, assistantName?: string): string {
+  const now = new Date();
+  const formatDateTime = (d: Date) => d.toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true
+  });
+
+  const lines: string[] = [];
+  lines.push(`# ${title || 'Conversation'}`);
+  lines.push('');
+  lines.push(`Archived: ${formatDateTime(now)}`);
+  lines.push('');
+  lines.push('---');
+  lines.push('');
+
+  for (const msg of messages) {
+    const sender = msg.role === 'user' ? 'User' : (assistantName || 'Assistant');
+    const content = msg.content.length > 2000
+      ? msg.content.slice(0, 2000) + '...'
+      : msg.content;
+    lines.push(`**${sender}**: ${content}`);
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Run a single query via Claude Agent SDK.
+ * Uses MessageStream (AsyncIterable) to keep isSingleUserTurn=false,
+ * allowing agent teams subagents to run to completion.
+ * Also pipes IPC messages into the stream during the query.
+ */
+export async function runQuery(
+  prompt: string,
+  sessionId: string | undefined,
+  mcpServerPath: string,
+  containerInput: ContainerInput,
+  sdkEnv: Record<string, string | undefined>,
+  resumeAt?: string,
+): Promise<BackendResult> {
+  const stream = new MessageStream();
+  stream.push(prompt);
+
+  // Poll IPC for follow-up messages and _close sentinel during the query
+  let ipcPolling = true;
+  let closedDuringQuery = false;
+  const pollIpcDuringQuery = () => {
+    if (!ipcPolling) return;
+    if (shouldClose()) {
+      log('Close sentinel detected during query, ending stream');
+      closedDuringQuery = true;
+      stream.end();
+      ipcPolling = false;
+      return;
+    }
+    const messages = drainIpcInput();
+    for (const text of messages) {
+      log(`Piping IPC message into active query (${text.length} chars)`);
+      stream.push(text);
+    }
+    setTimeout(pollIpcDuringQuery, IPC_POLL_MS);
+  };
+  setTimeout(pollIpcDuringQuery, IPC_POLL_MS);
+
+  let newSessionId: string | undefined;
+  let lastAssistantUuid: string | undefined;
+  let messageCount = 0;
+  let resultCount = 0;
+
+  // Load global CLAUDE.md as additional system context (shared across all groups)
+  const globalClaudeMdPath = '/workspace/global/CLAUDE.md';
+  let globalClaudeMd: string | undefined;
+  if (!containerInput.isMain && fs.existsSync(globalClaudeMdPath)) {
+    globalClaudeMd = fs.readFileSync(globalClaudeMdPath, 'utf-8');
+  }
+
+  // Discover additional directories mounted at /workspace/extra/*
+  const extraDirs: string[] = [];
+  const extraBase = '/workspace/extra';
+  if (fs.existsSync(extraBase)) {
+    for (const entry of fs.readdirSync(extraBase)) {
+      const fullPath = path.join(extraBase, entry);
+      if (fs.statSync(fullPath).isDirectory()) {
+        extraDirs.push(fullPath);
+      }
+    }
+  }
+  if (extraDirs.length > 0) {
+    log(`Additional directories: ${extraDirs.join(', ')}`);
+  }
+
+  for await (const message of query({
+    prompt: stream,
+    options: {
+      cwd: '/workspace/group',
+      additionalDirectories: extraDirs.length > 0 ? extraDirs : undefined,
+      resume: sessionId,
+      resumeSessionAt: resumeAt,
+      systemPrompt: globalClaudeMd
+        ? { type: 'preset' as const, preset: 'claude_code' as const, append: globalClaudeMd }
+        : undefined,
+      allowedTools: [
+        'Bash',
+        'Read', 'Write', 'Edit', 'Glob', 'Grep',
+        'WebSearch', 'WebFetch',
+        'Task', 'TaskOutput', 'TaskStop',
+        'TeamCreate', 'TeamDelete', 'SendMessage',
+        'TodoWrite', 'ToolSearch', 'Skill',
+        'NotebookEdit',
+        'mcp__nanoclaw__*'
+      ],
+      env: sdkEnv,
+      permissionMode: 'bypassPermissions',
+      allowDangerouslySkipPermissions: true,
+      settingSources: ['project', 'user'],
+      mcpServers: {
+        nanoclaw: {
+          command: 'node',
+          args: [mcpServerPath],
+          env: {
+            NANOCLAW_CHAT_JID: containerInput.chatJid,
+            NANOCLAW_GROUP_FOLDER: containerInput.groupFolder,
+            NANOCLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
+          },
+        },
+      },
+      hooks: {
+        PreCompact: [{ hooks: [createPreCompactHook(containerInput.assistantName)] }],
+      },
+    }
+  })) {
+    messageCount++;
+    const msgType = message.type === 'system' ? `system/${(message as { subtype?: string }).subtype}` : message.type;
+    log(`[msg #${messageCount}] type=${msgType}`);
+
+    if (message.type === 'assistant' && 'uuid' in message) {
+      lastAssistantUuid = (message as { uuid: string }).uuid;
+    }
+
+    if (message.type === 'system' && message.subtype === 'init') {
+      newSessionId = message.session_id;
+      log(`Session initialized: ${newSessionId}`);
+    }
+
+    if (message.type === 'system' && (message as { subtype?: string }).subtype === 'task_notification') {
+      const tn = message as { task_id: string; status: string; summary: string };
+      log(`Task notification: task=${tn.task_id} status=${tn.status} summary=${tn.summary}`);
+    }
+
+    if (message.type === 'result') {
+      resultCount++;
+      const textResult = 'result' in message ? (message as { result?: string }).result : null;
+      log(`Result #${resultCount}: subtype=${message.subtype}${textResult ? ` text=${textResult.slice(0, 200)}` : ''}`);
+      writeOutput({
+        status: 'success',
+        result: textResult || null,
+        newSessionId
+      });
+    }
+  }
+
+  ipcPolling = false;
+  log(`Query done. Messages: ${messageCount}, results: ${resultCount}, lastAssistantUuid: ${lastAssistantUuid || 'none'}, closedDuringQuery: ${closedDuringQuery}`);
+  return { newSessionId, lastAssistantUuid, closedDuringQuery };
+}

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -12,87 +12,24 @@
  *   Each result is wrapped in OUTPUT_START_MARKER / OUTPUT_END_MARKER pairs.
  *   Multiple results may be emitted (one per agent teams result).
  *   Final marker after loop ends signals completion.
+ *
+ * Backend selection:
+ *   AGENT_BACKEND=claude  → Claude Agent SDK (default)
+ *   AGENT_BACKEND=rovodev → Rovo Dev serve HTTP/SSE API
  */
 
 import fs from 'fs';
 import path from 'path';
-import { query, HookCallback, PreCompactHookInput } from '@anthropic-ai/claude-agent-sdk';
 import { fileURLToPath } from 'url';
-
-interface ContainerInput {
-  prompt: string;
-  sessionId?: string;
-  groupFolder: string;
-  chatJid: string;
-  isMain: boolean;
-  isScheduledTask?: boolean;
-  assistantName?: string;
-}
-
-interface ContainerOutput {
-  status: 'success' | 'error';
-  result: string | null;
-  newSessionId?: string;
-  error?: string;
-}
-
-interface SessionEntry {
-  sessionId: string;
-  fullPath: string;
-  summary: string;
-  firstPrompt: string;
-}
-
-interface SessionsIndex {
-  entries: SessionEntry[];
-}
-
-interface SDKUserMessage {
-  type: 'user';
-  message: { role: 'user'; content: string };
-  parent_tool_use_id: null;
-  session_id: string;
-}
-
-const IPC_INPUT_DIR = '/workspace/ipc/input';
-const IPC_INPUT_CLOSE_SENTINEL = path.join(IPC_INPUT_DIR, '_close');
-const IPC_POLL_MS = 500;
-
-/**
- * Push-based async iterable for streaming user messages to the SDK.
- * Keeps the iterable alive until end() is called, preventing isSingleUserTurn.
- */
-class MessageStream {
-  private queue: SDKUserMessage[] = [];
-  private waiting: (() => void) | null = null;
-  private done = false;
-
-  push(text: string): void {
-    this.queue.push({
-      type: 'user',
-      message: { role: 'user', content: text },
-      parent_tool_use_id: null,
-      session_id: '',
-    });
-    this.waiting?.();
-  }
-
-  end(): void {
-    this.done = true;
-    this.waiting?.();
-  }
-
-  async *[Symbol.asyncIterator](): AsyncGenerator<SDKUserMessage> {
-    while (true) {
-      while (this.queue.length > 0) {
-        yield this.queue.shift()!;
-      }
-      if (this.done) return;
-      await new Promise<void>(r => { this.waiting = r; });
-      this.waiting = null;
-    }
-  }
-}
+import type { ContainerInput, RunQueryFn } from './backend-types.js';
+import {
+  IPC_INPUT_DIR,
+  IPC_INPUT_CLOSE_SENTINEL,
+  writeOutput,
+  log,
+  drainIpcInput,
+  waitForIpcMessage,
+} from './shared.js';
 
 async function readStdin(): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -104,364 +41,21 @@ async function readStdin(): Promise<string> {
   });
 }
 
-const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
-const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
-
-function writeOutput(output: ContainerOutput): void {
-  console.log(OUTPUT_START_MARKER);
-  console.log(JSON.stringify(output));
-  console.log(OUTPUT_END_MARKER);
-}
-
-function log(message: string): void {
-  console.error(`[agent-runner] ${message}`);
-}
-
-function getSessionSummary(sessionId: string, transcriptPath: string): string | null {
-  const projectDir = path.dirname(transcriptPath);
-  const indexPath = path.join(projectDir, 'sessions-index.json');
-
-  if (!fs.existsSync(indexPath)) {
-    log(`Sessions index not found at ${indexPath}`);
-    return null;
-  }
-
-  try {
-    const index: SessionsIndex = JSON.parse(fs.readFileSync(indexPath, 'utf-8'));
-    const entry = index.entries.find(e => e.sessionId === sessionId);
-    if (entry?.summary) {
-      return entry.summary;
-    }
-  } catch (err) {
-    log(`Failed to read sessions index: ${err instanceof Error ? err.message : String(err)}`);
-  }
-
-  return null;
-}
-
 /**
- * Archive the full transcript to conversations/ before compaction.
+ * Dynamically load the appropriate backend based on AGENT_BACKEND env var.
  */
-function createPreCompactHook(assistantName?: string): HookCallback {
-  return async (input, _toolUseId, _context) => {
-    const preCompact = input as PreCompactHookInput;
-    const transcriptPath = preCompact.transcript_path;
-    const sessionId = preCompact.session_id;
+async function loadBackend(): Promise<{ runQuery: RunQueryFn; cleanup?: () => Promise<void> }> {
+  const backend = (process.env.AGENT_BACKEND || 'claude').toLowerCase();
 
-    if (!transcriptPath || !fs.existsSync(transcriptPath)) {
-      log('No transcript found for archiving');
-      return {};
-    }
-
-    try {
-      const content = fs.readFileSync(transcriptPath, 'utf-8');
-      const messages = parseTranscript(content);
-
-      if (messages.length === 0) {
-        log('No messages to archive');
-        return {};
-      }
-
-      const summary = getSessionSummary(sessionId, transcriptPath);
-      const name = summary ? sanitizeFilename(summary) : generateFallbackName();
-
-      const conversationsDir = '/workspace/group/conversations';
-      fs.mkdirSync(conversationsDir, { recursive: true });
-
-      const date = new Date().toISOString().split('T')[0];
-      const filename = `${date}-${name}.md`;
-      const filePath = path.join(conversationsDir, filename);
-
-      const markdown = formatTranscriptMarkdown(messages, summary, assistantName);
-      fs.writeFileSync(filePath, markdown);
-
-      log(`Archived conversation to ${filePath}`);
-    } catch (err) {
-      log(`Failed to archive transcript: ${err instanceof Error ? err.message : String(err)}`);
-    }
-
-    return {};
-  };
-}
-
-function sanitizeFilename(summary: string): string {
-  return summary
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, 50);
-}
-
-function generateFallbackName(): string {
-  const time = new Date();
-  return `conversation-${time.getHours().toString().padStart(2, '0')}${time.getMinutes().toString().padStart(2, '0')}`;
-}
-
-interface ParsedMessage {
-  role: 'user' | 'assistant';
-  content: string;
-}
-
-function parseTranscript(content: string): ParsedMessage[] {
-  const messages: ParsedMessage[] = [];
-
-  for (const line of content.split('\n')) {
-    if (!line.trim()) continue;
-    try {
-      const entry = JSON.parse(line);
-      if (entry.type === 'user' && entry.message?.content) {
-        const text = typeof entry.message.content === 'string'
-          ? entry.message.content
-          : entry.message.content.map((c: { text?: string }) => c.text || '').join('');
-        if (text) messages.push({ role: 'user', content: text });
-      } else if (entry.type === 'assistant' && entry.message?.content) {
-        const textParts = entry.message.content
-          .filter((c: { type: string }) => c.type === 'text')
-          .map((c: { text: string }) => c.text);
-        const text = textParts.join('');
-        if (text) messages.push({ role: 'assistant', content: text });
-      }
-    } catch {
-    }
+  if (backend === 'rovodev') {
+    log('Using Rovo Dev backend');
+    const mod = await import('./rovodev-backend.js');
+    return { runQuery: mod.runQuery, cleanup: mod.cleanup };
   }
 
-  return messages;
-}
-
-function formatTranscriptMarkdown(messages: ParsedMessage[], title?: string | null, assistantName?: string): string {
-  const now = new Date();
-  const formatDateTime = (d: Date) => d.toLocaleString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-    hour12: true
-  });
-
-  const lines: string[] = [];
-  lines.push(`# ${title || 'Conversation'}`);
-  lines.push('');
-  lines.push(`Archived: ${formatDateTime(now)}`);
-  lines.push('');
-  lines.push('---');
-  lines.push('');
-
-  for (const msg of messages) {
-    const sender = msg.role === 'user' ? 'User' : (assistantName || 'Assistant');
-    const content = msg.content.length > 2000
-      ? msg.content.slice(0, 2000) + '...'
-      : msg.content;
-    lines.push(`**${sender}**: ${content}`);
-    lines.push('');
-  }
-
-  return lines.join('\n');
-}
-
-/**
- * Check for _close sentinel.
- */
-function shouldClose(): boolean {
-  if (fs.existsSync(IPC_INPUT_CLOSE_SENTINEL)) {
-    try { fs.unlinkSync(IPC_INPUT_CLOSE_SENTINEL); } catch { /* ignore */ }
-    return true;
-  }
-  return false;
-}
-
-/**
- * Drain all pending IPC input messages.
- * Returns messages found, or empty array.
- */
-function drainIpcInput(): string[] {
-  try {
-    fs.mkdirSync(IPC_INPUT_DIR, { recursive: true });
-    const files = fs.readdirSync(IPC_INPUT_DIR)
-      .filter(f => f.endsWith('.json'))
-      .sort();
-
-    const messages: string[] = [];
-    for (const file of files) {
-      const filePath = path.join(IPC_INPUT_DIR, file);
-      try {
-        const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-        fs.unlinkSync(filePath);
-        if (data.type === 'message' && data.text) {
-          messages.push(data.text);
-        }
-      } catch (err) {
-        log(`Failed to process input file ${file}: ${err instanceof Error ? err.message : String(err)}`);
-        try { fs.unlinkSync(filePath); } catch { /* ignore */ }
-      }
-    }
-    return messages;
-  } catch (err) {
-    log(`IPC drain error: ${err instanceof Error ? err.message : String(err)}`);
-    return [];
-  }
-}
-
-/**
- * Wait for a new IPC message or _close sentinel.
- * Returns the messages as a single string, or null if _close.
- */
-function waitForIpcMessage(): Promise<string | null> {
-  return new Promise((resolve) => {
-    const poll = () => {
-      if (shouldClose()) {
-        resolve(null);
-        return;
-      }
-      const messages = drainIpcInput();
-      if (messages.length > 0) {
-        resolve(messages.join('\n'));
-        return;
-      }
-      setTimeout(poll, IPC_POLL_MS);
-    };
-    poll();
-  });
-}
-
-/**
- * Run a single query and stream results via writeOutput.
- * Uses MessageStream (AsyncIterable) to keep isSingleUserTurn=false,
- * allowing agent teams subagents to run to completion.
- * Also pipes IPC messages into the stream during the query.
- */
-async function runQuery(
-  prompt: string,
-  sessionId: string | undefined,
-  mcpServerPath: string,
-  containerInput: ContainerInput,
-  sdkEnv: Record<string, string | undefined>,
-  resumeAt?: string,
-): Promise<{ newSessionId?: string; lastAssistantUuid?: string; closedDuringQuery: boolean }> {
-  const stream = new MessageStream();
-  stream.push(prompt);
-
-  // Poll IPC for follow-up messages and _close sentinel during the query
-  let ipcPolling = true;
-  let closedDuringQuery = false;
-  const pollIpcDuringQuery = () => {
-    if (!ipcPolling) return;
-    if (shouldClose()) {
-      log('Close sentinel detected during query, ending stream');
-      closedDuringQuery = true;
-      stream.end();
-      ipcPolling = false;
-      return;
-    }
-    const messages = drainIpcInput();
-    for (const text of messages) {
-      log(`Piping IPC message into active query (${text.length} chars)`);
-      stream.push(text);
-    }
-    setTimeout(pollIpcDuringQuery, IPC_POLL_MS);
-  };
-  setTimeout(pollIpcDuringQuery, IPC_POLL_MS);
-
-  let newSessionId: string | undefined;
-  let lastAssistantUuid: string | undefined;
-  let messageCount = 0;
-  let resultCount = 0;
-
-  // Load global CLAUDE.md as additional system context (shared across all groups)
-  const globalClaudeMdPath = '/workspace/global/CLAUDE.md';
-  let globalClaudeMd: string | undefined;
-  if (!containerInput.isMain && fs.existsSync(globalClaudeMdPath)) {
-    globalClaudeMd = fs.readFileSync(globalClaudeMdPath, 'utf-8');
-  }
-
-  // Discover additional directories mounted at /workspace/extra/*
-  // These are passed to the SDK so their CLAUDE.md files are loaded automatically
-  const extraDirs: string[] = [];
-  const extraBase = '/workspace/extra';
-  if (fs.existsSync(extraBase)) {
-    for (const entry of fs.readdirSync(extraBase)) {
-      const fullPath = path.join(extraBase, entry);
-      if (fs.statSync(fullPath).isDirectory()) {
-        extraDirs.push(fullPath);
-      }
-    }
-  }
-  if (extraDirs.length > 0) {
-    log(`Additional directories: ${extraDirs.join(', ')}`);
-  }
-
-  for await (const message of query({
-    prompt: stream,
-    options: {
-      cwd: '/workspace/group',
-      additionalDirectories: extraDirs.length > 0 ? extraDirs : undefined,
-      resume: sessionId,
-      resumeSessionAt: resumeAt,
-      systemPrompt: globalClaudeMd
-        ? { type: 'preset' as const, preset: 'claude_code' as const, append: globalClaudeMd }
-        : undefined,
-      allowedTools: [
-        'Bash',
-        'Read', 'Write', 'Edit', 'Glob', 'Grep',
-        'WebSearch', 'WebFetch',
-        'Task', 'TaskOutput', 'TaskStop',
-        'TeamCreate', 'TeamDelete', 'SendMessage',
-        'TodoWrite', 'ToolSearch', 'Skill',
-        'NotebookEdit',
-        'mcp__nanoclaw__*'
-      ],
-      env: sdkEnv,
-      permissionMode: 'bypassPermissions',
-      allowDangerouslySkipPermissions: true,
-      settingSources: ['project', 'user'],
-      mcpServers: {
-        nanoclaw: {
-          command: 'node',
-          args: [mcpServerPath],
-          env: {
-            NANOCLAW_CHAT_JID: containerInput.chatJid,
-            NANOCLAW_GROUP_FOLDER: containerInput.groupFolder,
-            NANOCLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
-          },
-        },
-      },
-      hooks: {
-        PreCompact: [{ hooks: [createPreCompactHook(containerInput.assistantName)] }],
-      },
-    }
-  })) {
-    messageCount++;
-    const msgType = message.type === 'system' ? `system/${(message as { subtype?: string }).subtype}` : message.type;
-    log(`[msg #${messageCount}] type=${msgType}`);
-
-    if (message.type === 'assistant' && 'uuid' in message) {
-      lastAssistantUuid = (message as { uuid: string }).uuid;
-    }
-
-    if (message.type === 'system' && message.subtype === 'init') {
-      newSessionId = message.session_id;
-      log(`Session initialized: ${newSessionId}`);
-    }
-
-    if (message.type === 'system' && (message as { subtype?: string }).subtype === 'task_notification') {
-      const tn = message as { task_id: string; status: string; summary: string };
-      log(`Task notification: task=${tn.task_id} status=${tn.status} summary=${tn.summary}`);
-    }
-
-    if (message.type === 'result') {
-      resultCount++;
-      const textResult = 'result' in message ? (message as { result?: string }).result : null;
-      log(`Result #${resultCount}: subtype=${message.subtype}${textResult ? ` text=${textResult.slice(0, 200)}` : ''}`);
-      writeOutput({
-        status: 'success',
-        result: textResult || null,
-        newSessionId
-      });
-    }
-  }
-
-  ipcPolling = false;
-  log(`Query done. Messages: ${messageCount}, results: ${resultCount}, lastAssistantUuid: ${lastAssistantUuid || 'none'}, closedDuringQuery: ${closedDuringQuery}`);
-  return { newSessionId, lastAssistantUuid, closedDuringQuery };
+  log('Using Claude Agent SDK backend');
+  const mod = await import('./claude-backend.js');
+  return { runQuery: mod.runQuery };
 }
 
 async function main(): Promise<void> {
@@ -481,8 +75,11 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  // Credentials are injected by the host's credential proxy via ANTHROPIC_BASE_URL.
-  // No real secrets exist in the container environment.
+  // Load the backend
+  const { runQuery, cleanup } = await loadBackend();
+
+  // Credentials are injected by the host's credential proxy via ANTHROPIC_BASE_URL (Claude)
+  // or via ~/.rovodev/ mount (Rovo Dev).
   const sdkEnv: Record<string, string | undefined> = { ...process.env };
 
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -520,8 +117,6 @@ async function main(): Promise<void> {
       }
 
       // If _close was consumed during the query, exit immediately.
-      // Don't emit a session-update marker (it would reset the host's
-      // idle timer and cause a 30-min delay before the next _close).
       if (queryResult.closedDuringQuery) {
         log('Close sentinel consumed during query, exiting');
         break;
@@ -551,8 +146,13 @@ async function main(): Promise<void> {
       newSessionId: sessionId,
       error: errorMessage
     });
+    // Clean up backend before exiting
+    if (cleanup) await cleanup();
     process.exit(1);
   }
+
+  // Clean up backend (e.g., shut down Rovo Dev serve)
+  if (cleanup) await cleanup();
 }
 
 main();

--- a/container/agent-runner/src/rovodev-backend.test.ts
+++ b/container/agent-runner/src/rovodev-backend.test.ts
@@ -1,0 +1,590 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+import { PassThrough } from 'stream';
+import http from 'http';
+
+// --- Mocks ---
+
+// Mock shared module
+const mockWriteOutput = vi.fn();
+const mockLog = vi.fn();
+const mockShouldClose = vi.fn(() => false);
+const mockDrainIpcInput = vi.fn(() => [] as string[]);
+
+vi.mock('./shared.js', () => ({
+  writeOutput: (...args: unknown[]) => mockWriteOutput(...args),
+  log: (...args: unknown[]) => mockLog(...args),
+  shouldClose: () => mockShouldClose(),
+  drainIpcInput: () => mockDrainIpcInput(),
+}));
+
+// Mock child_process.spawn
+const mockSpawn = vi.fn();
+vi.mock('child_process', () => ({
+  spawn: (...args: unknown[]) => mockSpawn(...args),
+}));
+
+// We need to intercept http.request calls
+const mockHttpRequest = vi.fn();
+vi.mock('http', async () => {
+  const actual = await vi.importActual<typeof import('http')>('http');
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      request: (...args: unknown[]) => mockHttpRequest(...args),
+    },
+    request: (...args: unknown[]) => mockHttpRequest(...args),
+  };
+});
+
+// --- Helpers ---
+
+function createMockChildProcess(): EventEmitter & {
+  stdout: PassThrough;
+  stderr: PassThrough;
+  kill: ReturnType<typeof vi.fn>;
+} {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdout: PassThrough;
+    stderr: PassThrough;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  proc.stdout = new PassThrough();
+  proc.stderr = new PassThrough();
+  proc.kill = vi.fn();
+  return proc;
+}
+
+function createMockResponse(statusCode: number, body: string): PassThrough & { statusCode: number } {
+  const res = new PassThrough() as PassThrough & { statusCode: number };
+  res.statusCode = statusCode;
+  // Push body data asynchronously
+  process.nextTick(() => {
+    res.push(body);
+    res.push(null); // end stream
+  });
+  return res;
+}
+
+function createMockRequest(): EventEmitter & {
+  write: ReturnType<typeof vi.fn>;
+  end: ReturnType<typeof vi.fn>;
+  destroy: ReturnType<typeof vi.fn>;
+} {
+  const req = new EventEmitter() as EventEmitter & {
+    write: ReturnType<typeof vi.fn>;
+    end: ReturnType<typeof vi.fn>;
+    destroy: ReturnType<typeof vi.fn>;
+  };
+  req.write = vi.fn();
+  req.end = vi.fn();
+  req.destroy = vi.fn();
+  return req;
+}
+
+/** Build an SSE chunk from event name and JSON data */
+function sseChunk(event: string, data: unknown): string {
+  const dataStr = typeof data === 'string' ? data : JSON.stringify(data);
+  return `event: ${event}\ndata: ${dataStr}\n\n`;
+}
+
+const defaultContainerInput = {
+  prompt: 'Hello',
+  groupFolder: 'test-group',
+  chatJid: 'test@chat',
+  isMain: false,
+  assistantName: 'TestBot',
+};
+
+// --- Tests ---
+
+describe('rovodev-backend', () => {
+  let requestCallIndex: number;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    requestCallIndex = 0;
+    process.env.AGENT_BACKEND = 'rovodev';
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete process.env.AGENT_BACKEND;
+    delete process.env.ROVODEV_MODEL;
+  });
+
+  /**
+   * Set up mockHttpRequest to handle a sequence of HTTP requests.
+   * Each handler receives (options, callback) and should call callback(response).
+   */
+  function setupHttpSequence(
+    handlers: Array<{
+      match: (options: { path: string; method: string }) => boolean;
+      handle: (req: ReturnType<typeof createMockRequest>) => void;
+      response: { status: number; body?: string; sse?: string };
+    }>,
+  ) {
+    mockHttpRequest.mockImplementation((options: unknown, callback?: (res: unknown) => void) => {
+      const opts = options as { path: string; method: string; hostname: string; port: string };
+      const req = createMockRequest();
+
+      const handler = handlers.find((h) => h.match(opts));
+
+      if (handler && callback) {
+        const res = new PassThrough() as PassThrough & { statusCode: number };
+        res.statusCode = handler.response.status;
+
+        process.nextTick(() => {
+          callback(res);
+          const body = handler.response.sse || handler.response.body || '';
+          if (body) {
+            res.push(body);
+          }
+          if (!handler.response.sse) {
+            res.push(null);
+          } else {
+            // For SSE, end after pushing
+            process.nextTick(() => res.push(null));
+          }
+          handler.handle(req);
+        });
+      }
+
+      req.end.mockImplementation(() => {
+        if (!handler && callback) {
+          // No matching handler — return 404
+          const res = createMockResponse(404, 'Not found');
+          process.nextTick(() => callback(res));
+        }
+      });
+
+      return req;
+    });
+  }
+
+  describe('SSE parsing', () => {
+    it('accumulates text from part_start and part_delta events', async () => {
+      const sseData =
+        sseChunk('user-prompt', { content: 'Hello', part_kind: 'user-prompt' }) +
+        sseChunk('part_start', { index: 0, part: { content: 'Hi ', part_kind: 'text' }, event_kind: 'part_start' }) +
+        sseChunk('part_delta', { index: 0, delta: { content_delta: 'there!', part_delta_kind: 'text' }, event_kind: 'part_delta' }) +
+        sseChunk('request-usage', { input_tokens: 10, output_tokens: 5 }) +
+        sseChunk('close', '');
+
+      const mockProc = createMockChildProcess();
+      mockSpawn.mockReturnValue(mockProc);
+
+      setupHttpSequence([
+        {
+          match: (o) => o.path === '/healthcheck',
+          handle: () => {},
+          response: { status: 200, body: 'OK' },
+        },
+        {
+          match: (o) => o.path === '/v3/set_chat_message' && o.method === 'POST',
+          handle: () => {},
+          response: { status: 200, body: '{"response":"Chat message set"}' },
+        },
+        {
+          match: (o) => o.path === '/v3/stream_chat',
+          handle: () => {},
+          response: { status: 200, sse: sseData },
+        },
+        {
+          match: (o) => o.path === '/v3/sessions/current_session',
+          handle: () => {},
+          response: { status: 200, body: '{"id":"sess-123"}' },
+        },
+      ]);
+
+      // Dynamically import after mocks are set up
+      const { runQuery } = await import('./rovodev-backend.js');
+
+      const result = await runQuery(
+        'Hello',
+        undefined,
+        '/mock/mcp-server.js',
+        defaultContainerInput,
+        {},
+      );
+
+      // Should have written output with accumulated text
+      expect(mockWriteOutput).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'success',
+          result: 'Hi there!',
+          newSessionId: 'sess-123',
+        }),
+      );
+      expect(result.newSessionId).toBe('sess-123');
+    });
+
+    it('handles tool calls without including tool args in text', async () => {
+      const sseData =
+        sseChunk('part_start', {
+          index: 0,
+          part: { tool_name: 'bash', args: null, tool_call_id: 'tc1', part_kind: 'tool-call' },
+        }) +
+        sseChunk('part_delta', {
+          index: 0,
+          delta: { args_delta: '{"command":"ls"}', tool_call_id: 'tc1', part_delta_kind: 'tool_call' },
+        }) +
+        sseChunk('on_call_tools_start', {
+          parts: [{ tool_name: 'bash', args: '{"command":"ls"}', tool_call_id: 'tc1', part_kind: 'tool-call' }],
+        }) +
+        sseChunk('tool-return', { tool_name: 'bash', content: 'file1\nfile2', tool_call_id: 'tc1', part_kind: 'tool-return' }) +
+        sseChunk('part_start', { index: 1, part: { content: 'Found 2 files.', part_kind: 'text' }, event_kind: 'part_start' }) +
+        sseChunk('close', '');
+
+      const mockProc = createMockChildProcess();
+      mockSpawn.mockReturnValue(mockProc);
+
+      setupHttpSequence([
+        {
+          match: (o) => o.path === '/healthcheck',
+          handle: () => {},
+          response: { status: 200, body: 'OK' },
+        },
+        {
+          match: (o) => o.path === '/v3/set_chat_message',
+          handle: () => {},
+          response: { status: 200, body: '{"response":"Chat message set"}' },
+        },
+        {
+          match: (o) => o.path === '/v3/stream_chat',
+          handle: () => {},
+          response: { status: 200, sse: sseData },
+        },
+        {
+          match: (o) => o.path === '/v3/sessions/current_session',
+          handle: () => {},
+          response: { status: 200, body: '{"id":"sess-456"}' },
+        },
+      ]);
+
+      const mod = await import('./rovodev-backend.js');
+      await mod.runQuery('List files', undefined, '/mock/mcp.js', defaultContainerInput, {});
+
+      // Text output should only contain the final text, not tool args
+      expect(mockWriteOutput).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'success',
+          result: 'Found 2 files.',
+        }),
+      );
+    });
+
+    it('returns null result when close event arrives with no text', async () => {
+      const sseData = sseChunk('close', '');
+
+      const mockProc = createMockChildProcess();
+      mockSpawn.mockReturnValue(mockProc);
+
+      setupHttpSequence([
+        {
+          match: (o) => o.path === '/healthcheck',
+          handle: () => {},
+          response: { status: 200, body: 'OK' },
+        },
+        {
+          match: (o) => o.path === '/v3/set_chat_message',
+          handle: () => {},
+          response: { status: 200, body: '{"response":"ok"}' },
+        },
+        {
+          match: (o) => o.path === '/v3/stream_chat',
+          handle: () => {},
+          response: { status: 200, sse: sseData },
+        },
+        {
+          match: (o) => o.path === '/v3/sessions/current_session',
+          handle: () => {},
+          response: { status: 200, body: '{"id":"sess-789"}' },
+        },
+      ]);
+
+      const mod = await import('./rovodev-backend.js');
+      await mod.runQuery('Hello', undefined, '/mock/mcp.js', defaultContainerInput, {});
+
+      expect(mockWriteOutput).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'success',
+          result: null,
+        }),
+      );
+    });
+  });
+
+  describe('session management', () => {
+    it('restores session when sessionId is provided', async () => {
+      const sseData =
+        sseChunk('part_start', { index: 0, part: { content: 'Resumed.', part_kind: 'text' } }) +
+        sseChunk('close', '');
+
+      const mockProc = createMockChildProcess();
+      mockSpawn.mockReturnValue(mockProc);
+
+      let restoredSessionId: string | null = null;
+
+      setupHttpSequence([
+        {
+          match: (o) => o.path === '/healthcheck',
+          handle: () => {},
+          response: { status: 200, body: 'OK' },
+        },
+        {
+          match: (o) => o.path.startsWith('/v3/sessions/') && o.path.endsWith('/restore'),
+          handle: () => {
+            // Extract session ID from path
+            const match = '/v3/sessions/old-sess-100/restore';
+            restoredSessionId = 'old-sess-100';
+          },
+          response: { status: 200, body: '{}' },
+        },
+        {
+          match: (o) => o.path === '/v3/set_chat_message',
+          handle: () => {},
+          response: { status: 200, body: '{"response":"ok"}' },
+        },
+        {
+          match: (o) => o.path === '/v3/stream_chat',
+          handle: () => {},
+          response: { status: 200, sse: sseData },
+        },
+        {
+          match: (o) => o.path === '/v3/sessions/current_session',
+          handle: () => {},
+          response: { status: 200, body: '{"id":"old-sess-100"}' },
+        },
+      ]);
+
+      const mod = await import('./rovodev-backend.js');
+      const result = await mod.runQuery(
+        'Continue',
+        'old-sess-100',
+        '/mock/mcp.js',
+        defaultContainerInput,
+        {},
+      );
+
+      expect(result.newSessionId).toBe('old-sess-100');
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('Restored session'));
+    });
+  });
+
+  describe('error handling', () => {
+    it('rejects when set_chat_message returns non-200', async () => {
+      const mockProc = createMockChildProcess();
+      mockSpawn.mockReturnValue(mockProc);
+
+      setupHttpSequence([
+        {
+          match: (o) => o.path === '/healthcheck',
+          handle: () => {},
+          response: { status: 200, body: 'OK' },
+        },
+        {
+          match: (o) => o.path === '/v3/set_chat_message',
+          handle: () => {},
+          response: { status: 500, body: '{"error":"Internal error"}' },
+        },
+      ]);
+
+      const mod = await import('./rovodev-backend.js');
+      await expect(
+        mod.runQuery('Hello', undefined, '/mock/mcp.js', defaultContainerInput, {}),
+      ).rejects.toThrow('set_chat_message failed');
+    });
+  });
+
+  describe('cleanup', () => {
+    it('sends shutdown request and cleans up', async () => {
+      const sseData =
+        sseChunk('part_start', { index: 0, part: { content: 'Done.', part_kind: 'text' } }) +
+        sseChunk('close', '');
+
+      const mockProc = createMockChildProcess();
+      mockSpawn.mockReturnValue(mockProc);
+
+      let shutdownCalled = false;
+
+      setupHttpSequence([
+        {
+          match: (o) => o.path === '/healthcheck',
+          handle: () => {},
+          response: { status: 200, body: 'OK' },
+        },
+        {
+          match: (o) => o.path === '/v3/set_chat_message',
+          handle: () => {},
+          response: { status: 200, body: '{"response":"ok"}' },
+        },
+        {
+          match: (o) => o.path === '/v3/stream_chat',
+          handle: () => {},
+          response: { status: 200, sse: sseData },
+        },
+        {
+          match: (o) => o.path === '/v3/sessions/current_session',
+          handle: () => {},
+          response: { status: 200, body: '{"id":"s1"}' },
+        },
+        {
+          match: (o) => o.path === '/shutdown' && o.method === 'POST',
+          handle: () => { shutdownCalled = true; },
+          response: { status: 200, body: 'Shutting down' },
+        },
+      ]);
+
+      const mod = await import('./rovodev-backend.js');
+      await mod.runQuery('Done', undefined, '/mock/mcp.js', defaultContainerInput, {});
+      await mod.cleanup();
+
+      expect(shutdownCalled).toBe(true);
+    });
+  });
+
+  describe('server startup', () => {
+    it('spawns acli rovodev serve with correct args', async () => {
+      const sseData =
+        sseChunk('part_start', { index: 0, part: { content: 'OK', part_kind: 'text' } }) +
+        sseChunk('close', '');
+
+      const mockProc = createMockChildProcess();
+      mockSpawn.mockReturnValue(mockProc);
+
+      setupHttpSequence([
+        {
+          match: (o) => o.path === '/healthcheck',
+          handle: () => {},
+          response: { status: 200, body: 'OK' },
+        },
+        {
+          match: (o) => o.path === '/v3/set_chat_message',
+          handle: () => {},
+          response: { status: 200, body: '{"response":"ok"}' },
+        },
+        {
+          match: (o) => o.path === '/v3/stream_chat',
+          handle: () => {},
+          response: { status: 200, sse: sseData },
+        },
+        {
+          match: (o) => o.path === '/v3/sessions/current_session',
+          handle: () => {},
+          response: { status: 200, body: '{"id":"s1"}' },
+        },
+      ]);
+
+      const mod = await import('./rovodev-backend.js');
+      await mod.runQuery('Test', undefined, '/mock/mcp.js', defaultContainerInput, {});
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'acli',
+        expect.arrayContaining([
+          'rovodev', 'serve',
+          expect.any(String), // port
+          '--non-interactive',
+          '--disable-session-token',
+          '--agent-mode', 'default',
+        ]),
+        expect.objectContaining({
+          cwd: '/workspace/group',
+        }),
+      );
+    });
+
+    it('uses --agent-mode default flag', async () => {
+      const sseData =
+        sseChunk('part_start', { index: 0, part: { content: 'OK', part_kind: 'text' } }) +
+        sseChunk('close', '');
+
+      const mockProc = createMockChildProcess();
+      mockSpawn.mockReturnValue(mockProc);
+
+      // Clean up previous server state so spawn is called again
+      const mod = await import('./rovodev-backend.js');
+      await mod.cleanup();
+
+      setupHttpSequence([
+        {
+          match: (o) => o.path === '/healthcheck',
+          handle: () => {},
+          response: { status: 200, body: 'OK' },
+        },
+        {
+          match: (o) => o.path === '/v3/set_chat_message',
+          handle: () => {},
+          response: { status: 200, body: '{"response":"ok"}' },
+        },
+        {
+          match: (o) => o.path === '/v3/stream_chat',
+          handle: () => {},
+          response: { status: 200, sse: sseData },
+        },
+        {
+          match: (o) => o.path === '/v3/sessions/current_session',
+          handle: () => {},
+          response: { status: 200, body: '{"id":"s1"}' },
+        },
+      ]);
+
+      await mod.runQuery('Test', undefined, '/mock/mcp.js', defaultContainerInput, {});
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'acli',
+        expect.arrayContaining(['--agent-mode', 'default']),
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe('IPC integration', () => {
+    it('appends pending IPC messages to the prompt', async () => {
+      mockDrainIpcInput.mockReturnValueOnce(['Follow up message']);
+
+      const sseData =
+        sseChunk('part_start', { index: 0, part: { content: 'OK', part_kind: 'text' } }) +
+        sseChunk('close', '');
+
+      const mockProc = createMockChildProcess();
+      mockSpawn.mockReturnValue(mockProc);
+
+      let sentMessage = '';
+      setupHttpSequence([
+        {
+          match: (o) => o.path === '/healthcheck',
+          handle: () => {},
+          response: { status: 200, body: 'OK' },
+        },
+        {
+          match: (o) => o.path === '/v3/set_chat_message',
+          handle: (req) => {
+            // Capture what was written
+            const writeCall = req.write.mock.calls[0];
+            if (writeCall) sentMessage = writeCall[0] as string;
+          },
+          response: { status: 200, body: '{"response":"ok"}' },
+        },
+        {
+          match: (o) => o.path === '/v3/stream_chat',
+          handle: () => {},
+          response: { status: 200, sse: sseData },
+        },
+        {
+          match: (o) => o.path === '/v3/sessions/current_session',
+          handle: () => {},
+          response: { status: 200, body: '{"id":"s1"}' },
+        },
+      ]);
+
+      const mod = await import('./rovodev-backend.js');
+      await mod.runQuery('Initial', undefined, '/mock/mcp.js', defaultContainerInput, {});
+
+      // The log should mention draining
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('Draining 1 pending IPC'));
+    });
+  });
+});

--- a/container/agent-runner/src/rovodev-backend.ts
+++ b/container/agent-runner/src/rovodev-backend.ts
@@ -1,0 +1,485 @@
+/**
+ * Rovo Dev Backend
+ * Runs queries via `acli rovodev serve` HTTP/SSE API.
+ *
+ * Flow:
+ *   1. Spawn `acli rovodev serve <port>` as a child process
+ *   2. Wait for /healthcheck to respond
+ *   3. POST /v3/set_chat_message with the prompt
+ *   4. GET /v3/stream_chat — consume SSE events, accumulate text
+ *   5. On `close` event, emit writeOutput() with accumulated text
+ *   6. For follow-up IPC messages, repeat steps 3-5
+ *   7. POST /shutdown on cleanup
+ */
+
+import { ChildProcess, spawn } from 'child_process';
+import http from 'http';
+import type { ContainerInput, BackendResult } from './backend-types.js';
+import { writeOutput, log, shouldClose, drainIpcInput } from './shared.js';
+
+const IPC_POLL_MS = 500;
+const HEALTH_CHECK_INTERVAL_MS = 500;
+const HEALTH_CHECK_TIMEOUT_MS = 60_000;
+const SERVE_PORT_BASE = 19800;
+
+// Pick a port based on process PID to reduce collisions in parallel containers
+function pickPort(): number {
+  return SERVE_PORT_BASE + (process.pid % 200);
+}
+
+// --- HTTP helpers ---
+
+function httpRequest(
+  method: string,
+  url: string,
+  body?: string,
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const parsedUrl = new URL(url);
+    const options = {
+      hostname: parsedUrl.hostname,
+      port: parsedUrl.port,
+      path: parsedUrl.pathname + parsedUrl.search,
+      method,
+      headers: body
+        ? { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) }
+        : undefined,
+    };
+
+    const req = http.request(options, (res) => {
+      let data = '';
+      res.on('data', (chunk) => { data += chunk; });
+      res.on('end', () => resolve({ status: res.statusCode || 0, body: data }));
+    });
+    req.on('error', reject);
+    if (body) req.write(body);
+    req.end();
+  });
+}
+
+function sseStream(
+  url: string,
+  onEvent: (event: string, data: string) => void,
+  onError: (err: Error) => void,
+  onEnd: () => void,
+): { abort: () => void } {
+  const parsedUrl = new URL(url);
+  let aborted = false;
+
+  const req = http.request(
+    {
+      hostname: parsedUrl.hostname,
+      port: parsedUrl.port,
+      path: parsedUrl.pathname + parsedUrl.search,
+      method: 'GET',
+      headers: { Accept: 'text/event-stream' },
+    },
+    (res) => {
+      let buffer = '';
+      res.on('data', (chunk) => {
+        if (aborted) return;
+        buffer += chunk.toString();
+
+        // Parse SSE: events separated by double newline
+        const parts = buffer.split('\n\n');
+        buffer = parts.pop() || '';
+
+        for (const part of parts) {
+          if (!part.trim()) continue;
+          let eventName = 'message';
+          let eventData = '';
+          for (const line of part.split('\n')) {
+            if (line.startsWith('event: ')) {
+              eventName = line.slice(7).trim();
+            } else if (line.startsWith('data: ')) {
+              eventData = line.slice(6);
+            } else if (line === 'data:') {
+              eventData = '';
+            }
+          }
+          onEvent(eventName, eventData);
+        }
+      });
+      res.on('end', () => {
+        if (!aborted) onEnd();
+      });
+      res.on('error', (err) => {
+        if (!aborted) onError(err);
+      });
+    },
+  );
+  req.on('error', (err) => {
+    if (!aborted) onError(err);
+  });
+  req.end();
+
+  return {
+    abort: () => {
+      aborted = true;
+      req.destroy();
+    },
+  };
+}
+
+// --- Rovo Dev serve lifecycle ---
+
+let serverProc: ChildProcess | null = null;
+let serverPort = 0;
+
+function baseUrl(): string {
+  return `http://127.0.0.1:${serverPort}`;
+}
+
+/**
+ * Authenticate acli inside the container using token passed via env var.
+ * Must be called before starting serve.
+ */
+async function authenticateAcli(): Promise<void> {
+  const token = process.env.ROVODEV_API_TOKEN;
+  const email = process.env.ROVODEV_EMAIL;
+
+  if (!token || !email) {
+    log('No ROVODEV_API_TOKEN or ROVODEV_EMAIL, skipping auth (may fail if not pre-authenticated)');
+    return;
+  }
+
+  log(`Authenticating acli as ${email}`);
+
+  return new Promise<void>((resolve, reject) => {
+    const proc = spawn('acli', ['rovodev', 'auth', 'login', '--email', email, '--token'], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    proc.stdin.write(token);
+    proc.stdin.end();
+
+    let stderr = '';
+    proc.stderr.on('data', (data) => { stderr += data.toString(); });
+    proc.stdout.on('data', (data) => { log(`[acli-auth] ${data.toString().trim()}`); });
+
+    proc.on('close', (code) => {
+      if (code === 0) {
+        log('acli authentication successful');
+        resolve();
+      } else {
+        log(`acli authentication failed (code ${code}): ${stderr.trim()}`);
+        reject(new Error(`acli auth failed: ${stderr.trim()}`));
+      }
+    });
+
+    proc.on('error', (err) => {
+      reject(new Error(`acli auth spawn error: ${err.message}`));
+    });
+  });
+}
+
+async function startServer(mcpServerPath: string, containerInput: ContainerInput): Promise<void> {
+  serverPort = pickPort();
+  log(`Starting acli rovodev serve on port ${serverPort}`);
+
+  // Authenticate before starting serve
+  await authenticateAcli();
+
+  const args = [
+    'rovodev', 'serve', String(serverPort),
+    '--non-interactive',
+    '--disable-session-token',
+  ];
+
+  // Agent mode: default gives full agent capabilities
+  args.push('--agent-mode', 'default');
+
+  // Site URL for billing if provided
+  const siteUrl = process.env.ROVODEV_SITE_URL;
+  if (siteUrl) {
+    args.push('--site-url', siteUrl);
+  }
+
+  serverProc = spawn('acli', args, {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    cwd: '/workspace/group',
+    env: {
+      ...process.env,
+      // Provide MCP config for the NanoClaw IPC server
+      NANOCLAW_MCP_SERVER_PATH: mcpServerPath,
+      NANOCLAW_CHAT_JID: containerInput.chatJid,
+      NANOCLAW_GROUP_FOLDER: containerInput.groupFolder,
+      NANOCLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
+    },
+  });
+
+  serverProc.stdout?.on('data', (data) => {
+    const lines = data.toString().trim().split('\n');
+    for (const line of lines) {
+      if (line) log(`[rovodev-stdout] ${line}`);
+    }
+  });
+
+  serverProc.stderr?.on('data', (data) => {
+    const lines = data.toString().trim().split('\n');
+    for (const line of lines) {
+      if (line) log(`[rovodev-stderr] ${line}`);
+    }
+  });
+
+  serverProc.on('error', (err) => {
+    log(`Rovo Dev serve process error: ${err.message}`);
+  });
+
+  serverProc.on('close', (code) => {
+    log(`Rovo Dev serve process exited with code ${code}`);
+    serverProc = null;
+  });
+
+  // Wait for healthcheck
+  await waitForHealthy();
+  log('Rovo Dev serve is healthy');
+
+  // Set model override via API if configured
+  const model = process.env.ROVODEV_MODEL;
+  if (model) {
+    try {
+      const resp = await httpRequest(
+        'PUT',
+        `${baseUrl()}/v3/agent-model`,
+        JSON.stringify({ model }),
+      );
+      if (resp.status === 200) {
+        log(`Model set to: ${model}`);
+      } else {
+        log(`Failed to set model to ${model}: ${resp.status} ${resp.body}`);
+      }
+    } catch (err) {
+      log(`Failed to set model: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+}
+
+async function waitForHealthy(): Promise<void> {
+  const deadline = Date.now() + HEALTH_CHECK_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    try {
+      const resp = await httpRequest('GET', `${baseUrl()}/healthcheck`);
+      if (resp.status === 200) return;
+    } catch {
+      // Server not ready yet
+    }
+    await new Promise((r) => setTimeout(r, HEALTH_CHECK_INTERVAL_MS));
+  }
+  throw new Error(`Rovo Dev serve failed to become healthy within ${HEALTH_CHECK_TIMEOUT_MS}ms`);
+}
+
+async function shutdownServer(): Promise<void> {
+  if (!serverProc) return;
+  try {
+    await httpRequest('POST', `${baseUrl()}/shutdown`);
+  } catch {
+    // If HTTP shutdown fails, kill the process
+    serverProc.kill('SIGTERM');
+  }
+  serverProc = null;
+}
+
+// --- Session management ---
+
+async function restoreSession(sessionId: string): Promise<boolean> {
+  try {
+    const resp = await httpRequest('POST', `${baseUrl()}/v3/sessions/${sessionId}/restore`);
+    return resp.status === 200;
+  } catch (err) {
+    log(`Failed to restore session ${sessionId}: ${err instanceof Error ? err.message : String(err)}`);
+    return false;
+  }
+}
+
+async function getCurrentSessionId(): Promise<string | undefined> {
+  try {
+    const resp = await httpRequest('GET', `${baseUrl()}/v3/sessions/current_session`);
+    if (resp.status === 200) {
+      const data = JSON.parse(resp.body);
+      return data.id;
+    }
+  } catch (err) {
+    log(`Failed to get current session: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  return undefined;
+}
+
+// --- Query execution ---
+
+/**
+ * Send a message and stream the response via SSE.
+ * Returns the accumulated text result.
+ */
+function streamQuery(prompt: string): Promise<string | null> {
+  return new Promise(async (resolve, reject) => {
+    // Step 1: Set the chat message
+    try {
+      const resp = await httpRequest(
+        'POST',
+        `${baseUrl()}/v3/set_chat_message`,
+        JSON.stringify({ message: prompt }),
+      );
+      if (resp.status !== 200) {
+        reject(new Error(`set_chat_message failed: ${resp.status} ${resp.body}`));
+        return;
+      }
+    } catch (err) {
+      reject(err);
+      return;
+    }
+
+    // Step 2: Stream the response
+    let accumulatedText = '';
+    let hasText = false;
+
+    const stream = sseStream(
+      `${baseUrl()}/v3/stream_chat`,
+      (event, data) => {
+        try {
+          switch (event) {
+            case 'part_start': {
+              const parsed = JSON.parse(data);
+              if (parsed.part?.part_kind === 'text' && parsed.part?.content) {
+                accumulatedText += parsed.part.content;
+                hasText = true;
+              }
+              break;
+            }
+            case 'part_delta': {
+              const parsed = JSON.parse(data);
+              if (parsed.delta?.part_delta_kind === 'text' && parsed.delta?.content_delta) {
+                accumulatedText += parsed.delta.content_delta;
+                hasText = true;
+              }
+              break;
+            }
+            case 'tool-return': {
+              const parsed = JSON.parse(data);
+              log(`Tool return: ${parsed.tool_name} (${(parsed.content || '').length} chars)`);
+              break;
+            }
+            case 'on_call_tools_start': {
+              const parsed = JSON.parse(data);
+              const toolNames = (parsed.parts || [])
+                .map((p: { tool_name?: string }) => p.tool_name)
+                .filter(Boolean);
+              log(`Tools executing: ${toolNames.join(', ')}`);
+              break;
+            }
+            case 'request-usage': {
+              const parsed = JSON.parse(data);
+              log(`Usage: input=${parsed.input_tokens || 0}, output=${parsed.output_tokens || 0}`);
+              break;
+            }
+            case 'close': {
+              resolve(hasText ? accumulatedText : null);
+              break;
+            }
+            case 'user-prompt':
+              // Echo of submitted message, ignore
+              break;
+            default:
+              log(`Unknown SSE event: ${event}`);
+          }
+        } catch (err) {
+          log(`Error parsing SSE event ${event}: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      },
+      (err) => {
+        reject(err);
+      },
+      () => {
+        // Stream ended without close event
+        resolve(hasText ? accumulatedText : null);
+      },
+    );
+
+    // Cancel on close sentinel
+    const checkClose = setInterval(() => {
+      if (shouldClose()) {
+        log('Close sentinel detected during Rovo Dev query, cancelling');
+        stream.abort();
+        httpRequest('POST', `${baseUrl()}/v3/cancel`).catch(() => {});
+        clearInterval(checkClose);
+        resolve(null);
+      }
+    }, IPC_POLL_MS);
+
+    // Clean up interval when query completes
+    const origResolve = resolve;
+    resolve = (value) => {
+      clearInterval(checkClose);
+      origResolve(value);
+    };
+  });
+}
+
+/**
+ * Run a single query via Rovo Dev serve API.
+ */
+export async function runQuery(
+  prompt: string,
+  sessionId: string | undefined,
+  mcpServerPath: string,
+  containerInput: ContainerInput,
+  sdkEnv: Record<string, string | undefined>,
+  _resumeAt?: string,
+): Promise<BackendResult> {
+  // Start the server if not running
+  if (!serverProc) {
+    await startServer(mcpServerPath, containerInput);
+  }
+
+  // Restore session if provided
+  if (sessionId) {
+    const restored = await restoreSession(sessionId);
+    if (restored) {
+      log(`Restored session: ${sessionId}`);
+    } else {
+      log(`Could not restore session ${sessionId}, starting fresh`);
+    }
+  }
+
+  // Poll IPC for follow-up messages during query
+  let ipcPolling = true;
+  let closedDuringQuery = false;
+
+  // Append any pending IPC messages to the initial prompt
+  const pending = drainIpcInput();
+  if (pending.length > 0) {
+    log(`Draining ${pending.length} pending IPC messages into prompt`);
+    prompt += '\n' + pending.join('\n');
+  }
+
+  // Run the query
+  const result = await streamQuery(prompt);
+
+  // Check if close was detected
+  if (shouldClose()) {
+    closedDuringQuery = true;
+  }
+
+  // Get session ID
+  const newSessionId = await getCurrentSessionId();
+
+  // Emit result
+  if (result !== null || !closedDuringQuery) {
+    writeOutput({
+      status: 'success',
+      result: result,
+      newSessionId,
+    });
+  }
+
+  ipcPolling = false;
+  log(`Query done. closedDuringQuery: ${closedDuringQuery}`);
+  return { newSessionId, closedDuringQuery };
+}
+
+/**
+ * Clean up: shut down the Rovo Dev serve process.
+ */
+export async function cleanup(): Promise<void> {
+  await shutdownServer();
+}

--- a/container/agent-runner/src/shared.ts
+++ b/container/agent-runner/src/shared.ts
@@ -1,0 +1,141 @@
+/**
+ * Shared utilities for agent backends.
+ * IPC helpers, output protocol, and message streaming.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import type { ContainerOutput } from './backend-types.js';
+
+const IPC_INPUT_DIR = '/workspace/ipc/input';
+const IPC_INPUT_CLOSE_SENTINEL = path.join(IPC_INPUT_DIR, '_close');
+const IPC_POLL_MS = 500;
+
+export { IPC_INPUT_DIR, IPC_INPUT_CLOSE_SENTINEL, IPC_POLL_MS };
+
+// --- Output protocol ---
+
+const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
+const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
+
+export function writeOutput(output: ContainerOutput): void {
+  console.log(OUTPUT_START_MARKER);
+  console.log(JSON.stringify(output));
+  console.log(OUTPUT_END_MARKER);
+}
+
+export function log(message: string): void {
+  console.error(`[agent-runner] ${message}`);
+}
+
+// --- IPC helpers ---
+
+/**
+ * Check for _close sentinel.
+ */
+export function shouldClose(): boolean {
+  if (fs.existsSync(IPC_INPUT_CLOSE_SENTINEL)) {
+    try { fs.unlinkSync(IPC_INPUT_CLOSE_SENTINEL); } catch { /* ignore */ }
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Drain all pending IPC input messages.
+ * Returns messages found, or empty array.
+ */
+export function drainIpcInput(): string[] {
+  try {
+    fs.mkdirSync(IPC_INPUT_DIR, { recursive: true });
+    const files = fs.readdirSync(IPC_INPUT_DIR)
+      .filter(f => f.endsWith('.json'))
+      .sort();
+
+    const messages: string[] = [];
+    for (const file of files) {
+      const filePath = path.join(IPC_INPUT_DIR, file);
+      try {
+        const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+        fs.unlinkSync(filePath);
+        if (data.type === 'message' && data.text) {
+          messages.push(data.text);
+        }
+      } catch (err) {
+        log(`Failed to process input file ${file}: ${err instanceof Error ? err.message : String(err)}`);
+        try { fs.unlinkSync(filePath); } catch { /* ignore */ }
+      }
+    }
+    return messages;
+  } catch (err) {
+    log(`IPC drain error: ${err instanceof Error ? err.message : String(err)}`);
+    return [];
+  }
+}
+
+/**
+ * Wait for a new IPC message or _close sentinel.
+ * Returns the messages as a single string, or null if _close.
+ */
+export function waitForIpcMessage(): Promise<string | null> {
+  return new Promise((resolve) => {
+    const poll = () => {
+      if (shouldClose()) {
+        resolve(null);
+        return;
+      }
+      const messages = drainIpcInput();
+      if (messages.length > 0) {
+        resolve(messages.join('\n'));
+        return;
+      }
+      setTimeout(poll, IPC_POLL_MS);
+    };
+    poll();
+  });
+}
+
+// --- Message streaming ---
+
+interface SDKUserMessage {
+  type: 'user';
+  message: { role: 'user'; content: string };
+  parent_tool_use_id: null;
+  session_id: string;
+}
+
+/**
+ * Push-based async iterable for streaming user messages to the SDK.
+ * Keeps the iterable alive until end() is called, preventing isSingleUserTurn.
+ */
+export class MessageStream {
+  private queue: SDKUserMessage[] = [];
+  private waiting: (() => void) | null = null;
+  private done = false;
+
+  push(text: string): void {
+    this.queue.push({
+      type: 'user',
+      message: { role: 'user', content: text },
+      parent_tool_use_id: null,
+      session_id: '',
+    });
+    this.waiting?.();
+  }
+
+  end(): void {
+    this.done = true;
+    this.waiting?.();
+  }
+
+  async *[Symbol.asyncIterator](): AsyncGenerator<SDKUserMessage> {
+    while (true) {
+      while (this.queue.length > 0) {
+        yield this.queue.shift()!;
+      }
+      if (this.done) return;
+      await new Promise<void>(r => { this.waiting = r; });
+      this.waiting = null;
+    }
+  }
+}

--- a/container/agent-runner/tsconfig.json
+++ b/container/agent-runner/tsconfig.json
@@ -11,5 +11,5 @@
     "declaration": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }

--- a/setup/environment.ts
+++ b/setup/environment.ts
@@ -39,8 +39,43 @@ export async function run(_args: string[]): Promise<void> {
     }
   }
 
+  // Check acli (Rovo Dev CLI)
+  let acli: 'installed' | 'not_found' = 'not_found';
+  if (commandExists('acli')) {
+    acli = 'installed';
+  }
+
+  // Detect configured agent backend from .env
+  let agentBackend: 'claude' | 'rovodev' | 'none' = 'none';
+  const envPath = path.join(projectRoot, '.env');
+  if (fs.existsSync(envPath)) {
+    const envContent = fs.readFileSync(envPath, 'utf-8');
+    const match = envContent.match(/^AGENT_BACKEND=(\S+)/m);
+    if (match) {
+      agentBackend = match[1].toLowerCase() === 'rovodev' ? 'rovodev' : 'claude';
+    }
+  }
+
+  // Check Rovo Dev auth status
+  let rovodevAuth: 'authenticated' | 'not_authenticated' | 'not_installed' =
+    'not_installed';
+  if (acli === 'installed') {
+    try {
+      const { execSync } = await import('child_process');
+      const authOutput = execSync('acli rovodev auth status 2>&1', {
+        encoding: 'utf-8',
+        timeout: 10000,
+      });
+      rovodevAuth = authOutput.includes('Authenticated')
+        ? 'authenticated'
+        : 'not_authenticated';
+    } catch {
+      rovodevAuth = 'not_authenticated';
+    }
+  }
+
   // Check existing config
-  const hasEnv = fs.existsSync(path.join(projectRoot, '.env'));
+  const hasEnv = fs.existsSync(envPath);
 
   const authDir = path.join(projectRoot, 'store', 'auth');
   const hasAuth = fs.existsSync(authDir) && fs.readdirSync(authDir).length > 0;
@@ -72,6 +107,9 @@ export async function run(_args: string[]): Promise<void> {
       wsl,
       appleContainer,
       docker,
+      acli,
+      agentBackend,
+      rovodevAuth,
       hasEnv,
       hasAuth,
       hasRegisteredGroups,
@@ -85,6 +123,9 @@ export async function run(_args: string[]): Promise<void> {
     IS_HEADLESS: headless,
     APPLE_CONTAINER: appleContainer,
     DOCKER: docker,
+    ACLI: acli,
+    AGENT_BACKEND: agentBackend,
+    ROVODEV_AUTH: rovodevAuth,
     HAS_ENV: hasEnv,
     HAS_AUTH: hasAuth,
     HAS_REGISTERED_GROUPS: hasRegisteredGroups,

--- a/setup/verify.ts
+++ b/setup/verify.ts
@@ -96,13 +96,35 @@ export async function run(_args: string[]): Promise<void> {
     }
   }
 
-  // 3. Check credentials
+  // 3. Check credentials (backend-aware)
   let credentials = 'missing';
+  let agentBackend = 'claude';
   const envFile = path.join(projectRoot, '.env');
   if (fs.existsSync(envFile)) {
     const envContent = fs.readFileSync(envFile, 'utf-8');
-    if (/^(CLAUDE_CODE_OAUTH_TOKEN|ANTHROPIC_API_KEY)=/m.test(envContent)) {
-      credentials = 'configured';
+    const backendMatch = envContent.match(/^AGENT_BACKEND=(\S+)/m);
+    if (backendMatch) {
+      agentBackend = backendMatch[1].toLowerCase();
+    }
+
+    if (agentBackend === 'rovodev') {
+      // Rovo Dev: check acli auth status
+      try {
+        const authOutput = execSync('acli rovodev auth status 2>&1', {
+          encoding: 'utf-8',
+          timeout: 10000,
+        });
+        if (authOutput.includes('Authenticated')) {
+          credentials = 'configured';
+        }
+      } catch {
+        // Auth check failed — credentials missing
+      }
+    } else {
+      // Claude: check for OAuth token or API key
+      if (/^(CLAUDE_CODE_OAUTH_TOKEN|ANTHROPIC_API_KEY)=/m.test(envContent)) {
+        credentials = 'configured';
+      }
     }
   }
 
@@ -179,6 +201,7 @@ export async function run(_args: string[]): Promise<void> {
   emitStatus('VERIFY', {
     SERVICE: service,
     CONTAINER_RUNTIME: containerRuntime,
+    AGENT_BACKEND: agentBackend,
     CREDENTIALS: credentials,
     CONFIGURED_CHANNELS: configuredChannels.join(','),
     CHANNEL_AUTH: JSON.stringify(channelAuth),

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,13 +6,38 @@ import { readEnvFile } from './env.js';
 // Read config values from .env (falls back to process.env).
 // Secrets (API keys, tokens) are NOT read here — they are loaded only
 // by the credential proxy (credential-proxy.ts), never exposed to containers.
-const envConfig = readEnvFile(['ASSISTANT_NAME', 'ASSISTANT_HAS_OWN_NUMBER']);
+const envConfig = readEnvFile([
+  'ASSISTANT_NAME',
+  'ASSISTANT_HAS_OWN_NUMBER',
+  'AGENT_BACKEND',
+  'ROVODEV_MODEL',
+  'ROVODEV_SITE_URL',
+]);
 
 export const ASSISTANT_NAME =
   process.env.ASSISTANT_NAME || envConfig.ASSISTANT_NAME || 'Andy';
 export const ASSISTANT_HAS_OWN_NUMBER =
   (process.env.ASSISTANT_HAS_OWN_NUMBER ||
     envConfig.ASSISTANT_HAS_OWN_NUMBER) === 'true';
+
+// Agent backend: "claude" (default) or "rovodev"
+export type AgentBackend = 'claude' | 'rovodev';
+const rawBackend = (
+  process.env.AGENT_BACKEND ||
+  envConfig.AGENT_BACKEND ||
+  'claude'
+).toLowerCase();
+export const AGENT_BACKEND: AgentBackend =
+  rawBackend === 'rovodev' ? 'rovodev' : 'claude';
+
+// Rovo Dev model override (optional)
+export const ROVODEV_MODEL: string | undefined =
+  process.env.ROVODEV_MODEL || envConfig.ROVODEV_MODEL || undefined;
+
+// Rovo Dev site URL (required when user has multiple Atlassian sites)
+export const ROVODEV_SITE_URL: string | undefined =
+  process.env.ROVODEV_SITE_URL || envConfig.ROVODEV_SITE_URL || undefined;
+
 export const POLL_INTERVAL = 2000;
 export const SCHEDULER_POLL_INTERVAL = 60000;
 

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -8,6 +8,7 @@ const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
 
 // Mock config
 vi.mock('./config.js', () => ({
+  AGENT_BACKEND: 'claude',
   CONTAINER_IMAGE: 'nanoclaw-agent:latest',
   CONTAINER_MAX_OUTPUT_SIZE: 10485760,
   CONTAINER_TIMEOUT: 1800000, // 30min
@@ -15,6 +16,8 @@ vi.mock('./config.js', () => ({
   DATA_DIR: '/tmp/nanoclaw-test-data',
   GROUPS_DIR: '/tmp/nanoclaw-test-groups',
   IDLE_TIMEOUT: 1800000, // 30min
+  ROVODEV_MODEL: undefined,
+  ROVODEV_SITE_URL: undefined,
   TIMEZONE: 'America/Los_Angeles',
 }));
 

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -2,11 +2,13 @@
  * Container Runner for NanoClaw
  * Spawns agent execution in containers and handles IPC
  */
-import { ChildProcess, exec, spawn } from 'child_process';
+import { ChildProcess, exec, execSync, spawn } from 'child_process';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
 import {
+  AGENT_BACKEND,
   CONTAINER_IMAGE,
   CONTAINER_MAX_OUTPUT_SIZE,
   CONTAINER_TIMEOUT,
@@ -14,6 +16,8 @@ import {
   DATA_DIR,
   GROUPS_DIR,
   IDLE_TIMEOUT,
+  ROVODEV_MODEL,
+  ROVODEV_SITE_URL,
   TIMEZONE,
 } from './config.js';
 import { resolveGroupFolderPath, resolveGroupIpcPath } from './group-folder.js';
@@ -54,6 +58,80 @@ interface VolumeMount {
   hostPath: string;
   containerPath: string;
   readonly: boolean;
+}
+
+/**
+ * Extract Rovo Dev API token from the macOS keychain.
+ * The token is stored by `acli` under service "acli" with account "rovodev:<account_id>".
+ * Falls back to ROVODEV_API_TOKEN env var if keychain is unavailable (e.g., on Linux).
+ */
+function getRovoDevToken(): string | undefined {
+  // Check env var first (allows manual override)
+  if (process.env.ROVODEV_API_TOKEN) {
+    return process.env.ROVODEV_API_TOKEN;
+  }
+
+  if (process.platform !== 'darwin') {
+    logger.warn('Rovo Dev keychain extraction only supported on macOS; set ROVODEV_API_TOKEN env var');
+    return undefined;
+  }
+
+  try {
+    // Read the account ID from acli's config file
+    const configPath = path.join(
+      process.env.HOME || os.homedir(),
+      '.config', 'acli', 'rovodev_config.yaml',
+    );
+    let accountId: string | undefined;
+    if (fs.existsSync(configPath)) {
+      const content = fs.readFileSync(configPath, 'utf-8');
+      const match = content.match(/accountId:\s*(\S+)/);
+      if (match) accountId = `rovodev:${match[1]}`;
+    }
+    if (!accountId) {
+      logger.warn('No Rovo Dev accountId found in config');
+      return undefined;
+    }
+
+    const raw = execSync(
+      `security find-generic-password -s "acli" -a "${accountId}" -w 2>/dev/null`,
+      { encoding: 'utf-8', timeout: 5000 },
+    ).trim();
+
+    if (!raw) return undefined;
+
+    // Decode go-keyring-base64: prefix (macOS uses -D for decode)
+    const b64 = raw.replace(/^go-keyring-base64:/, '');
+    return Buffer.from(b64, 'base64').toString('utf-8');
+  } catch {
+    logger.warn('Failed to extract Rovo Dev token from keychain');
+    return undefined;
+  }
+}
+
+/**
+ * Read the Rovo Dev email from acli config.
+ */
+function getRovoDevEmail(): string | undefined {
+  if (process.env.ROVODEV_EMAIL) {
+    return process.env.ROVODEV_EMAIL;
+  }
+
+  const configPath = path.join(
+    process.env.HOME || os.homedir(),
+    '.config', 'acli', 'rovodev_config.yaml',
+  );
+
+  try {
+    if (fs.existsSync(configPath)) {
+      const content = fs.readFileSync(configPath, 'utf-8');
+      const match = content.match(/email:\s*(\S+)/);
+      if (match) return match[1];
+    }
+  } catch {
+    // Ignore
+  }
+  return undefined;
 }
 
 function buildVolumeMounts(
@@ -199,6 +277,21 @@ function buildVolumeMounts(
     readonly: false,
   });
 
+  // Rovo Dev auth: mount host ~/.rovodev/ into container (read-only)
+  if (AGENT_BACKEND === 'rovodev') {
+    const rovodevDir = path.join(
+      process.env.HOME || os.homedir(),
+      '.rovodev',
+    );
+    if (fs.existsSync(rovodevDir)) {
+      mounts.push({
+        hostPath: rovodevDir,
+        containerPath: '/home/node/.rovodev',
+        readonly: true,
+      });
+    }
+  }
+
   // Additional mounts validated against external allowlist (tamper-proof from containers)
   if (group.containerConfig?.additionalMounts) {
     const validatedMounts = validateAdditionalMounts(
@@ -221,21 +314,44 @@ function buildContainerArgs(
   // Pass host timezone so container's local time matches the user's
   args.push('-e', `TZ=${TIMEZONE}`);
 
-  // Route API traffic through the credential proxy (containers never see real secrets)
-  args.push(
-    '-e',
-    `ANTHROPIC_BASE_URL=http://${CONTAINER_HOST_GATEWAY}:${CREDENTIAL_PROXY_PORT}`,
-  );
+  // Pass agent backend selection to container
+  args.push('-e', `AGENT_BACKEND=${AGENT_BACKEND}`);
 
-  // Mirror the host's auth method with a placeholder value.
-  // API key mode: SDK sends x-api-key, proxy replaces with real key.
-  // OAuth mode:   SDK exchanges placeholder token for temp API key,
-  //               proxy injects real OAuth token on that exchange request.
-  const authMode = detectAuthMode();
-  if (authMode === 'api-key') {
-    args.push('-e', 'ANTHROPIC_API_KEY=placeholder');
+  if (AGENT_BACKEND === 'rovodev') {
+    // Rovo Dev backend: extract API token from host keychain and pass to container.
+    // The container will authenticate on startup before running serve.
+    const rovodevToken = getRovoDevToken();
+    if (rovodevToken) {
+      args.push('-e', `ROVODEV_API_TOKEN=${rovodevToken}`);
+    }
+    const rovodevEmail = getRovoDevEmail();
+    if (rovodevEmail) {
+      args.push('-e', `ROVODEV_EMAIL=${rovodevEmail}`);
+    }
+    if (ROVODEV_MODEL) {
+      args.push('-e', `ROVODEV_MODEL=${ROVODEV_MODEL}`);
+    }
+    if (ROVODEV_SITE_URL) {
+      args.push('-e', `ROVODEV_SITE_URL=${ROVODEV_SITE_URL}`);
+    }
   } else {
-    args.push('-e', 'CLAUDE_CODE_OAUTH_TOKEN=placeholder');
+    // Claude backend: route API traffic through the credential proxy
+    // (containers never see real secrets)
+    args.push(
+      '-e',
+      `ANTHROPIC_BASE_URL=http://${CONTAINER_HOST_GATEWAY}:${CREDENTIAL_PROXY_PORT}`,
+    );
+
+    // Mirror the host's auth method with a placeholder value.
+    // API key mode: SDK sends x-api-key, proxy replaces with real key.
+    // OAuth mode:   SDK exchanges placeholder token for temp API key,
+    //               proxy injects real OAuth token on that exchange request.
+    const authMode = detectAuthMode();
+    if (authMode === 'api-key') {
+      args.push('-e', 'ANTHROPIC_API_KEY=placeholder');
+    } else {
+      args.push('-e', 'CLAUDE_CODE_OAUTH_TOKEN=placeholder');
+    }
   }
 
   // Runtime-specific args for host gateway resolution

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['src/**/*.test.ts', 'setup/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'setup/**/*.test.ts', 'container/**/*.test.ts'],
   },
 });


### PR DESCRIPTION
Add acli rovodev serve as an alternative to the Claude Agent SDK for running agent queries inside containers. Both backends coexist and are selected via AGENT_BACKEND config (claude|rovodev).

Backend architecture:
- Extract Claude SDK logic to claude-backend.ts
- New rovodev-backend.ts using HTTP/SSE API (set_chat_message + stream_chat)
- Shared utilities in shared.ts (IPC, output protocol, MessageStream)
- Dynamic backend loading in agent-runner index.ts

Container changes:
- Dockerfile installs acli binary for Rovo Dev CLI
- Auth token extracted from macOS keychain, passed via env var
- Container authenticates on startup before starting serve

Host changes:
- src/config.ts: AGENT_BACKEND, ROVODEV_MODEL, ROVODEV_SITE_URL
- src/container-runner.ts: backend-aware env vars, ~/.rovodev mount, keychain token extraction, acli config email reading

Setup flow:
- Step 4 now asks user to choose Claude or Rovo Dev backend
- environment.ts detects acli, AGENT_BACKEND, rovodev auth status
- verify.ts checks credentials based on configured backend
- SKILL.md documents full Rovo Dev setup path

Tests: 228 pass (219 existing + 9 new rovodev backend tests)

<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description


## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files)
- [x] SKILL.md is under 500 lines
- [x] I tested this skill on a fresh clone
