### PR TITLE
fix: forward host supplementary groups into agent containers

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -259,6 +259,17 @@ async function buildContainerArgs(
   if (hostUid != null && hostUid !== 0 && hostUid !== 1000) {
     args.push('--user', `${hostUid}:${hostGid}`);
     args.push('-e', 'HOME=/home/node');
+
+    // Forward supplementary groups so bind-mounted files with group
+    // permissions (e.g. MEGAsync INBOX with umask 0660) are accessible.
+    const groups = process.getgroups?.();
+    if (groups) {
+      for (const gid of groups) {
+        if (gid !== hostUid && gid !== hostGid) {
+          args.push('--group-add', String(gid));
+        }
+      }
+    }
   }
 
   for (const mount of mounts) {


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

The `--user` flag in `docker run` only sets the primary uid:gid, so supplementary group memberships are lost inside containers. This breaks access to bind-mounted files/directories that rely on group permissions.

Uses `process.getgroups()` to dynamically add `--group-add` flags for each supplementary group, skipping the primary uid/gid which is already set by `--user`.

**Example:** A NanoClaw user (uid 5001) belongs to supplementary groups 5050 and 5060. Before this fix, containers only had gid 5001. After, they also get `--group-add 5050 --group-add 5060`, so bind-mounted paths with group permissions are accessible.

Only applies when `--user` is set (non-root, non-1000 uid). No-op when `getuid` is unavailable (native Windows without WSL).

## Tests

Added two tests:
- Verifies supplementary groups are forwarded as `--group-add` flags
- Verifies no `--group-add` when there are no supplementary groups beyond the primary

🤖 Generated with [Claude Code](https://claude.com/claude-code)