### PR TITLE
docs: add flobo3 to contributors

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,3 +13,4 @@ Thanks to everyone who has contributed to NanoClaw!
 - [baijunjie](https://github.com/baijunjie) — BaiJunjie
 - [Michaelliv](https://github.com/Michaelliv) — Michael
 - [kk17](https://github.com/kk17) — Kyle Zhike Chen
+- [flobo3](https://github.com/flobo3) — Flo


### PR DESCRIPTION
Adds flobo3 to CONTRIBUTORS.md for the Telegram topics fix (message_thread_id support).

The code fix has been applied directly to the [telegram fork](https://github.com/qwibitai/nanoclaw-telegram).

Closes #1420