### PR TITLE
feat: add optional name parameter to schedule_task for idempotency

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -93,6 +93,15 @@ function createSchema(database: Database.Database): void {
     /* column already exists */
   }
 
+  // Add name column for task idempotency (migration for existing DBs)
+  try {
+    database.exec(
+      `ALTER TABLE scheduled_tasks ADD COLUMN name TEXT`,
+    );
+  } catch {
+    /* column already exists */
+  }
+
   // Add is_bot_message column if it doesn't exist (migration for existing DBs)
   try {
     database.exec(
@@ -368,8 +377,8 @@ export function createTask(
 ): void {
   db.prepare(
     `
-    INSERT INTO scheduled_tasks (id, group_folder, chat_jid, prompt, schedule_type, schedule_value, context_mode, next_run, status, created_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO scheduled_tasks (id, group_folder, chat_jid, prompt, schedule_type, schedule_value, context_mode, name, next_run, status, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `,
   ).run(
     task.id,
@@ -379,10 +388,22 @@ export function createTask(
     task.schedule_type,
     task.schedule_value,
     task.context_mode || 'isolated',
+    task.name || null,
     task.next_run,
     task.status,
     task.created_at,
   );
+}
+
+export function getActiveTaskByName(
+  name: string,
+  groupFolder: string,
+): ScheduledTask | undefined {
+  return db
+    .prepare(
+      `SELECT * FROM scheduled_tasks WHERE name = ? AND group_folder = ? AND status = 'active'`,
+    )
+    .get(name, groupFolder) as ScheduledTask | undefined;
 }
 
 export function getTaskById(id: string): ScheduledTask | undefined {

--- a/src/ipc-auth.test.ts
+++ b/src/ipc-auth.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import {
   _initTestDatabase,
   createTask,
+  getActiveTaskByName,
   getAllTasks,
   getRegisteredGroup,
   getTaskById,
@@ -633,6 +634,129 @@ describe('schedule_task context_mode', () => {
 
     const tasks = getAllTasks();
     expect(tasks[0].context_mode).toBe('isolated');
+  });
+});
+
+// --- schedule_task idempotency (Issue #783) ---
+
+describe('schedule_task idempotency via name', () => {
+  it('deduplicates tasks with the same name in the same group', async () => {
+    await processTaskIpc(
+      {
+        type: 'schedule_task',
+        prompt: 'daily report',
+        schedule_type: 'cron',
+        schedule_value: '0 9 * * *',
+        targetJid: 'other@g.us',
+        name: 'daily-report',
+      },
+      'whatsapp_main',
+      true,
+      deps,
+    );
+
+    // Second call with same name should be a no-op
+    await processTaskIpc(
+      {
+        type: 'schedule_task',
+        prompt: 'daily report',
+        schedule_type: 'cron',
+        schedule_value: '0 9 * * *',
+        targetJid: 'other@g.us',
+        name: 'daily-report',
+      },
+      'whatsapp_main',
+      true,
+      deps,
+    );
+
+    const tasks = getAllTasks();
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].name).toBe('daily-report');
+  });
+
+  it('allows same name in different groups', async () => {
+    await processTaskIpc(
+      {
+        type: 'schedule_task',
+        prompt: 'report for other',
+        schedule_type: 'interval',
+        schedule_value: '3600000',
+        targetJid: 'other@g.us',
+        name: 'hourly-check',
+      },
+      'whatsapp_main',
+      true,
+      deps,
+    );
+
+    await processTaskIpc(
+      {
+        type: 'schedule_task',
+        prompt: 'report for third',
+        schedule_type: 'interval',
+        schedule_value: '3600000',
+        targetJid: 'third@g.us',
+        name: 'hourly-check',
+      },
+      'whatsapp_main',
+      true,
+      deps,
+    );
+
+    expect(getAllTasks()).toHaveLength(2);
+  });
+
+  it('creates duplicate tasks when no name is provided', async () => {
+    await processTaskIpc(
+      {
+        type: 'schedule_task',
+        prompt: 'unnamed task',
+        schedule_type: 'once',
+        schedule_value: '2025-06-01T00:00:00',
+        targetJid: 'other@g.us',
+      },
+      'whatsapp_main',
+      true,
+      deps,
+    );
+
+    await processTaskIpc(
+      {
+        type: 'schedule_task',
+        prompt: 'unnamed task',
+        schedule_type: 'once',
+        schedule_value: '2025-06-01T00:00:00',
+        targetJid: 'other@g.us',
+      },
+      'whatsapp_main',
+      true,
+      deps,
+    );
+
+    // Without a name, duplicates are still allowed (backwards compatible)
+    expect(getAllTasks()).toHaveLength(2);
+  });
+
+  it('stores name on created task and retrieves via getActiveTaskByName', async () => {
+    await processTaskIpc(
+      {
+        type: 'schedule_task',
+        prompt: 'named task',
+        schedule_type: 'cron',
+        schedule_value: '0 9 * * *',
+        targetJid: 'other@g.us',
+        name: 'my-task',
+      },
+      'whatsapp_main',
+      true,
+      deps,
+    );
+
+    const task = getActiveTaskByName('my-task', 'other-group');
+    expect(task).toBeDefined();
+    expect(task!.name).toBe('my-task');
+    expect(task!.prompt).toBe('named task');
   });
 });
 

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -5,7 +5,13 @@ import { CronExpressionParser } from 'cron-parser';
 
 import { DATA_DIR, IPC_POLL_INTERVAL, TIMEZONE } from './config.js';
 import { AvailableGroup } from './container-runner.js';
-import { createTask, deleteTask, getTaskById, updateTask } from './db.js';
+import {
+  createTask,
+  deleteTask,
+  getActiveTaskByName,
+  getTaskById,
+  updateTask,
+} from './db.js';
 import { isValidGroupFolder } from './group-folder.js';
 import { logger } from './logger.js';
 import { RegisteredGroup } from './types.js';
@@ -248,6 +254,24 @@ export async function processTaskIpc(
           nextRun = date.toISOString();
         }
 
+        const taskName = data.name
+          ? String(data.name).trim() || null
+          : null;
+
+        // Idempotency: if a name is provided and an active task with that
+        // name already exists in this group, return the existing task ID
+        // instead of creating a duplicate.  (Fixes #783)
+        if (taskName) {
+          const existing = getActiveTaskByName(taskName, targetFolder);
+          if (existing) {
+            logger.info(
+              { taskId: existing.id, taskName, targetFolder },
+              'Task with this name already exists, skipping duplicate',
+            );
+            break;
+          }
+        }
+
         const taskId =
           data.taskId ||
           `task-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -263,12 +287,13 @@ export async function processTaskIpc(
           schedule_type: scheduleType,
           schedule_value: data.schedule_value,
           context_mode: contextMode,
+          name: taskName,
           next_run: nextRun,
           status: 'active',
           created_at: new Date().toISOString(),
         });
         logger.info(
-          { taskId, sourceGroup, targetFolder, contextMode },
+          { taskId, taskName, sourceGroup, targetFolder, contextMode },
           'Task created via IPC',
         );
         deps.onTasksChanged();

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,7 @@ export interface ScheduledTask {
   schedule_type: 'cron' | 'interval' | 'once';
   schedule_value: string;
   context_mode: 'group' | 'isolated';
+  name?: string | null;
   next_run: string | null;
   last_run: string | null;
   last_result: string | null;


### PR DESCRIPTION
## Summary

- Add optional `name` parameter to `schedule_task` IPC call that acts as an idempotency key
- If an active task with the same name already exists in the group, the duplicate is silently skipped
- Backwards compatible: tasks without a name behave exactly as before

Closes #783

## Changes

| File | Change |
|------|--------|
| `src/types.ts` | Add optional `name` field to `ScheduledTask` interface |
| `src/db.ts` | Migration to add `name` column; new `getActiveTaskByName()` query; include `name` in `createTask()` INSERT |
| `src/ipc.ts` | Check for existing active task by name before creating; pass `name` through to `createTask()` |
| `src/ipc-auth.test.ts` | 4 new tests: dedup with same name, same name across different groups allowed, no-name tasks still duplicate, name stored and queryable |

## How it works

Agents pass an optional `name` when scheduling:
```json
{"type": "schedule_task", "name": "daily-report", "prompt": "...", ...}
```

Before inserting, the IPC handler checks:
```sql
SELECT * FROM scheduled_tasks WHERE name = ? AND group_folder = ? AND status = 'active'
```

If a match is found, the task is skipped with an info log. No existing behavior changes.

## Test plan

- [x] All 274 existing tests pass
- [x] New test: duplicate named task is deduplicated (1 task created, not 2)
- [x] New test: same name in different groups creates separate tasks
- [x] New test: tasks without name still allow duplicates (backwards compat)
- [x] New test: `getActiveTaskByName` returns stored task correctly