### PR TITLE
fix: auto-recover from stale sessions after crash

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -548,6 +548,10 @@ export function setSession(groupFolder: string, sessionId: string): void {
   ).run(groupFolder, sessionId);
 }
 
+export function deleteSession(groupFolder: string): void {
+  db.prepare('DELETE FROM sessions WHERE group_folder = ?').run(groupFolder);
+}
+
 export function getAllSessions(): Record<string, string> {
   const rows = db
     .prepare('SELECT group_folder, session_id FROM sessions')

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import {
 import {
   getAllChats,
   getAllRegisteredGroups,
+  deleteSession,
   getAllSessions,
   getAllTasks,
   getMessagesSince,
@@ -372,7 +373,21 @@ async function runAgent(
       wrappedOnOutput,
     );
 
-    if (output.newSessionId) {
+    // Detect stale sessions: if the error indicates the session no longer
+    // exists (e.g. after a crash), discard the session ID so the next retry
+    // creates a fresh session instead of looping on the same dead ID.
+    const isStaleSession =
+      output.status === 'error' &&
+      output.error?.includes('No conversation found with session ID');
+
+    if (isStaleSession) {
+      logger.warn(
+        { group: group.name, sessionId: output.newSessionId },
+        'Stale session detected, discarding so next retry creates a new one',
+      );
+      delete sessions[group.folder];
+      deleteSession(group.folder);
+    } else if (output.newSessionId) {
       sessions[group.folder] = output.newSessionId;
       setSession(group.folder, output.newSessionId);
     }


### PR DESCRIPTION
## Summary
- Detect stale Claude sessions (e.g. after a WSL/container crash) by checking for "No conversation found with session ID" errors
- Automatically discard the dead session ID from memory and database so the next retry creates a fresh session
- Add `deleteSession()` helper to `db.ts`

## Problem
When nanoclaw crashes or WSL is force-killed, session IDs stored in the database become invalid. On restart, the agent-runner keeps retrying with the stale session ID and fails in a loop with "No conversation found with session ID".

## Solution
After each agent run, if the error matches a stale session signature, we clear the session from both the in-memory map and the database. The next retry naturally creates a new session.

## Test plan
- [ ] Kill WSL mid-conversation, restart, verify agent recovers automatically
- [ ] Verify normal session continuity still works (no regression)
- [ ] Verify new groups still get sessions created correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)