### PR TITLE
fix: sync all agent-runner source files to existing groups, not just index.ts

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -193,13 +193,21 @@ function buildVolumeMounts(
     'agent-runner-src',
   );
   if (fs.existsSync(agentRunnerSrc)) {
-    const srcIndex = path.join(agentRunnerSrc, 'index.ts');
-    const cachedIndex = path.join(groupAgentRunnerDir, 'index.ts');
-    const needsCopy =
-      !fs.existsSync(groupAgentRunnerDir) ||
-      !fs.existsSync(cachedIndex) ||
-      (fs.existsSync(srcIndex) &&
-        fs.statSync(srcIndex).mtimeMs > fs.statSync(cachedIndex).mtimeMs);
+    let needsCopy = !fs.existsSync(groupAgentRunnerDir);
+    if (!needsCopy) {
+      // Re-sync when any source file is newer than its cached copy
+      for (const file of fs.readdirSync(agentRunnerSrc)) {
+        const srcFile = path.join(agentRunnerSrc, file);
+        const cachedFile = path.join(groupAgentRunnerDir, file);
+        if (
+          !fs.existsSync(cachedFile) ||
+          fs.statSync(srcFile).mtimeMs > fs.statSync(cachedFile).mtimeMs
+        ) {
+          needsCopy = true;
+          break;
+        }
+      }
+    }
     if (needsCopy) {
       fs.cpSync(agentRunnerSrc, groupAgentRunnerDir, { recursive: true });
     }


### PR DESCRIPTION
## Summary

- The previous cache-refresh logic (from commit d05a8de) only compared `index.ts` timestamps when deciding whether to re-sync agent-runner source to per-group directories
- Changes to other source files like `ipc-mcp-stdio.ts` (MCP tools, parameters, bug fixes) did not propagate to pre-existing groups
- Now iterates all files in the agent-runner `src/` directory and triggers a re-sync when **any** file is newer than its cached copy

Closes #1236

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — 235 passed (pre-existing `claw-skill.test.ts` timeout unrelated)
- [ ] Modify `container/agent-runner/src/ipc-mcp-stdio.ts`, verify existing group picks up the change on next agent run