### PR TITLE
fix(claw): pass secrets as env vars to container

### DIFF
--- a/.claude/skills/claw/scripts/claw
+++ b/.claude/skills/claw/scripts/claw
@@ -156,6 +156,9 @@ def run_container(runtime: str, image: str, payload: dict,
                   folder: str | None = None, is_main: bool = False,
                   timeout: int = 300) -> None:
     cmd = [runtime, "run", "-i", "--rm"]
+    # Pass secrets as env vars so the container can reach the API without a credential proxy
+    for key, val in payload.get("secrets", {}).items():
+        cmd += ["-e", f"{key}={val}"]
     if folder:
         for host, container, readonly in build_mounts(folder, is_main):
             if readonly:


### PR DESCRIPTION
Without -e flags, docker run had no credentials and agent required /login even when secrets existed in .env.

<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description


## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
