### PR TITLE
fix: don't persist session ID from failed container runs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -396,7 +396,7 @@ async function runAgent(
       wrappedOnOutput,
     );
 
-    if (output.newSessionId) {
+    if (output.newSessionId && output.status !== 'error') {
       sessions[group.folder] = output.newSessionId;
       setSession(group.folder, output.newSessionId);
     }


### PR DESCRIPTION
## Summary

- Skip saving `newSessionId` to the DB when the container exits with an error status
- Prevents infinite retry loops when a session expires or gets corrupted

Fixes #1531

## Root cause

The orchestrator persisted the session ID from error output *before* checking the error status. The agent-runner always echoes back the input session ID on failure, so the next retry would resume the same dead session — looping forever with exponential backoff.

## Change

```diff
- if (output.newSessionId) {
+ if (output.newSessionId && output.status !== 'error') {
```

`src/index.ts` — 1 line changed.

## Test plan

- [x] Reproduced on production: group stuck in retry loop (6+ retries) with expired session
- [x] Deployed fix, deleted stale session, restarted service
- [x] Confirmed container started fresh session and responded successfully
- [x] No regression — other groups unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)