### PR TITLE
fix: add SELinux :z label to Docker volume mounts

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -265,7 +265,7 @@ async function buildContainerArgs(
     if (mount.readonly) {
       args.push(...readonlyMountArgs(mount.hostPath, mount.containerPath));
     } else {
-      args.push('-v', `${mount.hostPath}:${mount.containerPath}`);
+      args.push('-v', `${mount.hostPath}:${mount.containerPath}:z`);
     }
   }
 

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -24,7 +24,7 @@ export function readonlyMountArgs(
   hostPath: string,
   containerPath: string,
 ): string[] {
-  return ['-v', `${hostPath}:${containerPath}:ro`];
+  return ['-v', `${hostPath}:${containerPath}:ro,z`];
 }
 
 /** Stop a container by name. Uses execFileSync to avoid shell injection. */


### PR DESCRIPTION
## What

Add the `:z` SELinux relabelling option to all Docker volume mounts in `container-runtime.ts` and `container-runner.ts`.

## Why

On SELinux-enforcing Linux systems (Fedora, RHEL, CentOS Stream), Docker bind mounts fail with permission denied unless the `:z` option is set. This makes NanoClaw unusable out of the box on these distributions without manual workarounds.

## How it works

Two line changes:
- `readonlyMountArgs()` in `container-runtime.ts`: `:ro` → `:ro,z`
- Read-write mount in `container-runner.ts`: no suffix → `:z`

The `:z` option tells Docker to relabel the mounted directory with the container's SELinux context. It is a no-op on non-SELinux systems so this is safe for all platforms.

## How it was tested

Tested on Fedora 43 with SELinux enforcing. Containers previously failed to start; with this fix they mount and run correctly.

## Checklist

- [x] Fix