### PR TITLE
feat: add WhatsApp media fetcher utility

### DIFF
--- a/integrations/whatsapp/media_fetcher.test.ts
+++ b/integrations/whatsapp/media_fetcher.test.ts
@@ -1,0 +1,27 @@
+import { fetchWhatsAppMedia } from "./media_fetcher";
+
+const mockMediaUrl = "https://cdn.whatsapp.net/media/abc123";
+const mockBinary = Buffer.from("fake-image-data");
+
+global.fetch = jest.fn()
+  .mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ url: mockMediaUrl }),
+  } as any)
+  .mockResolvedValueOnce({
+    ok: true,
+    arrayBuffer: async () => mockBinary.buffer,
+  } as any);
+
+describe("fetchWhatsAppMedia", () => {
+  it("fetches media and returns a Buffer", async () => {
+    const result = await fetchWhatsAppMedia("media-id-123", "test-token");
+    expect(Buffer.isBuffer(result)).toBe(true);
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws if the URL lookup fails", async () => {
+    (fetch as jest.Mock).mockResolvedValueOnce({ ok: false, statusText: "Unauthorized" });
+    await expect(fetchWhatsAppMedia("bad-id", "bad-token")).rejects.toThrow("Failed to resolve media URL");
+  });
+});

--- a/integrations/whatsapp/media_fetcher.ts
+++ b/integrations/whatsapp/media_fetcher.ts
@@ -1,0 +1,30 @@
+export async function fetchWhatsAppMedia(
+  mediaId: string,
+  accessToken: string
+): Promise<Buffer> {
+  // Step 1: Resolve the media_id to a download URL
+  const urlResponse = await fetch(
+    `https://graph.facebook.com/v19.0/${mediaId}`,
+    {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    }
+  );
+
+  if (!urlResponse.ok) {
+    throw new Error(`Failed to resolve media URL: ${urlResponse.statusText}`);
+  }
+
+  const { url } = await urlResponse.json();
+
+  // Step 2: Download the binary
+  const mediaResponse = await fetch(url, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  if (!mediaResponse.ok) {
+    throw new Error(`Failed to download media: ${mediaResponse.statusText}`);
+  }
+
+  const arrayBuffer = await mediaResponse.arrayBuffer();
+  return Buffer.from(arrayBuffer);
+}


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description
When a WhatsApp user sends a photo or voice note, the agent receives a `media_id` 
and access token but never the actual content. This adds a lightweight utility that 
resolves a `media_id` to its binary — fetching the download URL from the WhatsApp 
media endpoint and returning the raw bytes. No encoding or transcription — just the 
fetch. Intentionally minimal so it can serve as the foundation for a follow-on 
message normalizer (image → base64, audio → transcription).

## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
