### PR TITLE
feat: add peer channel for NanoClaw-to-NanoClaw direct messaging

### DIFF
--- a/.claude/skills/add-peer-api/SKILL.md
+++ b/.claude/skills/add-peer-api/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: add-peer-api
+description: Connect two NanoClaw instances so their agents can exchange messages and structured data directly over HTTP, without a third-party broker. Each instance runs a lightweight HTTP server; agents use peer_send and peer_list MCP tools to communicate.
+---
+
+# Add Peer API
+
+This skill adds direct NanoClaw-to-NanoClaw communication. Each configured instance runs an HTTP server on `PEER_API_PORT`. Agents get two MCP tools — `peer_list` to check which peers are reachable, and `peer_send` to send messages or structured JSON to a named peer.
+
+Messages travel in both directions: when peer A's agent calls `peer_send("bob", content)`, the message arrives at peer B's NanoClaw and is delivered to a dedicated peer group where B's agent processes it. B's agent can reply with its own `peer_send`.
+
+## Phase 1: Pre-flight
+
+Check if the peer channel is already installed:
+
+```bash
+grep -q 'peer' src/channels/index.ts && echo "already installed" || echo "not installed"
+```
+
+If already installed, skip to Phase 2 (Configure).
+
+## Phase 2: Apply Code Changes
+
+### Ensure upstream remote
+
+```bash
+git remote -v
+```
+
+If `upstream` is missing:
+
+```bash
+git remote add upstream https://github.com/qwibitai/nanoclaw.git
+```
+
+### Merge the skill branch
+
+```bash
+git fetch upstream skill/peer-api
+git merge upstream/skill/peer-api
+```
+
+### Validate
+
+```bash
+npm install
+npm run build
+```
+
+Build must be clean before continuing.
+
+## Phase 3: Configure
+
+You need values for **both** NanoClaw instances. Set these in each instance's `.env`:
+
+**Instance A (e.g. local Mac):**
+
+```bash
+PEER_NAME=alice
+PEER_API_PORT=7843
+PEER_API_TOKEN=<shared-secret>
+PEER_TARGETS=bob=https://<vps-host>:7843
+```
+
+**Instance B (e.g. VPS):**
+
+```bash
+PEER_NAME=bob
+PEER_API_PORT=7843
+PEER_API_TOKEN=<same-shared-secret>
+PEER_TARGETS=alice=https://<mac-host>:7843
+```
+
+**Rules:**
+- `PEER_NAME` — a short lowercase identifier for this instance (e.g. `alice`, `home`, `vps`)
+- `PEER_API_PORT` — TCP port to listen on. Open it in your firewall/security group.
+- `PEER_API_TOKEN` — a strong random secret shared across all peers in the cluster. Generate with: `openssl rand -hex 32`
+- `PEER_TARGETS` — comma-separated `name=url` pairs. Use `https://` when the peer is on the public internet.
+
+### Firewall
+
+The peer HTTP server binds to `0.0.0.0`. Ensure `PEER_API_PORT` (default 7843) is reachable from peer machines. On cloud VMs, add a security group/firewall rule.
+
+For production use, put a TLS reverse proxy (nginx, Caddy) in front and use `https://` URLs in `PEER_TARGETS`.
+
+### Sync env to containers
+
+```bash
+mkdir -p data/env && cp .env data/env/env
+```
+
+## Phase 4: Build and Restart
+
+```bash
+npm run build
+./container/build.sh
+```
+
+Restart the service:
+
+```bash
+# macOS (launchd)
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+
+# Linux (systemd)
+systemctl --user restart nanoclaw
+```
+
+Repeat on both instances.
+
+## Phase 5: Verify
+
+### Check the peer server is up
+
+From the other machine (or via curl):
+
+```bash
+curl http://<peer-host>:7843/peer/health
+# Expected: {"ok":true,"name":"alice"}
+```
+
+### Test from a group chat
+
+Ask your agent:
+
+> "Use peer_list to check which peers are online, then send 'hello from alice' to bob using peer_send."
+
+On bob's side, check that a message arrives in the `peer_alice` group.
+
+### Check logs
+
+```bash
+tail -f logs/nanoclaw.log | grep PEER
+```
+
+Look for:
+- `[PEER] Server listening on port 7843` — server started
+- `[PEER] Inbound message from alice` — message received
+- `[PEER] Sending message to bob` — message sent
+
+## How It Works
+
+Each NanoClaw instance:
+1. Runs an HTTP server on `PEER_API_PORT` (bound to `0.0.0.0`)
+2. Auto-provisions a registered group for each configured peer (e.g. `peer_bob`)
+3. Routes inbound `POST /peer/message` requests to that group's agent
+4. Outbound `sendMessage("peer_bob@nanoclaw", text)` POSTs to bob's HTTP server
+
+Agents get two MCP tools:
+- **`peer_list`** — lists configured peers and checks `/peer/health` on each
+- **`peer_send(name, content)`** — sends text or JSON string to a named peer
+
+The `content` field supports any string — pass `JSON.stringify(data)` for structured payloads.
+
+## Troubleshooting
+
+**`[PEER] Port already in use`** — another process is on PEER_API_PORT. Change `PEER_API_PORT` or stop the conflicting process.
+
+**`peer_send` returns HTTP 401** — `PEER_API_TOKEN` doesn't match between the two instances. Verify both `.env` files have the same token and restart.
+
+**`peer_send` returns timeout** — the peer is unreachable. Check: firewall rules, correct URL in `PEER_TARGETS`, peer service is running.
+
+**Agent doesn't have peer tools** — `PEER_TARGETS` wasn't set when the container started. Rebuild the container (`./container/build.sh`) and restart.
+
+**Peer group doesn't appear** — `PEER_NAME` and `PEER_API_TOKEN` must both be set for the peer channel to activate. Check `.env` and restart.

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Peer API — NanoClaw-to-NanoClaw direct messaging
+# PEER_NAME=alice
+# PEER_API_PORT=7843
+# PEER_API_TOKEN=your-shared-secret-token
+# PEER_TARGETS=bob=https://bob.example.com:7843,carol=https://carol.example.com:7843

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -409,7 +409,8 @@ async function runQuery(
         'TeamCreate', 'TeamDelete', 'SendMessage',
         'TodoWrite', 'ToolSearch', 'Skill',
         'NotebookEdit',
-        'mcp__nanoclaw__*'
+        'mcp__nanoclaw__*',
+        ...(process.env.PEER_TARGETS ? ['mcp__nanoclaw_peer__*'] : []),
       ],
       env: sdkEnv,
       permissionMode: 'bypassPermissions',
@@ -425,6 +426,19 @@ async function runQuery(
             NANOCLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
           },
         },
+        ...(process.env.PEER_TARGETS
+          ? {
+              nanoclaw_peer: {
+                command: 'node',
+                args: [path.join(__dirname, 'peer-mcp-stdio.js')],
+                env: {
+                  PEER_NAME: process.env.PEER_NAME || '',
+                  PEER_API_TOKEN: process.env.PEER_API_TOKEN || '',
+                  PEER_TARGETS: process.env.PEER_TARGETS || '',
+                },
+              },
+            }
+          : {}),
       },
       hooks: {
         PreCompact: [{ hooks: [createPreCompactHook(containerInput.assistantName)] }],

--- a/container/agent-runner/src/peer-mcp-stdio.ts
+++ b/container/agent-runner/src/peer-mcp-stdio.ts
@@ -1,0 +1,221 @@
+/**
+ * Peer MCP Server — NanoClaw-to-NanoClaw messaging from inside containers.
+ *
+ * Exposes two tools to the container agent:
+ *   peer_list  — list configured peers and their online status
+ *   peer_send  — send a text or JSON message to a named peer
+ *
+ * Reads peer config from environment variables set by the host:
+ *   PEER_NAME     — this instance's name
+ *   PEER_API_TOKEN — shared Bearer token
+ *   PEER_TARGETS  — comma-separated "name=url" pairs
+ */
+
+import http from 'http';
+import https from 'https';
+import { URL } from 'url';
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+
+const PEER_NAME = process.env.PEER_NAME || '';
+const PEER_API_TOKEN = process.env.PEER_API_TOKEN || '';
+const PEER_TARGETS_RAW = process.env.PEER_TARGETS || '';
+
+interface PeerTarget {
+  name: string;
+  url: string;
+}
+
+function parsePeerTargets(raw: string): PeerTarget[] {
+  if (!raw.trim()) return [];
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((entry) => {
+      const idx = entry.indexOf('=');
+      if (idx < 1) return null;
+      const name = entry.slice(0, idx).trim().toLowerCase();
+      const url = entry.slice(idx + 1).trim();
+      return name && url ? { name, url } : null;
+    })
+    .filter((t): t is PeerTarget => t !== null);
+}
+
+const targets = parsePeerTargets(PEER_TARGETS_RAW);
+
+function peerLog(msg: string): void {
+  process.stderr.write(`[PEER] ${msg}\n`);
+}
+
+/** HTTP/HTTPS GET helper, returns parsed JSON or null. */
+async function getJson<T>(url: string, timeoutMs = 5000): Promise<T | null> {
+  return new Promise((resolve) => {
+    let timedOut = false;
+    const parsed = new URL(url);
+    const lib = parsed.protocol === 'https:' ? https : http;
+    const req = lib.get(
+      {
+        hostname: parsed.hostname,
+        port: parsed.port || (parsed.protocol === 'https:' ? 443 : 80),
+        path: parsed.pathname + parsed.search,
+      },
+      (res) => {
+        let data = '';
+        res.on('data', (c) => { data += c; });
+        res.on('end', () => {
+          if (!timedOut) {
+            try { resolve(JSON.parse(data) as T); } catch { resolve(null); }
+          }
+        });
+      },
+    );
+    req.on('error', () => { if (!timedOut) resolve(null); });
+    const timer = setTimeout(() => {
+      timedOut = true;
+      req.destroy();
+      resolve(null);
+    }, timeoutMs);
+    req.on('close', () => clearTimeout(timer));
+  });
+}
+
+/** HTTP/HTTPS POST helper, returns {ok, status, body}. */
+async function postJson(
+  url: string,
+  token: string,
+  body: object,
+  timeoutMs = 10000,
+): Promise<{ ok: boolean; status: number; body: string }> {
+  return new Promise((resolve) => {
+    let timedOut = false;
+    const payload = JSON.stringify(body);
+    const parsed = new URL(url);
+    const lib = parsed.protocol === 'https:' ? https : http;
+    const options = {
+      hostname: parsed.hostname,
+      port: parsed.port || (parsed.protocol === 'https:' ? 443 : 80),
+      path: parsed.pathname + parsed.search,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(payload),
+        Authorization: `Bearer ${token}`,
+      },
+    };
+    const req = lib.request(options, (res) => {
+      let data = '';
+      res.on('data', (c) => { data += c; });
+      res.on('end', () => {
+        if (!timedOut) resolve({ ok: res.statusCode === 200, status: res.statusCode ?? 0, body: data });
+      });
+    });
+    req.on('error', (err) => {
+      if (!timedOut) resolve({ ok: false, status: 0, body: err.message });
+    });
+    const timer = setTimeout(() => {
+      timedOut = true;
+      req.destroy();
+      resolve({ ok: false, status: 0, body: 'timeout' });
+    }, timeoutMs);
+    req.on('close', () => clearTimeout(timer));
+    req.write(payload);
+    req.end();
+  });
+}
+
+const server = new McpServer({
+  name: 'nanoclaw-peer',
+  version: '1.0.0',
+});
+
+server.tool(
+  'peer_list',
+  'List all configured peer NanoClaw instances and check which ones are reachable.',
+  {},
+  async () => {
+    if (targets.length === 0) {
+      return { content: [{ type: 'text' as const, text: 'No peer targets configured. Set PEER_TARGETS in .env.' }] };
+    }
+
+    const rows = await Promise.all(
+      targets.map(async (t) => {
+        const health = await getJson<{ ok: boolean; name?: string }>(`${t.url}/peer/health`);
+        const status = health?.ok ? 'online' : 'offline';
+        const remoteName = health?.name ? ` (${health.name})` : '';
+        return `  ${t.name}${remoteName}: ${status}  [${t.url}]`;
+      }),
+    );
+
+    peerLog(`Listed ${targets.length} peer(s)`);
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: `Configured peers:\n${rows.join('\n')}\n\nThis instance: ${PEER_NAME || '(unnamed)'}`,
+        },
+      ],
+    };
+  },
+);
+
+server.tool(
+  'peer_send',
+  'Send a message to a named peer NanoClaw instance. Content can be plain text or a JSON string for structured data exchange. The peer\'s agent will receive and process the message in its peer group.',
+  {
+    name: z.string().describe('Peer name as configured in PEER_TARGETS (e.g. "bob")'),
+    content: z.string().describe('Message content — plain text or a JSON string for structured data'),
+  },
+  async (args: { name: string; content: string }) => {
+    const target = targets.find((t) => t.name === args.name.toLowerCase());
+    if (!target) {
+      const available = targets.map((t) => t.name).join(', ') || 'none';
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Unknown peer: "${args.name}". Available: ${available}`,
+          },
+        ],
+      };
+    }
+
+    const body = {
+      from: PEER_NAME,
+      content: args.content,
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      ts: new Date().toISOString(),
+    };
+
+    peerLog(`Sending message to ${target.name} (${args.content.length} chars)`);
+    const result = await postJson(`${target.url}/peer/message`, PEER_API_TOKEN, body);
+
+    if (result.ok) {
+      peerLog(`Message delivered to ${target.name}`);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Message delivered to ${target.name}.`,
+          },
+        ],
+      };
+    } else {
+      peerLog(`Failed to deliver to ${target.name}: status=${result.status} body=${result.body}`);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Failed to deliver message to ${target.name} (HTTP ${result.status}): ${result.body}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -5,6 +5,9 @@
 
 // gmail
 
+// peer
+import './peer.js';
+
 // slack
 
 // telegram

--- a/src/channels/peer.ts
+++ b/src/channels/peer.ts
@@ -1,0 +1,294 @@
+/**
+ * Peer Channel — NanoClaw-to-NanoClaw structured data exchange.
+ *
+ * Each instance with peer config runs a lightweight HTTP server.
+ * Peers exchange messages directly over HTTPS without a broker.
+ *
+ * Config (in .env):
+ *   PEER_NAME=alice                           — name of this instance
+ *   PEER_API_PORT=7843                        — inbound HTTP server port
+ *   PEER_API_TOKEN=secret                     — shared Bearer token
+ *   PEER_TARGETS=bob=https://bob.host:7843    — comma-separated name=url pairs
+ *
+ * JID format: peer_{name}@nanoclaw (e.g. peer_bob@nanoclaw)
+ * Each configured peer gets a registered group auto-provisioned at connect().
+ */
+import http from 'http';
+import https from 'https';
+import { URL } from 'url';
+
+import {
+  ASSISTANT_NAME,
+  PEER_API_PORT,
+  PEER_API_TOKEN,
+  PEER_NAME,
+  PEER_TARGETS,
+} from '../config.js';
+import { logger } from '../logger.js';
+import { Channel, RegisteredGroup } from '../types.js';
+import { ChannelOpts, registerChannel } from './registry.js';
+
+export interface PeerTarget {
+  name: string;
+  url: string;
+}
+
+/** Parse "bob=https://url,carol=https://url2" into target objects. */
+export function parsePeerTargets(raw: string): PeerTarget[] {
+  if (!raw.trim()) return [];
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((entry) => {
+      const idx = entry.indexOf('=');
+      if (idx < 1) {
+        logger.warn({ entry }, 'Peer target entry has no "=" separator, skipping');
+        return null;
+      }
+      const name = entry.slice(0, idx).trim().toLowerCase();
+      const url = entry.slice(idx + 1).trim();
+      if (!name || !url) {
+        logger.warn({ entry }, 'Peer target entry missing name or url, skipping');
+        return null;
+      }
+      return { name, url };
+    })
+    .filter((t): t is PeerTarget => t !== null);
+}
+
+/** Convert a peer name to its JID. */
+function peerJid(name: string): string {
+  return `peer_${name}@nanoclaw`;
+}
+
+/** Extract peer name from a JID. Returns null if not a peer JID. */
+function jidToPeerName(jid: string): string | null {
+  const m = jid.match(/^peer_(.+)@nanoclaw$/);
+  return m ? m[1] : null;
+}
+
+/** Make a JSON HTTP/HTTPS POST to url with body, return {ok, status, body}. */
+async function postJson(
+  url: string,
+  token: string,
+  body: object,
+  timeoutMs = 10000,
+): Promise<{ ok: boolean; status: number; body: string }> {
+  return new Promise((resolve) => {
+    let timedOut = false;
+    const payload = JSON.stringify(body);
+    const parsed = new URL(url);
+    const lib = parsed.protocol === 'https:' ? https : http;
+    const options = {
+      hostname: parsed.hostname,
+      port: parsed.port || (parsed.protocol === 'https:' ? 443 : 80),
+      path: parsed.pathname + parsed.search,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(payload),
+        Authorization: `Bearer ${token}`,
+      },
+    };
+    const req = lib.request(options, (res) => {
+      let data = '';
+      res.on('data', (chunk) => { data += chunk; });
+      res.on('end', () => {
+        if (!timedOut) resolve({ ok: res.statusCode === 200, status: res.statusCode ?? 0, body: data });
+      });
+    });
+    req.on('error', (err) => {
+      if (!timedOut) resolve({ ok: false, status: 0, body: err.message });
+    });
+    const timer = setTimeout(() => {
+      timedOut = true;
+      req.destroy();
+      resolve({ ok: false, status: 0, body: 'timeout' });
+    }, timeoutMs);
+    req.on('close', () => clearTimeout(timer));
+    req.write(payload);
+    req.end();
+  });
+}
+
+export class PeerChannel implements Channel {
+  name = 'peer';
+
+  private server: http.Server | null = null;
+  private connected = false;
+  private targets: PeerTarget[] = [];
+  private opts: ChannelOpts;
+
+  constructor(opts: ChannelOpts) {
+    this.opts = opts;
+    this.targets = parsePeerTargets(PEER_TARGETS);
+  }
+
+  async connect(): Promise<void> {
+    // Auto-provision a registered group for each configured peer target.
+    // This ensures the orchestrator routes inbound peer messages correctly.
+    for (const target of this.targets) {
+      const jid = peerJid(target.name);
+      const existing = this.opts.registeredGroups()[jid];
+      if (!existing && this.opts.registerGroup) {
+        const group: RegisteredGroup = {
+          name: `Peer: ${target.name}`,
+          folder: `peer_${target.name}`,
+          trigger: `@${ASSISTANT_NAME}`,
+          added_at: new Date().toISOString(),
+          requiresTrigger: false,
+          isMain: false,
+        };
+        this.opts.registerGroup(jid, group);
+        logger.info({ jid, folder: group.folder }, '[PEER] Auto-registered peer group');
+      }
+      // Notify orchestrator of this peer chat so it appears in the DB.
+      this.opts.onChatMetadata(jid, new Date().toISOString(), `Peer: ${target.name}`, 'peer', false);
+    }
+
+    await this.startServer();
+    this.connected = true;
+    logger.info(
+      { port: PEER_API_PORT, name: PEER_NAME, peers: this.targets.map((t) => t.name) },
+      `[PEER] Server listening on port ${PEER_API_PORT}`,
+    );
+  }
+
+  private startServer(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.server = http.createServer((req, res) => {
+        this.handleRequest(req, res);
+      });
+
+      this.server.on('error', (err: NodeJS.ErrnoException) => {
+        if (err.code === 'EADDRINUSE') {
+          logger.error({ port: PEER_API_PORT }, '[PEER] Port already in use — check PEER_API_PORT');
+        }
+        reject(err);
+      });
+
+      this.server.listen(PEER_API_PORT, '0.0.0.0', () => resolve());
+    });
+  }
+
+  private handleRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
+    const url = req.url || '';
+
+    // Health check — no auth required
+    if (req.method === 'GET' && url === '/peer/health') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true, name: PEER_NAME }));
+      return;
+    }
+
+    // Inbound message from another NanoClaw instance
+    if (req.method === 'POST' && url === '/peer/message') {
+      // Validate Bearer token
+      const auth = req.headers['authorization'] || '';
+      if (!PEER_API_TOKEN || auth !== `Bearer ${PEER_API_TOKEN}`) {
+        res.writeHead(401, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Unauthorized' }));
+        return;
+      }
+
+      let body = '';
+      req.on('data', (chunk) => { body += chunk; });
+      req.on('end', () => {
+        try {
+          const msg = JSON.parse(body) as {
+            from?: string;
+            content?: string;
+            id?: string;
+            ts?: string;
+          };
+          if (!msg.from || !msg.content) {
+            res.writeHead(400, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'Missing from or content' }));
+            return;
+          }
+
+          const chatJid = peerJid(msg.from);
+          const ts = msg.ts || new Date().toISOString();
+          const id = msg.id || `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+          logger.info({ from: msg.from, chars: msg.content.length }, `[PEER] Inbound message from ${msg.from}`);
+
+          this.opts.onMessage(chatJid, {
+            id,
+            chat_jid: chatJid,
+            sender: chatJid,
+            sender_name: msg.from,
+            content: msg.content,
+            timestamp: ts,
+            is_from_me: false,
+            is_bot_message: false,
+          });
+
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: true }));
+        } catch (err) {
+          logger.warn({ err }, '[PEER] Failed to parse inbound message');
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Invalid JSON' }));
+        }
+      });
+      return;
+    }
+
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Not found' }));
+  }
+
+  async sendMessage(jid: string, text: string): Promise<void> {
+    const peerName = jidToPeerName(jid);
+    if (!peerName) {
+      logger.warn({ jid }, '[PEER] sendMessage called with non-peer JID');
+      return;
+    }
+
+    const target = this.targets.find((t) => t.name === peerName);
+    if (!target) {
+      logger.warn({ jid, peerName }, '[PEER] No target URL configured for peer');
+      return;
+    }
+
+    const body = {
+      from: PEER_NAME,
+      content: text,
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      ts: new Date().toISOString(),
+    };
+
+    logger.info({ to: peerName, chars: text.length }, `[PEER] Sending message to ${peerName}`);
+    const result = await postJson(`${target.url}/peer/message`, PEER_API_TOKEN, body);
+    if (!result.ok) {
+      logger.warn({ to: peerName, status: result.status, body: result.body }, '[PEER] Failed to send message');
+    }
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  ownsJid(jid: string): boolean {
+    return jid.endsWith('@nanoclaw');
+  }
+
+  async disconnect(): Promise<void> {
+    this.connected = false;
+    return new Promise((resolve) => {
+      if (this.server) {
+        this.server.close(() => resolve());
+      } else {
+        resolve();
+      }
+    });
+  }
+}
+
+registerChannel('peer', (opts: ChannelOpts): PeerChannel | null => {
+  // Only activate when PEER_NAME and PEER_API_TOKEN are configured.
+  if (!PEER_NAME || !PEER_API_TOKEN) return null;
+  return new PeerChannel(opts);
+});

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -9,6 +9,8 @@ export interface ChannelOpts {
   onMessage: OnInboundMessage;
   onChatMetadata: OnChatMetadata;
   registeredGroups: () => Record<string, RegisteredGroup>;
+  /** Optional: register a new group at runtime (used by channels that auto-provision chats). */
+  registerGroup?: (jid: string, group: RegisteredGroup) => void;
 }
 
 export type ChannelFactory = (opts: ChannelOpts) => Channel | null;

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,10 @@ const envConfig = readEnvFile([
   'ASSISTANT_HAS_OWN_NUMBER',
   'ONECLI_URL',
   'TZ',
+  'PEER_NAME',
+  'PEER_API_PORT',
+  'PEER_API_TOKEN',
+  'PEER_TARGETS',
 ]);
 
 export const ASSISTANT_NAME =
@@ -95,3 +99,19 @@ function resolveConfigTimezone(): string {
   return 'UTC';
 }
 export const TIMEZONE = resolveConfigTimezone();
+
+// Peer API — NanoClaw-to-NanoClaw structured data exchange
+// PEER_NAME:    human-readable name for this instance (e.g. "alice")
+// PEER_API_PORT: port for the inbound HTTP server (default: 7843)
+// PEER_API_TOKEN: shared Bearer token for authenticating peer requests
+// PEER_TARGETS: comma-separated "name=url" pairs, e.g. "bob=https://bob.example.com:7843"
+export const PEER_NAME =
+  process.env.PEER_NAME || envConfig.PEER_NAME || '';
+export const PEER_API_PORT = parseInt(
+  process.env.PEER_API_PORT || envConfig.PEER_API_PORT || '7843',
+  10,
+);
+export const PEER_API_TOKEN =
+  process.env.PEER_API_TOKEN || envConfig.PEER_API_TOKEN || '';
+export const PEER_TARGETS =
+  process.env.PEER_TARGETS || envConfig.PEER_TARGETS || '';

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -14,6 +14,9 @@ import {
   GROUPS_DIR,
   IDLE_TIMEOUT,
   ONECLI_URL,
+  PEER_API_TOKEN,
+  PEER_NAME,
+  PEER_TARGETS,
   TIMEZONE,
 } from './config.js';
 import { resolveGroupFolderPath, resolveGroupIpcPath } from './group-folder.js';
@@ -233,6 +236,11 @@ async function buildContainerArgs(
   // Pass host timezone so container's local time matches the user's
   args.push('-e', `TZ=${TIMEZONE}`);
 
+  // Pass peer config so containers can use peer MCP tools
+  if (PEER_NAME) args.push('-e', `PEER_NAME=${PEER_NAME}`);
+  if (PEER_API_TOKEN) args.push('-e', `PEER_API_TOKEN=${PEER_API_TOKEN}`);
+  if (PEER_TARGETS) args.push('-e', `PEER_TARGETS=${PEER_TARGETS}`);
+
   // OneCLI gateway handles credential injection — containers never see real secrets.
   // The gateway intercepts HTTPS traffic and injects API keys or OAuth tokens.
   const onecliApplied = await onecli.applyContainerConfig(args, {
@@ -400,7 +408,12 @@ export async function runContainerAgent(
       const chunk = data.toString();
       const lines = chunk.trim().split('\n');
       for (const line of lines) {
-        if (line) logger.debug({ container: group.folder }, line);
+        if (!line) continue;
+        if (line.includes('[PEER]')) {
+          logger.info({ container: group.folder }, line);
+        } else {
+          logger.debug({ container: group.folder }, line);
+        }
       }
       // Don't reset timeout on stderr — SDK writes debug logs continuously.
       // Timeout only resets on actual output (OUTPUT_MARKER in stdout).

--- a/src/index.ts
+++ b/src/index.ts
@@ -650,6 +650,7 @@ async function main(): Promise<void> {
       isGroup?: boolean,
     ) => storeChatMetadata(chatJid, timestamp, name, channel, isGroup),
     registeredGroups: () => registeredGroups,
+    registerGroup,
   };
 
   // Create and connect all registered channels.


### PR DESCRIPTION
## Summary

- Adds a `peer` channel that lets two NanoClaw instances exchange messages and structured data directly over HTTP, without a broker
- Each instance runs a lightweight HTTP server; peer groups are auto-provisioned at startup
- Container agents get `peer_list` and `peer_send` MCP tools for proactive cross-instance messaging

## How it works

Configure both instances with matching `PEER_API_TOKEN` and point `PEER_TARGETS` at each other:

```
PEER_NAME=alice
PEER_API_PORT=7843
PEER_API_TOKEN=<shared-secret>
PEER_TARGETS=bob=https://bob.example.com:7843
```

Alice's agent calls `peer_send("bob", content)` → POSTs to bob's HTTP server → bob's NanoClaw delivers it to a `peer_alice` group → bob's agent processes and can reply with `peer_send("alice", response)`.

Content can be plain text or a JSON string for structured data exchange.

## Changes

- `src/channels/peer.ts` — PeerChannel: HTTP server, auto-registers peer groups, routes inbound/outbound messages
- `container/agent-runner/src/peer-mcp-stdio.ts` — MCP server with `peer_list` and `peer_send` tools
- `src/config.ts` — `PEER_NAME`, `PEER_API_PORT`, `PEER_API_TOKEN`, `PEER_TARGETS`
- `src/channels/registry.ts` — optional `registerGroup` in `ChannelOpts`
- `src/channels/index.ts` — peer channel import
- `src/index.ts` — pass `registerGroup` into channel opts
- `src/container-runner.ts` — pass `PEER_*` env vars to containers; surface `[PEER]` logs at INFO
- `.env.example` — documents the four config vars
- `.claude/skills/add-peer-api/SKILL.md` — full setup and troubleshooting guide

## Testing

Built and verified clean `npm run build` on macOS (Apple M4). Channel activates only when `PEER_NAME` and `PEER_API_TOKEN` are set — zero impact on existing installs.

## Checklist

- [x] Feature skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)