### PR TITLE
feat: load group-level MCP servers from .mcp.json

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -366,6 +366,30 @@ function waitForIpcMessage(): Promise<string | null> {
 }
 
 /**
+ * Load additional MCP servers from the group-level .mcp.json.
+ * Supports both stdio servers (command + args + env) and HTTP servers
+ * (type: "http", url, headers). The SDK handles header injection for
+ * HTTP servers natively via McpHttpServerConfig.
+ */
+function loadGroupMcpServers(): Record<string, unknown> {
+  const configPath = '/workspace/group/.mcp.json';
+  try {
+    if (fs.existsSync(configPath)) {
+      const mcpJson = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      const servers = mcpJson.mcpServers || {};
+      const count = Object.keys(servers).length;
+      if (count > 0) {
+        log(`Loaded ${count} MCP server(s) from .mcp.json: ${Object.keys(servers).join(', ')}`);
+      }
+      return servers;
+    }
+  } catch (err) {
+    log(`Failed to load .mcp.json: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  return {};
+}
+
+/**
  * Run a single query and stream results via writeOutput.
  * Uses MessageStream (AsyncIterable) to keep isSingleUserTurn=false,
  * allowing agent teams subagents to run to completion.
@@ -435,6 +459,33 @@ async function runQuery(
     log(`Additional directories: ${extraDirs.join(', ')}`);
   }
 
+  // Load additional MCP servers from the group's .mcp.json
+  const groupMcpServers = loadGroupMcpServers();
+  const allMcpServers: Record<string, unknown> = {
+    nanoclaw: {
+      command: 'node',
+      args: [mcpServerPath],
+      env: {
+        NANOCLAW_CHAT_JID: containerInput.chatJid,
+        NANOCLAW_GROUP_FOLDER: containerInput.groupFolder,
+        NANOCLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
+      },
+    },
+    ...groupMcpServers,
+  };
+
+  const mcpToolPatterns = Object.keys(allMcpServers).map(name => `mcp__${name}__*`);
+  const allowedTools = [
+    'Bash',
+    'Read', 'Write', 'Edit', 'Glob', 'Grep',
+    'WebSearch', 'WebFetch',
+    'Task', 'TaskOutput', 'TaskStop',
+    'TeamCreate', 'TeamDelete', 'SendMessage',
+    'TodoWrite', 'ToolSearch', 'Skill',
+    'NotebookEdit',
+    ...mcpToolPatterns,
+  ];
+
   for await (const message of query({
     prompt: stream,
     options: {
@@ -449,42 +500,12 @@ async function runQuery(
             append: globalClaudeMd,
           }
         : undefined,
-      allowedTools: [
-        'Bash',
-        'Read',
-        'Write',
-        'Edit',
-        'Glob',
-        'Grep',
-        'WebSearch',
-        'WebFetch',
-        'Task',
-        'TaskOutput',
-        'TaskStop',
-        'TeamCreate',
-        'TeamDelete',
-        'SendMessage',
-        'TodoWrite',
-        'ToolSearch',
-        'Skill',
-        'NotebookEdit',
-        'mcp__nanoclaw__*',
-      ],
+      allowedTools,
       env: sdkEnv,
       permissionMode: 'bypassPermissions',
       allowDangerouslySkipPermissions: true,
       settingSources: ['project', 'user'],
-      mcpServers: {
-        nanoclaw: {
-          command: 'node',
-          args: [mcpServerPath],
-          env: {
-            NANOCLAW_CHAT_JID: containerInput.chatJid,
-            NANOCLAW_GROUP_FOLDER: containerInput.groupFolder,
-            NANOCLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
-          },
-        },
-      },
+      mcpServers: allMcpServers as Record<string, any>,
       hooks: {
         PreCompact: [
           { hooks: [createPreCompactHook(containerInput.assistantName)] },


### PR DESCRIPTION
## Summary

Enable agent containers to connect to external MCP servers (Home Assistant, Rohlik, Google Workspace, etc.) via a per-group config file.

The agent-runner reads `/workspace/group/.mcp.json` on container start and merges any declared MCP servers with the built-in `nanoclaw` server. Tool access patterns (`mcp__<name>__*`) are auto-generated.

## Problem

Currently, every MCP integration skill (e.g., #1327 Home Assistant, #1324 MCP bridge) must hardcode its server registration in the agent-runner source. This doesn't scale — each skill modifies the same file, and changes conflict on merge.

## Solution

A single config-driven mechanism:

```json
{
  "mcpServers": {
    "my-stdio-server": {
      "command": "node",
      "args": ["/workspace/group/my-mcp/dist/index.js"],
      "env": { "API_KEY": "..." }
    },
    "my-http-server": {
      "type": "http",
      "url": "https://api.example.com/mcp",
      "headers": { "Authorization": "Bearer ..." }
    }
  }
}
```

Both stdio and HTTP MCP servers are supported. HTTP `headers` are passed through to the SDK's native `McpHttpServerConfig` type.

## Why core, not a skill

- Infrastructure that all MCP skills need. Without this, every skill modifies agent-runner source.
- Uses the existing per-group folder convention (`.mcp.json` alongside `CLAUDE.md`).
- The agent can self-modify `.mcp.json` to add new servers at runtime (fits NanoClaw's self-modification model).
- ~30 lines of new code in one file.

## Changes

Single file: `container/agent-runner/src/index.ts`
- `loadGroupMcpServers()` — reads `.mcp.json` and returns server configs
- `allMcpServers` — merges group servers with built-in nanoclaw server
- `allowedTools` — dynamically includes `mcp__<name>__*` for all loaded servers

## Notes

- **Environment variables**: Env vars referenced in `.mcp.json` (e.g., `"env": { "API_KEY": "..." }`) must be available inside the container. Ensure the required variables reach the container via `-e` flags in the Docker run command or via the `.env` file read by the container runner.
- **Avoid `npx` in containers**: Using `"command": "npx"` in `.mcp.json` triggers a download on every container start, which can cause OOM kills (exit 137) in memory-constrained containers. Pre-install MCP servers in the Dockerfile or group folder instead.

## Related

- #1324 (MCP bridge for host-side servers) — this PR provides a simpler per-group alternative
- #1327 (hardcoded HA MCP) — this PR enables HA integration via config instead of code changes

## Test plan

1. Create `.mcp.json` in a group folder with a test MCP server
2. Send a message — verify the agent sees the new MCP tools
3. Call a tool from the external MCP server — verify it works
4. Remove the entry from `.mcp.json` — verify tools disappear on next container
