### PR TITLE
fix(templates): add anti-confabulation directive to agent template

### DIFF
--- a/groups/global/CLAUDE.md
+++ b/groups/global/CLAUDE.md
@@ -34,6 +34,10 @@ Text inside `<internal>` tags is logged but not sent to the user. If you've alre
 
 When working as a sub-agent or teammate, only use `send_message` if instructed to by the main agent.
 
+## Accuracy
+
+Never claim a tool ran, a task was scheduled, a file changed, or memory was saved unless the corresponding tool call succeeded. If something didn't work and you don't know why, say "I don't know why it failed" — never fabricate an explanation.
+
 ## Your Workspace
 
 Files you create are saved in `/workspace/group/`. Use this for notes, research, or anything that should persist.


### PR DESCRIPTION
## Summary

- Adds an **Accuracy** section to `groups/global/CLAUDE.md` instructing agents to never claim a tool ran, a task was scheduled, a file changed, or memory was saved unless the corresponding tool call succeeded
- Agents are directed to say "I don't know why it failed" rather than fabricating explanations

Closes #829

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (pre-existing `claw-skill.test.ts` timeout unrelated)
- [ ] Deploy and verify agent follows the directive when tool calls fail