### PR TITLE
fix: clear stale session IDs to prevent permanent resume failures

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -582,7 +582,20 @@ async function main(): Promise<void> {
     while (true) {
       log(`Starting query (session: ${sessionId || 'new'}, resumeAt: ${resumeAt || 'latest'})...`);
 
-      const queryResult = await runQuery(prompt, sessionId, mcpServerPath, containerInput, sdkEnv, resumeAt);
+      let queryResult;
+      try {
+        queryResult = await runQuery(prompt, sessionId, mcpServerPath, containerInput, sdkEnv, resumeAt);
+      } catch (resumeErr) {
+        const msg = resumeErr instanceof Error ? resumeErr.message : String(resumeErr);
+        if (sessionId && /session|conversation not found|resume/i.test(msg)) {
+          log(`Session resume failed (${msg}), retrying with fresh session`);
+          sessionId = undefined;
+          resumeAt = undefined;
+          queryResult = await runQuery(prompt, sessionId, mcpServerPath, containerInput, sdkEnv, resumeAt);
+        } else {
+          throw resumeErr;
+        }
+      }
       if (queryResult.newSessionId) {
         sessionId = queryResult.newSessionId;
       }

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -3,13 +3,17 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import {
   _initTestDatabase,
   createTask,
+  deleteSession,
   deleteTask,
   getAllChats,
   getAllRegisteredGroups,
+  getAllSessions,
   getMessagesSince,
   getNewMessages,
+  getSession,
   getTaskById,
   setRegisteredGroup,
+  setSession,
   storeChatMetadata,
   storeMessage,
   updateTask,
@@ -480,5 +484,104 @@ describe('registered group isMain', () => {
     const group = groups['group@g.us'];
     expect(group).toBeDefined();
     expect(group.isMain).toBeUndefined();
+  });
+});
+
+// --- Session CRUD ---
+
+describe('session management', () => {
+  it('stores and retrieves a session', () => {
+    setSession('whatsapp_main', 'session-abc');
+    expect(getSession('whatsapp_main')).toBe('session-abc');
+  });
+
+  it('returns undefined for unknown group', () => {
+    expect(getSession('nonexistent')).toBeUndefined();
+  });
+
+  it('overwrites session on update', () => {
+    setSession('whatsapp_main', 'session-old');
+    setSession('whatsapp_main', 'session-new');
+    expect(getSession('whatsapp_main')).toBe('session-new');
+  });
+
+  it('deletes a session', () => {
+    setSession('whatsapp_main', 'session-abc');
+    deleteSession('whatsapp_main');
+    expect(getSession('whatsapp_main')).toBeUndefined();
+  });
+
+  it('deleteSession is a no-op for unknown group', () => {
+    expect(() => deleteSession('nonexistent')).not.toThrow();
+  });
+
+  it('getAllSessions returns all stored sessions', () => {
+    setSession('group_a', 'sess-1');
+    setSession('group_b', 'sess-2');
+    const all = getAllSessions();
+    expect(all).toEqual({ group_a: 'sess-1', group_b: 'sess-2' });
+  });
+
+  it('getAllSessions excludes deleted sessions', () => {
+    setSession('group_a', 'sess-1');
+    setSession('group_b', 'sess-2');
+    deleteSession('group_a');
+    const all = getAllSessions();
+    expect(all).toEqual({ group_b: 'sess-2' });
+  });
+
+  it('stale session recovery: delete clears session so next lookup returns undefined', () => {
+    // Simulate: session stored from a previous run
+    setSession('whatsapp_main', 'stale-session-xyz');
+    expect(getSession('whatsapp_main')).toBe('stale-session-xyz');
+
+    // Simulate: host detects resume error and clears the session
+    deleteSession('whatsapp_main');
+
+    // Next agent invocation should get no session (starts fresh)
+    expect(getSession('whatsapp_main')).toBeUndefined();
+
+    // getAllSessions also reflects the deletion
+    expect(getAllSessions()).toEqual({});
+  });
+});
+
+// --- Session error detection pattern ---
+
+describe('session error detection pattern', () => {
+  // This is the regex used in src/index.ts and container/agent-runner to
+  // detect stale-session errors and trigger recovery.
+  const SESSION_ERROR_PATTERN = /session|conversation not found|resume/i;
+
+  it('matches "No conversation found with session ID"', () => {
+    expect(
+      SESSION_ERROR_PATTERN.test(
+        'No conversation found with session ID abc-123',
+      ),
+    ).toBe(true);
+  });
+
+  it('matches "session expired"', () => {
+    expect(SESSION_ERROR_PATTERN.test('session expired')).toBe(true);
+  });
+
+  it('matches "invalid session"', () => {
+    expect(SESSION_ERROR_PATTERN.test('invalid session')).toBe(true);
+  });
+
+  it('matches "failed to resume"', () => {
+    expect(SESSION_ERROR_PATTERN.test('failed to resume conversation')).toBe(
+      true,
+    );
+  });
+
+  it('matches case-insensitively', () => {
+    expect(SESSION_ERROR_PATTERN.test('SESSION NOT FOUND')).toBe(true);
+  });
+
+  it('does not match unrelated errors', () => {
+    expect(SESSION_ERROR_PATTERN.test('rate limit exceeded')).toBe(false);
+    expect(SESSION_ERROR_PATTERN.test('network timeout')).toBe(false);
+    expect(SESSION_ERROR_PATTERN.test('out of memory')).toBe(false);
   });
 });

--- a/src/db.ts
+++ b/src/db.ts
@@ -548,6 +548,10 @@ export function setSession(groupFolder: string, sessionId: string): void {
   ).run(groupFolder, sessionId);
 }
 
+export function deleteSession(groupFolder: string): void {
+  db.prepare('DELETE FROM sessions WHERE group_folder = ?').run(groupFolder);
+}
+
 export function getAllSessions(): Record<string, string> {
   const rows = db
     .prepare('SELECT group_folder, session_id FROM sessions')

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import {
   ensureContainerRuntimeRunning,
 } from './container-runtime.js';
 import {
+  deleteSession,
   getAllChats,
   getAllRegisteredGroups,
   getAllSessions,
@@ -382,6 +383,18 @@ async function runAgent(
         { group: group.name, error: output.error },
         'Container agent error',
       );
+      // Clear stale session so next invocation starts fresh
+      if (
+        output.error &&
+        /session|conversation not found|resume/i.test(output.error)
+      ) {
+        delete sessions[group.folder];
+        deleteSession(group.folder);
+        logger.info(
+          { group: group.name },
+          'Cleared stale session after resume error',
+        );
+      }
       return 'error';
     }
 


### PR DESCRIPTION
## Summary

- Adds `deleteSession()` to `db.ts` for removing expired session records
- Host (`index.ts`) now detects session/resume errors in container output and clears the stale session from both memory and database, so the next invocation starts fresh
- Agent-runner catches session-not-found errors during resume and automatically retries with a fresh session instead of exiting with a permanent failure

Closes #1216

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — 249 passed (pre-existing `claw-skill.test.ts` timeout unrelated)
- [x] Session CRUD unit tests: set, get, overwrite, delete, getAllSessions with deletions (8 tests)
- [x] Stale session recovery scenario: insert session → delete → verify next lookup returns undefined (1 test)
- [x] Error detection regex: matches session/resume error strings, rejects unrelated errors (6 tests)
- [x] Live integration: inserted `fake-stale-session-xyz` into DB, restarted NanoClaw, sent Telegram message — agent-runner logged `Session resume failed (...not a valid UUID), retrying with fresh session`, recovered with new session `0cd8f64d`, produced output, and persisted valid session to DB