### PR TITLE
perf: use pre-compiled TypeScript in container entrypoint

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -55,7 +55,8 @@ RUN mkdir -p /workspace/group /workspace/global /workspace/extra /workspace/ipc/
 # Container input (prompt, group info) is passed via stdin JSON.
 # Credentials are injected by the host's credential proxy — never passed here.
 # Follow-up messages arrive via IPC files in /workspace/ipc/input/
-RUN printf '#!/bin/bash\nset -e\ncd /app && npx tsc --outDir /tmp/dist 2>&1 >&2\nln -s /app/node_modules /tmp/dist/node_modules\nchmod -R a-w /tmp/dist\ncat > /tmp/input.json\nnode /tmp/dist/index.js < /tmp/input.json\n' > /app/entrypoint.sh && chmod +x /app/entrypoint.sh
+# TypeScript is pre-compiled at build time (npm run build → /app/dist/)
+RUN printf '#!/bin/bash\nset -e\ncat > /tmp/input.json\nnode /app/dist/index.js < /tmp/input.json\n' > /app/entrypoint.sh && chmod +x /app/entrypoint.sh
 
 # Set ownership to node user (non-root) for writable directories
 RUN chown -R node:node /workspace && chmod 777 /home/node


### PR DESCRIPTION
## Summary

- Remove redundant `npx tsc` recompilation from the container entrypoint script
- Use the pre-compiled `dist/` output from the `npm run build` step already in the Dockerfile

## Problem

The Dockerfile runs `npm run build` at image build time, but the entrypoint was re-running `npx tsc --outDir /tmp/dist` on every container start. This added ~5s on Docker and 2-5 minutes on Apple Containers, for no benefit since the compiled output was already available.

## Test plan

- [ ] Build container image with `./container/build.sh`
- [ ] Verify agent container starts and processes messages correctly
- [ ] Confirm startup time improvement (no `tsc` compilation delay)

Fixes #941

🤖 Generated with [Claude Code](https://claude.com/claude-code)