### PR TITLE
feat(reactions): emoji status tracker with non-main group support

### DIFF
--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -142,6 +142,15 @@ export class GroupQueue {
   }
 
   /**
+   * Check whether a group has an active (running) container.
+   * Used by the status tracker heartbeat to detect dead containers.
+   */
+  isActive(groupJid: string): boolean {
+    const state = this.groups.get(groupJid);
+    return state?.active === true;
+  }
+
+  /**
    * Mark the container as idle-waiting (finished work, waiting for IPC input).
    * If tasks are pending, preempt the idle container immediately.
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,7 @@ import {
   shouldDropMessage,
 } from './sender-allowlist.js';
 import { startSchedulerLoop } from './task-scheduler.js';
+import { StatusTracker } from './status-tracker.js';
 import { Channel, NewMessage, RegisteredGroup } from './types.js';
 import { logger } from './logger.js';
 
@@ -75,6 +76,7 @@ let messageLoopRunning = false;
 
 const channels: Channel[] = [];
 const queue = new GroupQueue();
+let statusTracker: StatusTracker | null = null;
 
 const onecli = new OneCLI({ url: ONECLI_URL });
 
@@ -238,7 +240,8 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   if (missedMessages.length === 0) return true;
 
   // For non-main groups, check if trigger is required and present
-  if (!isMainGroup && group.requiresTrigger !== false) {
+  const needsTrigger = !isMainGroup && group.requiresTrigger !== false;
+  if (needsTrigger) {
     const triggerPattern = getTriggerPattern(group.trigger);
     const allowlistCfg = loadSenderAllowlist();
     const hasTrigger = missedMessages.some(
@@ -263,6 +266,39 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     'Processing messages',
   );
 
+  // Track received messages for emoji status reactions.
+  // For trigger-gated groups, only react to trigger messages — context messages
+  // are processed by the agent but shouldn't get emoji reactions.
+  const trackableMessages = needsTrigger
+    ? (() => {
+        const triggerPattern = getTriggerPattern(group.trigger);
+        const cfg = loadSenderAllowlist();
+        return missedMessages.filter(
+          (m) =>
+            triggerPattern.test(m.content.trim()) &&
+            (m.is_from_me || isTriggerAllowed(chatJid, m.sender, cfg)),
+        );
+      })()
+    : missedMessages;
+  for (const msg of trackableMessages) {
+    const fromMe = msg.is_from_me === true || (msg.is_from_me as unknown) === 1;
+    statusTracker?.markReceived(
+      msg.id,
+      chatJid,
+      fromMe,
+      msg.sender,
+      msg.is_bot_message === true,
+    );
+  }
+
+  // Advance user messages to THINKING (eyes -> thought bubble)
+  const userMessages = trackableMessages.filter(
+    (m) => !m.is_bot_message && (isMainGroup || !m.is_from_me),
+  );
+  for (const msg of userMessages) {
+    statusTracker?.markThinking(msg.id, chatJid);
+  }
+
   // Track idle timer for closing stdin when agent is idle
   let idleTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -280,10 +316,17 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   await channel.setTyping?.(chatJid, true);
   let hadError = false;
   let outputSentToUser = false;
+  let firstOutputSeen = false;
 
   const output = await runAgent(group, prompt, chatJid, async (result) => {
     // Streaming output callback — called for each agent result
     if (result.result) {
+      // Advance all tracked messages to WORKING on first output
+      // Uses markAllWorking so piped messages are included, not just the initial batch
+      if (!firstOutputSeen) {
+        firstOutputSeen = true;
+        statusTracker?.markAllWorking(chatJid);
+      }
       const raw =
         typeof result.result === 'string'
           ? result.result
@@ -301,6 +344,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
 
     if (result.status === 'success') {
       queue.notifyIdle(chatJid);
+      statusTracker?.markAllDone(chatJid);
     }
 
     if (result.status === 'error') {
@@ -315,12 +359,14 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     // If we already sent output to the user, don't roll back the cursor —
     // the user got their response and re-processing would send duplicates.
     if (outputSentToUser) {
+      statusTracker?.markAllDone(chatJid);
       logger.warn(
         { group: group.name },
         'Agent error after output was sent, skipping cursor rollback to prevent duplicates',
       );
       return true;
     }
+    statusTracker?.markAllFailed(chatJid, 'Agent error \u{2014} retrying.');
     // Roll back cursor so retries can re-process these messages
     lastAgentTimestamp[chatJid] = previousCursor;
     saveState();
@@ -331,6 +377,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     return false;
   }
 
+  statusTracker?.markAllDone(chatJid);
   return true;
 }
 
@@ -493,6 +540,35 @@ async function startMessageLoop(): Promise<void> {
           const formatted = formatMessages(messagesToSend, TIMEZONE);
 
           if (queue.sendMessage(chatJid, formatted)) {
+            // Track piped messages for emoji status (trigger already checked above).
+            // For trigger-gated groups, only react to trigger messages.
+            const pipedTrackable = needsTrigger
+              ? (() => {
+                  const triggerPattern = getTriggerPattern(group.trigger);
+                  const cfg = loadSenderAllowlist();
+                  return groupMessages.filter(
+                    (m) =>
+                      triggerPattern.test(m.content.trim()) &&
+                      (m.is_from_me ||
+                        isTriggerAllowed(chatJid, m.sender, cfg)),
+                  );
+                })()
+              : groupMessages;
+            for (const msg of pipedTrackable) {
+              const fromMe =
+                msg.is_from_me === true || (msg.is_from_me as unknown) === 1;
+              statusTracker?.markReceived(
+                msg.id,
+                chatJid,
+                fromMe,
+                msg.sender,
+                msg.is_bot_message === true,
+              );
+            }
+            // Agent is about to see these — advance to THINKING
+            for (const msg of pipedTrackable) {
+              statusTracker?.markThinking(msg.id, chatJid);
+            }
             logger.debug(
               { chatJid, count: messagesToSend.length },
               'Piped messages to active container',
@@ -523,21 +599,37 @@ async function startMessageLoop(): Promise<void> {
  * Startup recovery: check for unprocessed messages in registered groups.
  * Handles crash between advancing lastTimestamp and processing messages.
  */
-function recoverPendingMessages(): void {
+function recoverPendingMessages(isStartup: boolean = false): void {
   for (const [chatJid, group] of Object.entries(registeredGroups)) {
+    const isMainGroup = group.isMain === true;
+    const needsTrigger = !isMainGroup && group.requiresTrigger !== false;
+
     const pending = getMessagesSince(
       chatJid,
       getOrRecoverCursor(chatJid),
       ASSISTANT_NAME,
       MAX_MESSAGES_PER_PROMPT,
     );
-    if (pending.length > 0) {
-      logger.info(
-        { group: group.name, pendingCount: pending.length },
-        'Recovery: found unprocessed messages',
+    if (pending.length === 0) continue;
+
+    // For trigger-gated groups, only enqueue if there's actually a trigger message
+    if (needsTrigger) {
+      const triggerPattern = getTriggerPattern(group.trigger);
+      const allowlistCfg = loadSenderAllowlist();
+      const hasTrigger = pending.some(
+        (m) =>
+          triggerPattern.test(m.content.trim()) &&
+          (m.is_from_me || isTriggerAllowed(chatJid, m.sender, allowlistCfg)),
       );
-      queue.enqueueMessageCheck(chatJid);
+      if (!hasTrigger) continue;
     }
+
+    const logFn = isStartup ? logger.info.bind(logger) : logger.debug.bind(logger);
+    logFn(
+      { group: group.name, pendingCount: pending.length },
+      'Recovery: found unprocessed messages',
+    );
+    queue.enqueueMessageCheck(chatJid);
   }
 }
 
@@ -563,6 +655,7 @@ async function main(): Promise<void> {
   // Graceful shutdown handlers
   const shutdown = async (signal: string) => {
     logger.info({ signal }, 'Shutdown signal received');
+    await statusTracker?.shutdown();
     await queue.shutdown(10000);
     for (const ch of channels) await ch.disconnect();
     process.exit(0);
@@ -641,6 +734,22 @@ async function main(): Promise<void> {
         }
       }
       storeMessage(msg);
+
+      // Fire eyes emoji immediately on real-time message event, not on next poll cycle.
+      // Main groups and requiresTrigger:false groups get instant reactions (no trigger gate).
+      // Trigger-gated groups wait for the batch/piping paths where trigger has been checked.
+      const group = registeredGroups[chatJid];
+      if (group?.isMain || group?.requiresTrigger === false) {
+        const fromMe =
+          msg.is_from_me === true || (msg.is_from_me as unknown) === 1;
+        statusTracker?.markReceived(
+          msg.id,
+          chatJid,
+          fromMe,
+          msg.sender,
+          msg.is_bot_message === true,
+        );
+      }
     },
     onChatMetadata: (
       chatJid: string,
@@ -651,6 +760,23 @@ async function main(): Promise<void> {
     ) => storeChatMetadata(chatJid, timestamp, name, channel, isGroup),
     registeredGroups: () => registeredGroups,
   };
+
+  // Initialize status tracker BEFORE channels connect, so onMessage can fire reactions immediately
+  statusTracker = new StatusTracker({
+    sendReaction: async (chatJid, messageKey, emoji) => {
+      const channel = findChannel(channels, chatJid);
+      if (!channel?.sendReaction) return;
+      await channel.sendReaction(chatJid, messageKey, emoji);
+    },
+    sendMessage: async (chatJid, text) => {
+      const channel = findChannel(channels, chatJid);
+      if (!channel) return;
+      await channel.sendMessage(chatJid, text);
+    },
+    isRegisteredGroup: (chatJid) => chatJid in registeredGroups,
+    isMainGroup: (chatJid) => registeredGroups[chatJid]?.isMain === true,
+    isContainerAlive: (chatJid) => queue.isActive(chatJid),
+  });
 
   // Create and connect all registered channels.
   // Each channel self-registers via the barrel import above.
@@ -672,6 +798,10 @@ async function main(): Promise<void> {
     logger.fatal('No channels connected');
     process.exit(1);
   }
+
+  // Recover pending status reactions now that channels are connected.
+  // Must run after channels connect so findChannel() can resolve JIDs.
+  await statusTracker.recover();
 
   // Start subsystems (independently of connection handler)
   startSchedulerLoop({
@@ -708,6 +838,7 @@ async function main(): Promise<void> {
     getAvailableGroups,
     writeGroupsSnapshot: (gf, im, ag, rj) =>
       writeGroupsSnapshot(gf, im, ag, rj),
+    statusHeartbeat: () => statusTracker?.heartbeatCheck(),
     onTasksChanged: () => {
       const tasks = getAllTasks();
       const taskRows = tasks.map((t) => ({
@@ -726,7 +857,7 @@ async function main(): Promise<void> {
     },
   });
   queue.setProcessMessagesFn(processGroupMessages);
-  recoverPendingMessages();
+  recoverPendingMessages(true);
   startMessageLoop().catch((err) => {
     logger.fatal({ err }, 'Message loop crashed unexpectedly');
     process.exit(1);

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -22,6 +22,7 @@ export interface IpcDeps {
     availableGroups: AvailableGroup[],
     registeredJids: Set<string>,
   ) => void;
+  statusHeartbeat?: () => void;
   onTasksChanged: () => void;
 }
 
@@ -146,6 +147,9 @@ export function startIpcWatcher(deps: IpcDeps): void {
         logger.error({ err, sourceGroup }, 'Error reading IPC tasks directory');
       }
     }
+
+    // Status emoji heartbeat — detect dead containers with stale emoji state
+    deps.statusHeartbeat?.();
 
     setTimeout(processIpcFiles, IPC_POLL_INTERVAL);
   };

--- a/src/status-tracker.test.ts
+++ b/src/status-tracker.test.ts
@@ -1,0 +1,745 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      existsSync: vi.fn(() => false),
+      writeFileSync: vi.fn(),
+      readFileSync: vi.fn(() => '[]'),
+      mkdirSync: vi.fn(),
+    },
+  };
+});
+
+vi.mock('./logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import {
+  StatusTracker,
+  StatusState,
+  StatusTrackerDeps,
+} from './status-tracker.js';
+
+const MAIN_JID = 'main@s.whatsapp.net';
+
+function makeDeps() {
+  return {
+    sendReaction: vi.fn<StatusTrackerDeps['sendReaction']>(async () => {}),
+    sendMessage: vi.fn<StatusTrackerDeps['sendMessage']>(async () => {}),
+    isRegisteredGroup: vi.fn<StatusTrackerDeps['isRegisteredGroup']>(
+      (jid) => jid === MAIN_JID || jid === 'group@g.us',
+    ),
+    isMainGroup: vi.fn<StatusTrackerDeps['isMainGroup']>(
+      (jid) => jid === MAIN_JID,
+    ),
+    isContainerAlive: vi.fn<StatusTrackerDeps['isContainerAlive']>(() => true),
+  };
+}
+
+describe('StatusTracker', () => {
+  let tracker: StatusTracker;
+  let deps: ReturnType<typeof makeDeps>;
+
+  beforeEach(() => {
+    deps = makeDeps();
+    tracker = new StatusTracker(deps);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('forward-only transitions', () => {
+    it('transitions RECEIVED -> THINKING -> WORKING -> DONE', async () => {
+      tracker.markReceived('msg1', MAIN_JID, false, '', false);
+      tracker.markThinking('msg1', MAIN_JID);
+      tracker.markWorking('msg1', MAIN_JID);
+      tracker.markDone('msg1', MAIN_JID);
+
+      // Wait for all reaction sends to complete
+      await tracker.flush();
+
+      expect(deps.sendReaction).toHaveBeenCalledTimes(4);
+      const emojis = deps.sendReaction.mock.calls.map((c) => c[2]);
+      expect(emojis).toEqual([
+        '\u{1F440}',
+        '\u{1F4AD}',
+        '\u{1F504}',
+        '\u{2705}',
+      ]);
+    });
+
+    it('rejects backward transitions (WORKING -> THINKING is no-op)', async () => {
+      tracker.markReceived('msg1', MAIN_JID, false, '', false);
+      tracker.markThinking('msg1', MAIN_JID);
+      tracker.markWorking('msg1', MAIN_JID);
+
+      const result = tracker.markThinking('msg1', MAIN_JID);
+      expect(result).toBe(false);
+
+      await tracker.flush();
+      expect(deps.sendReaction).toHaveBeenCalledTimes(3);
+    });
+
+    it('rejects duplicate transitions (DONE -> DONE is no-op)', async () => {
+      tracker.markReceived('msg1', MAIN_JID, false, '', false);
+      tracker.markDone('msg1', MAIN_JID);
+
+      const result = tracker.markDone('msg1', MAIN_JID);
+      expect(result).toBe(false);
+
+      await tracker.flush();
+      expect(deps.sendReaction).toHaveBeenCalledTimes(2);
+    });
+
+    it('allows FAILED from any non-terminal state', async () => {
+      tracker.markReceived('msg1', MAIN_JID, false, '', false);
+      tracker.markFailed('msg1', MAIN_JID);
+      await tracker.flush();
+
+      const emojis = deps.sendReaction.mock.calls.map((c) => c[2]);
+      expect(emojis).toEqual(['\u{1F440}', '\u{274C}']);
+    });
+
+    it('rejects FAILED after DONE', async () => {
+      tracker.markReceived('msg1', MAIN_JID, false, '', false);
+      tracker.markDone('msg1', MAIN_JID);
+
+      const result = tracker.markFailed('msg1', MAIN_JID);
+      expect(result).toBe(false);
+
+      await tracker.flush();
+      expect(deps.sendReaction).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('registered group gating', () => {
+    it('ignores messages from unregistered groups', async () => {
+      tracker.markReceived('msg1', 'unknown@g.us', false, '', false);
+      await tracker.flush();
+      expect(deps.sendReaction).not.toHaveBeenCalled();
+    });
+
+    it('tracks messages from non-main registered groups', async () => {
+      const result = tracker.markReceived('msg1', 'group@g.us', false, 'sender@s.whatsapp.net', false);
+      expect(result).toBe(true);
+      await tracker.flush();
+      expect(deps.sendReaction).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('duplicate tracking', () => {
+    it('rejects duplicate markReceived for same messageId', async () => {
+      const first = tracker.markReceived('msg1', MAIN_JID, false, '', false);
+      const second = tracker.markReceived('msg1', MAIN_JID, false, '', false);
+
+      expect(first).toBe(true);
+      expect(second).toBe(false);
+
+      await tracker.flush();
+      expect(deps.sendReaction).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('unknown message handling', () => {
+    it('returns false for transitions on untracked messages', () => {
+      expect(tracker.markThinking('unknown', 'any@jid')).toBe(false);
+      expect(tracker.markWorking('unknown', 'any@jid')).toBe(false);
+      expect(tracker.markDone('unknown', 'any@jid')).toBe(false);
+      expect(tracker.markFailed('unknown', 'any@jid')).toBe(false);
+    });
+  });
+
+  describe('batch operations', () => {
+    it('markAllDone transitions all tracked messages for a chatJid', async () => {
+      tracker.markReceived('msg1', MAIN_JID, false, '', false);
+      tracker.markReceived('msg2', MAIN_JID, false, '', false);
+      tracker.markAllDone(MAIN_JID);
+      await tracker.flush();
+
+      const doneCalls = deps.sendReaction.mock.calls.filter(
+        (c) => c[2] === '\u{2705}',
+      );
+      expect(doneCalls).toHaveLength(2);
+    });
+
+    it('markAllFailed transitions all tracked messages and sends error message', async () => {
+      tracker.markReceived('msg1', MAIN_JID, false, '', false);
+      tracker.markReceived('msg2', MAIN_JID, false, '', false);
+      tracker.markAllFailed(MAIN_JID, 'Task crashed');
+      await tracker.flush();
+
+      const failCalls = deps.sendReaction.mock.calls.filter(
+        (c) => c[2] === '\u{274C}',
+      );
+      expect(failCalls).toHaveLength(2);
+      expect(deps.sendMessage).toHaveBeenCalledWith(
+        MAIN_JID,
+        '[system] Task crashed',
+      );
+    });
+  });
+
+  describe('serialized sends', () => {
+    it('sends reactions in order even when transitions are rapid', async () => {
+      const order: string[] = [];
+      deps.sendReaction.mockImplementation(async (_jid, _key, emoji) => {
+        await new Promise((r) => setTimeout(r, Math.random() * 10));
+        order.push(emoji);
+      });
+
+      tracker.markReceived('msg1', MAIN_JID, false, '', false);
+      tracker.markThinking('msg1', MAIN_JID);
+      tracker.markWorking('msg1', MAIN_JID);
+      tracker.markDone('msg1', MAIN_JID);
+
+      await tracker.flush();
+      expect(order).toEqual([
+        '\u{1F440}',
+        '\u{1F4AD}',
+        '\u{1F504}',
+        '\u{2705}',
+      ]);
+    });
+  });
+
+  describe('recover', () => {
+    it('marks orphaned non-terminal entries as failed and sends error message', async () => {
+      const fs = await import('fs');
+      const persisted = JSON.stringify([
+        {
+          messageId: 'orphan1',
+          chatJid: 'main@s.whatsapp.net',
+          fromMe: false,
+          state: 0,
+          terminal: null,
+          trackedAt: 1000,
+        },
+        {
+          messageId: 'orphan2',
+          chatJid: 'main@s.whatsapp.net',
+          fromMe: false,
+          state: 2,
+          terminal: null,
+          trackedAt: 2000,
+        },
+        {
+          messageId: 'done1',
+          chatJid: 'main@s.whatsapp.net',
+          fromMe: false,
+          state: 3,
+          terminal: 'done',
+          trackedAt: 3000,
+        },
+      ]);
+      (fs.default.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      (fs.default.readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(
+        persisted,
+      );
+
+      await tracker.recover();
+
+      // Should send ❌ reaction for the 2 non-terminal entries only
+      const failCalls = deps.sendReaction.mock.calls.filter(
+        (c) => c[2] === '❌',
+      );
+      expect(failCalls).toHaveLength(2);
+
+      // Should send one error message per chatJid
+      expect(deps.sendMessage).toHaveBeenCalledWith(
+        MAIN_JID,
+        '[system] Restarted — reprocessing your message.',
+      );
+      expect(deps.sendMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles missing persistence file gracefully', async () => {
+      const fs = await import('fs');
+      (fs.default.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(
+        false,
+      );
+
+      await tracker.recover(); // should not throw
+      expect(deps.sendReaction).not.toHaveBeenCalled();
+    });
+
+    it('handles composite keys correctly — same messageId from different chats', async () => {
+      const fs = await import('fs');
+      const persisted = JSON.stringify([
+        {
+          messageId: '42',
+          chatJid: 'chatA@g.us',
+          fromMe: false,
+          state: 1,
+          terminal: null,
+          trackedAt: 1000,
+        },
+        {
+          messageId: '42',
+          chatJid: 'chatB@g.us',
+          fromMe: false,
+          state: 2,
+          terminal: null,
+          trackedAt: 2000,
+        },
+      ]);
+      (fs.default.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      (fs.default.readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(persisted);
+      deps.isRegisteredGroup.mockReturnValue(true);
+
+      await tracker.recover();
+
+      // Should send ❌ for both entries (different composite keys)
+      const failCalls = deps.sendReaction.mock.calls.filter((c) => c[2] === '❌');
+      expect(failCalls).toHaveLength(2);
+      // Verify both chatJids got ❌
+      const failedJids = failCalls.map((c) => c[0]);
+      expect(failedJids).toContain('chatA@g.us');
+      expect(failedJids).toContain('chatB@g.us');
+
+      // No [system] text messages — both are non-main groups
+      expect(deps.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('skips error message when sendErrorMessage is false', async () => {
+      const fs = await import('fs');
+      const persisted = JSON.stringify([
+        {
+          messageId: 'orphan1',
+          chatJid: 'main@s.whatsapp.net',
+          fromMe: false,
+          state: 1,
+          terminal: null,
+          trackedAt: 1000,
+        },
+      ]);
+      (fs.default.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      (fs.default.readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(
+        persisted,
+      );
+
+      await tracker.recover(false);
+
+      // Still sends ❌ reaction
+      expect(deps.sendReaction).toHaveBeenCalledTimes(1);
+      expect(deps.sendReaction.mock.calls[0][2]).toBe('❌');
+      // But no text message
+      expect(deps.sendMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('heartbeatCheck', () => {
+    it('marks messages as failed when container is dead', async () => {
+      deps.isContainerAlive.mockReturnValue(false);
+      tracker.markReceived('msg1', MAIN_JID, false, '', false);
+      tracker.markThinking('msg1', MAIN_JID);
+
+      tracker.heartbeatCheck();
+      await tracker.flush();
+
+      const failCalls = deps.sendReaction.mock.calls.filter(
+        (c) => c[2] === '❌',
+      );
+      expect(failCalls).toHaveLength(1);
+      expect(deps.sendMessage).toHaveBeenCalledWith(
+        MAIN_JID,
+        '[system] Task crashed — retrying.',
+      );
+    });
+
+    it('does nothing when container is alive', async () => {
+      deps.isContainerAlive.mockReturnValue(true);
+      tracker.markReceived('msg1', MAIN_JID, false, '', false);
+      tracker.markThinking('msg1', MAIN_JID);
+
+      tracker.heartbeatCheck();
+      await tracker.flush();
+
+      // Only the 👀 and 💭 reactions, no ❌
+      expect(deps.sendReaction).toHaveBeenCalledTimes(2);
+      const emojis = deps.sendReaction.mock.calls.map((c) => c[2]);
+      expect(emojis).toEqual(['👀', '💭']);
+    });
+
+    it('skips RECEIVED messages within grace period even if container is dead', async () => {
+      vi.useFakeTimers();
+      deps.isContainerAlive.mockReturnValue(false);
+      tracker.markReceived('msg1', MAIN_JID, false, '', false);
+
+      // Only 10s elapsed — within 30s grace period
+      await vi.advanceTimersByTimeAsync(10_000);
+      tracker.heartbeatCheck();
+      await vi.advanceTimersByTimeAsync(1000);
+      await tracker.flush();
+
+      // Only the 👀 reaction, no ❌
+      expect(deps.sendReaction).toHaveBeenCalledTimes(1);
+      expect(deps.sendReaction.mock.calls[0][2]).toBe('👀');
+    });
+
+    it('fails RECEIVED messages after grace period when container is dead', async () => {
+      vi.useFakeTimers();
+      deps.isContainerAlive.mockReturnValue(false);
+      tracker.markReceived('msg1', MAIN_JID, false, '', false);
+
+      // 31s elapsed — past 30s grace period
+      await vi.advanceTimersByTimeAsync(31_000);
+      tracker.heartbeatCheck();
+      await vi.advanceTimersByTimeAsync(1000);
+      await tracker.flush();
+
+      const failCalls = deps.sendReaction.mock.calls.filter(
+        (c) => c[2] === '❌',
+      );
+      expect(failCalls).toHaveLength(1);
+      expect(deps.sendMessage).toHaveBeenCalledWith(
+        MAIN_JID,
+        '[system] Task crashed — retrying.',
+      );
+    });
+
+    it('does NOT fail RECEIVED messages after grace period when container is alive', async () => {
+      vi.useFakeTimers();
+      deps.isContainerAlive.mockReturnValue(true);
+      tracker.markReceived('msg1', MAIN_JID, false, '', false);
+
+      // 31s elapsed but container is alive — don't fail
+      await vi.advanceTimersByTimeAsync(31_000);
+      tracker.heartbeatCheck();
+      await vi.advanceTimersByTimeAsync(1000);
+      await tracker.flush();
+
+      expect(deps.sendReaction).toHaveBeenCalledTimes(1);
+      expect(deps.sendReaction.mock.calls[0][2]).toBe('👀');
+    });
+
+    it('detects stuck messages beyond timeout', async () => {
+      vi.useFakeTimers();
+      deps.isContainerAlive.mockReturnValue(true); // container "alive" but hung
+
+      tracker.markReceived('msg1', MAIN_JID, false, '', false);
+      tracker.markThinking('msg1', MAIN_JID);
+
+      // Advance time beyond container timeout (default 1800000ms = 30min)
+      await vi.advanceTimersByTimeAsync(1_800_001);
+
+      tracker.heartbeatCheck();
+      await vi.advanceTimersByTimeAsync(1000);
+      await tracker.flush();
+
+      const failCalls = deps.sendReaction.mock.calls.filter(
+        (c) => c[2] === '❌',
+      );
+      expect(failCalls).toHaveLength(1);
+      expect(deps.sendMessage).toHaveBeenCalledWith(
+        MAIN_JID,
+        '[system] Task timed out — retrying.',
+      );
+    });
+
+    it('does not timeout messages queued long in RECEIVED before reaching THINKING', async () => {
+      vi.useFakeTimers();
+      deps.isContainerAlive.mockReturnValue(true);
+
+      tracker.markReceived('msg1', MAIN_JID, false, '', false);
+
+      // Message sits in RECEIVED for longer than CONTAINER_TIMEOUT (queued, waiting for slot)
+      await vi.advanceTimersByTimeAsync(2_000_000);
+
+      // Now container starts — trackedAt resets on THINKING transition
+      tracker.markThinking('msg1', MAIN_JID);
+
+      // Check immediately — should NOT timeout (trackedAt was just reset)
+      await vi.advanceTimersByTimeAsync(1000);
+      tracker.heartbeatCheck();
+      await tracker.flush();
+
+      const failCalls = deps.sendReaction.mock.calls.filter(
+        (c) => c[2] === '❌',
+      );
+      expect(failCalls).toHaveLength(0);
+
+      // Advance past CONTAINER_TIMEOUT from THINKING — NOW it should timeout
+      await vi.advanceTimersByTimeAsync(1_800_001);
+
+      tracker.heartbeatCheck();
+      await vi.advanceTimersByTimeAsync(1000);
+      await tracker.flush();
+
+      const failCallsAfter = deps.sendReaction.mock.calls.filter(
+        (c) => c[2] === '❌',
+      );
+      expect(failCallsAfter).toHaveLength(1);
+    });
+
+    it('checks multiple groups independently (failing one does not skip others)', async () => {
+      vi.useFakeTimers();
+      deps.isRegisteredGroup.mockReturnValue(true);
+      // Container dead for chatA, alive for chatB
+      deps.isContainerAlive.mockImplementation((jid) => jid === 'chatB@g.us');
+
+      tracker.markReceived('msgA', 'chatA@g.us', false, '', false);
+      tracker.markThinking('msgA', 'chatA@g.us');
+      tracker.markReceived('msgB', 'chatB@g.us', false, '', false);
+      tracker.markThinking('msgB', 'chatB@g.us');
+
+      // Advance past container timeout for chatB
+      await vi.advanceTimersByTimeAsync(1_800_001);
+
+      tracker.heartbeatCheck();
+      // Advance enough for all chained sends (👀 800ms + 💭 800ms + ❌ 800ms per message)
+      await vi.advanceTimersByTimeAsync(5000);
+      await tracker.flush();
+
+      // Both chats should have ❌ reactions
+      const failCalls = deps.sendReaction.mock.calls.filter((c) => c[2] === '❌');
+      expect(failCalls).toHaveLength(2);
+      // Verify both chatJids got ❌ (not just one)
+      const failedJids = failCalls.map((c) => c[0]);
+      expect(failedJids).toContain('chatA@g.us');
+      expect(failedJids).toContain('chatB@g.us');
+    });
+  });
+
+  describe('cleanup', () => {
+    it('removes terminal messages after delay', async () => {
+      vi.useFakeTimers();
+      tracker.markReceived('msg1', MAIN_JID, false, '', false);
+      tracker.markDone('msg1', MAIN_JID);
+
+      // Message should still be tracked
+      expect(tracker.isTracked('msg1', MAIN_JID)).toBe(true);
+
+      // Advance past cleanup delay
+      vi.advanceTimersByTime(6000);
+
+      expect(tracker.isTracked('msg1', MAIN_JID)).toBe(false);
+    });
+  });
+
+  describe('reaction retry', () => {
+    it('retries failed sends with exponential backoff (2s, 4s)', async () => {
+      vi.useFakeTimers();
+      let callCount = 0;
+      deps.sendReaction.mockImplementation(async () => {
+        callCount++;
+        if (callCount <= 2) throw new Error('network error');
+      });
+
+      tracker.markReceived('msg1', MAIN_JID, false, '', false);
+
+      // First attempt fires immediately
+      await vi.advanceTimersByTimeAsync(100);
+      expect(callCount).toBe(1);
+
+      // After 2s: second attempt (first retry delay = 2s)
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(callCount).toBe(2);
+
+      // After 1s more (3s total): still waiting for 4s delay
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(callCount).toBe(2);
+
+      // After 3s more (6s total): third attempt fires (second retry delay = 4s)
+      await vi.advanceTimersByTimeAsync(3000);
+      expect(callCount).toBe(3);
+
+      // Advance past the post-send transition delay
+      await vi.advanceTimersByTimeAsync(1000);
+      await tracker.flush();
+    });
+
+    it('gives up after max retries', async () => {
+      vi.useFakeTimers();
+      let callCount = 0;
+      deps.sendReaction.mockImplementation(async () => {
+        callCount++;
+        throw new Error('permanent failure');
+      });
+
+      tracker.markReceived('msg1', MAIN_JID, false, '', false);
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      await tracker.flush();
+
+      expect(callCount).toBe(3); // MAX_RETRIES = 3
+    });
+  });
+
+  describe('batch transitions', () => {
+    it('markThinking can be called on multiple messages independently', async () => {
+      tracker.markReceived('msg1', MAIN_JID, false, '', false);
+      tracker.markReceived('msg2', MAIN_JID, false, '', false);
+      tracker.markReceived('msg3', MAIN_JID, false, '', false);
+
+      // Mark all as thinking (simulates batch behavior)
+      tracker.markThinking('msg1', MAIN_JID);
+      tracker.markThinking('msg2', MAIN_JID);
+      tracker.markThinking('msg3', MAIN_JID);
+
+      await tracker.flush();
+
+      const thinkingCalls = deps.sendReaction.mock.calls.filter(
+        (c) => c[2] === '💭',
+      );
+      expect(thinkingCalls).toHaveLength(3);
+    });
+
+    it('markWorking can be called on multiple messages independently', async () => {
+      tracker.markReceived('msg1', MAIN_JID, false, '', false);
+      tracker.markReceived('msg2', MAIN_JID, false, '', false);
+      tracker.markThinking('msg1', MAIN_JID);
+      tracker.markThinking('msg2', MAIN_JID);
+
+      tracker.markWorking('msg1', MAIN_JID);
+      tracker.markWorking('msg2', MAIN_JID);
+
+      await tracker.flush();
+
+      const workingCalls = deps.sendReaction.mock.calls.filter(
+        (c) => c[2] === '🔄',
+      );
+      expect(workingCalls).toHaveLength(2);
+    });
+  });
+
+  describe('per-JID tracking cap', () => {
+    it('rejects markReceived after 20 non-terminal messages for same JID', async () => {
+      for (let i = 0; i < 20; i++) {
+        expect(tracker.markReceived(`msg${i}`, MAIN_JID, false, '', false)).toBe(true);
+      }
+      // 21st should be rejected
+      expect(tracker.markReceived('msg20', MAIN_JID, false, '', false)).toBe(false);
+      await tracker.flush();
+      expect(deps.sendReaction).toHaveBeenCalledTimes(20);
+    });
+
+    it('does not count terminal entries toward cap', async () => {
+      vi.useFakeTimers();
+      for (let i = 0; i < 20; i++) {
+        tracker.markReceived(`msg${i}`, MAIN_JID, false, '', false);
+      }
+      // Mark first 5 as done (terminal)
+      for (let i = 0; i < 5; i++) {
+        tracker.markDone(`msg${i}`, MAIN_JID);
+      }
+      // Should now accept new messages (only 15 non-terminal)
+      expect(tracker.markReceived('msg20', MAIN_JID, false, '', false)).toBe(true);
+    });
+
+    it('cap is per-JID — different JIDs have independent caps', async () => {
+      deps.isRegisteredGroup.mockReturnValue(true);
+      for (let i = 0; i < 20; i++) {
+        tracker.markReceived(`msg${i}`, 'chatA@g.us', false, '', false);
+      }
+      // chatB should still accept
+      expect(tracker.markReceived('msg0', 'chatB@g.us', false, '', false)).toBe(true);
+    });
+  });
+
+  describe('system error message suppression', () => {
+    it('suppresses [system] error message for non-main group failures', async () => {
+      tracker.markReceived('msg1', 'group@g.us', false, 'sender@s.whatsapp.net', false);
+      tracker.markAllFailed('group@g.us', 'Task crashed');
+      await tracker.flush();
+
+      // ❌ emoji should be sent
+      const failCalls = deps.sendReaction.mock.calls.filter((c) => c[2] === '❌');
+      expect(failCalls).toHaveLength(1);
+      // But no text message
+      expect(deps.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('suppresses [system] recovery message for non-main groups', async () => {
+      const fs = await import('fs');
+      const persisted = JSON.stringify([
+        {
+          messageId: 'orphan1',
+          chatJid: 'group@g.us',
+          fromMe: false,
+          state: 1,
+          terminal: null,
+          trackedAt: 1000,
+        },
+      ]);
+      (fs.default.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      (fs.default.readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(persisted);
+
+      await tracker.recover();
+
+      // ❌ emoji should be sent
+      expect(deps.sendReaction).toHaveBeenCalledTimes(1);
+      // But no text message to non-main group
+      expect(deps.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('sends [system] error message for main group failures', async () => {
+      tracker.markReceived('msg1', MAIN_JID, false, '', false);
+      tracker.markAllFailed(MAIN_JID, 'Task crashed');
+      await tracker.flush();
+
+      expect(deps.sendMessage).toHaveBeenCalledWith(
+        MAIN_JID,
+        '[system] Task crashed',
+      );
+    });
+
+    it('sends [system] recovery message for main group', async () => {
+      const fs = await import('fs');
+      const persisted = JSON.stringify([
+        {
+          messageId: 'orphan1',
+          chatJid: MAIN_JID,
+          fromMe: false,
+          state: 1,
+          terminal: null,
+          trackedAt: 1000,
+        },
+      ]);
+      (fs.default.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      (fs.default.readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(persisted);
+
+      await tracker.recover();
+
+      expect(deps.sendMessage).toHaveBeenCalledWith(
+        MAIN_JID,
+        '[system] Restarted — reprocessing your message.',
+      );
+    });
+  });
+
+  describe('piping path emoji sequence', () => {
+    it('markReceived then markThinking produces eyes then thinking emoji', async () => {
+      deps.isRegisteredGroup.mockReturnValue(true);
+
+      tracker.markReceived('msg1', 'group@g.us', false, 'sender@s.whatsapp.net', false);
+      tracker.markThinking('msg1', 'group@g.us');
+
+      await tracker.flush();
+
+      expect(deps.sendReaction).toHaveBeenCalledTimes(2);
+      const emojis = deps.sendReaction.mock.calls.map((c) => c[2]);
+      expect(emojis).toEqual(['\u{1F440}', '\u{1F4AD}']);
+      // Verify reactions sent to the correct chat
+      expect(deps.sendReaction.mock.calls[0][0]).toBe('group@g.us');
+    });
+  });
+
+  describe('composite key isolation', () => {
+    it('tracks same messageId in different chatJids independently', async () => {
+      // Both chats are "registered"
+      deps.isRegisteredGroup.mockReturnValue(true);
+
+      tracker.markReceived('42', 'chatA@g.us', false, '', false);
+      tracker.markReceived('42', 'chatB@g.us', false, '', false);
+
+      await tracker.flush();
+      // Should get 2 👀 reactions (one per chat), not 1
+      expect(deps.sendReaction).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/status-tracker.ts
+++ b/src/status-tracker.ts
@@ -1,0 +1,419 @@
+import fs from 'fs';
+import path from 'path';
+
+import { DATA_DIR, CONTAINER_TIMEOUT } from './config.js';
+import { logger } from './logger.js';
+
+// DONE and FAILED share value 3: both are terminal states with monotonic
+// forward-only transitions (state >= current). The emoji differs but the
+// ordering logic treats them identically.
+export enum StatusState {
+  RECEIVED = 0,
+  THINKING = 1,
+  WORKING = 2,
+  DONE = 3,
+  FAILED = 3,
+}
+
+const DONE_EMOJI = '\u{2705}';
+const FAILED_EMOJI = '\u{274C}';
+
+const CLEANUP_DELAY_MS = 5000;
+const RECEIVED_GRACE_MS = 30_000;
+const REACTION_MAX_RETRIES = 3;
+const REACTION_BASE_DELAY_MS = 2000;
+const MIN_TRANSITION_DELAY_MS = 800;
+const MAX_TRACKED_PER_JID = 20;
+
+interface MessageKey {
+  id: string;
+  remoteJid: string;
+  fromMe?: boolean;
+  participant?: string;
+}
+
+interface TrackedMessage {
+  messageId: string;
+  chatJid: string;
+  fromMe: boolean;
+  senderJid: string;
+  state: number;
+  terminal: 'done' | 'failed' | null;
+  sendChain: Promise<void>;
+  trackedAt: number;
+}
+
+interface PersistedEntry {
+  messageId: string;
+  chatJid: string;
+  fromMe: boolean;
+  senderJid: string;
+  state: number;
+  terminal: 'done' | 'failed' | null;
+  trackedAt: number;
+}
+
+export interface StatusTrackerDeps {
+  sendReaction: (
+    chatJid: string,
+    messageKey: MessageKey,
+    emoji: string,
+  ) => Promise<void>;
+  sendMessage: (chatJid: string, text: string) => Promise<void>;
+  isRegisteredGroup: (chatJid: string) => boolean;
+  isMainGroup: (chatJid: string) => boolean;
+  isContainerAlive: (chatJid: string) => boolean;
+}
+
+export class StatusTracker {
+  private tracked = new Map<string, TrackedMessage>();
+  private deps: StatusTrackerDeps;
+  private persistPath: string;
+  private _shuttingDown = false;
+
+  constructor(deps: StatusTrackerDeps) {
+    this.deps = deps;
+    this.persistPath = path.join(DATA_DIR, 'status-tracker.json');
+  }
+
+  private trackingKey(chatJid: string, messageId: string): string {
+    return `${chatJid}:${messageId}`;
+  }
+
+  markReceived(
+    messageId: string,
+    chatJid: string,
+    fromMe: boolean,
+    senderJid: string,
+    isBotMessage: boolean,
+  ): boolean {
+    if (!this.deps.isRegisteredGroup(chatJid)) return false;
+    if (isBotMessage) return false;
+
+    // Per-JID cap: count non-terminal tracked messages for this JID
+    let nonTerminalCount = 0;
+    for (const msg of this.tracked.values()) {
+      if (msg.chatJid === chatJid && msg.terminal === null) nonTerminalCount++;
+    }
+    if (nonTerminalCount >= MAX_TRACKED_PER_JID) {
+      logger.warn({ chatJid, messageId, nonTerminalCount }, 'Per-JID tracking cap reached, skipping emoji status');
+      return false;
+    }
+
+    if (this.tracked.has(this.trackingKey(chatJid, messageId))) return false;
+
+    const msg: TrackedMessage = {
+      messageId,
+      chatJid,
+      fromMe,
+      senderJid,
+      state: StatusState.RECEIVED,
+      terminal: null,
+      sendChain: Promise.resolve(),
+      trackedAt: Date.now(),
+    };
+
+    this.tracked.set(this.trackingKey(chatJid, messageId), msg);
+    this.enqueueSend(msg, '\u{1F440}');
+    this.persist();
+    return true;
+  }
+
+  markThinking(messageId: string, chatJid: string): boolean {
+    return this.transition(this.trackingKey(chatJid, messageId), StatusState.THINKING, '\u{1F4AD}');
+  }
+
+  markWorking(messageId: string, chatJid: string): boolean {
+    return this.transition(this.trackingKey(chatJid, messageId), StatusState.WORKING, '\u{1F504}');
+  }
+
+  markDone(messageId: string, chatJid: string): boolean {
+    return this.transitionTerminal(this.trackingKey(chatJid, messageId), 'done', DONE_EMOJI);
+  }
+
+  markFailed(messageId: string, chatJid: string): boolean {
+    return this.transitionTerminal(this.trackingKey(chatJid, messageId), 'failed', FAILED_EMOJI);
+  }
+
+  markAllWorking(chatJid: string): void {
+    for (const [id, msg] of this.tracked) {
+      if (msg.chatJid === chatJid && msg.terminal === null) {
+        this.transition(id, StatusState.WORKING, '\u{1F504}');
+      }
+    }
+  }
+
+  markAllDone(chatJid: string): void {
+    for (const [id, msg] of this.tracked) {
+      if (msg.chatJid === chatJid && msg.terminal === null) {
+        this.transitionTerminal(id, 'done', DONE_EMOJI);
+      }
+    }
+  }
+
+  markAllFailed(chatJid: string, errorMessage: string): void {
+    let anyFailed = false;
+    for (const [id, msg] of this.tracked) {
+      if (msg.chatJid === chatJid && msg.terminal === null) {
+        this.transitionTerminal(id, 'failed', FAILED_EMOJI);
+        anyFailed = true;
+      }
+    }
+    if (anyFailed && this.deps.isMainGroup(chatJid)) {
+      this.deps
+        .sendMessage(chatJid, `[system] ${errorMessage}`)
+        .catch((err) =>
+          logger.error({ chatJid, err }, 'Failed to send status error message'),
+        );
+    }
+  }
+
+  isTracked(messageId: string, chatJid: string): boolean {
+    return this.tracked.has(this.trackingKey(chatJid, messageId));
+  }
+
+  /** Wait for all pending reaction sends to complete. */
+  async flush(): Promise<void> {
+    const chains = Array.from(this.tracked.values()).map((m) => m.sendChain);
+    await Promise.allSettled(chains);
+  }
+
+  /** Signal shutdown and flush. Prevents new retry sleeps so flush resolves quickly. */
+  async shutdown(): Promise<void> {
+    this._shuttingDown = true;
+    await this.flush();
+  }
+
+  /**
+   * Startup recovery: read persisted state and mark all non-terminal entries as failed.
+   * Call this before the message loop starts.
+   */
+  async recover(sendErrorMessage: boolean = true): Promise<void> {
+    let entries: PersistedEntry[] = [];
+    try {
+      if (fs.existsSync(this.persistPath)) {
+        const raw = fs.readFileSync(this.persistPath, 'utf-8');
+        const parsed = JSON.parse(raw);
+        if (!Array.isArray(parsed)) {
+          logger.warn('Status tracker persistence file is not an array, ignoring');
+        } else {
+          entries = parsed;
+        }
+      }
+    } catch (err) {
+      logger.warn({ err }, 'Failed to read status tracker persistence file');
+      return;
+    }
+
+    // Clear persistence immediately after reading to prevent race with
+    // markReceived() persisting new entries during the async flush below.
+    // Node.js single-threaded: no interleaving between readFileSync and this.
+    this.clearPersistence();
+
+    const orphanedByChat = new Map<string, number>();
+    for (const entry of entries) {
+      if (entry.terminal !== null) continue;
+      // Skip entries for groups that are no longer registered
+      if (!this.deps.isRegisteredGroup(entry.chatJid)) continue;
+
+      // Reconstruct tracked message for the reaction send
+      const msg: TrackedMessage = {
+        messageId: entry.messageId,
+        chatJid: entry.chatJid,
+        fromMe: entry.fromMe,
+        senderJid: entry.senderJid || '',
+        state: entry.state,
+        terminal: null,
+        sendChain: Promise.resolve(),
+        trackedAt: entry.trackedAt,
+      };
+      this.tracked.set(this.trackingKey(entry.chatJid, entry.messageId), msg);
+      this.transitionTerminal(this.trackingKey(entry.chatJid, entry.messageId), 'failed', FAILED_EMOJI);
+      orphanedByChat.set(
+        entry.chatJid,
+        (orphanedByChat.get(entry.chatJid) || 0) + 1,
+      );
+    }
+
+    if (sendErrorMessage) {
+      for (const [chatJid] of orphanedByChat) {
+        if (!this.deps.isMainGroup(chatJid)) continue;
+        this.deps
+          .sendMessage(
+            chatJid,
+            `[system] Restarted \u{2014} reprocessing your message.`,
+          )
+          .catch((err) =>
+            logger.error({ chatJid, err }, 'Failed to send recovery message'),
+          );
+      }
+    }
+
+    await this.flush();
+    logger.info(
+      { recoveredCount: entries.filter((e) => e.terminal === null).length },
+      'Status tracker recovery complete',
+    );
+  }
+
+  /**
+   * Heartbeat: check for stale tracked messages where container has died.
+   * Call this from the IPC poll cycle.
+   */
+  heartbeatCheck(): void {
+    const now = Date.now();
+    for (const [id, msg] of this.tracked) {
+      if (msg.terminal !== null) continue;
+
+      // For RECEIVED messages, only fail if container is dead AND grace period elapsed.
+      // This closes the gap where a container dies before advancing to THINKING.
+      if (msg.state < StatusState.THINKING) {
+        if (
+          !this.deps.isContainerAlive(msg.chatJid) &&
+          now - msg.trackedAt > RECEIVED_GRACE_MS
+        ) {
+          logger.warn(
+            { messageId: msg.messageId, chatJid: msg.chatJid, age: now - msg.trackedAt },
+            'Heartbeat: RECEIVED message stuck with dead container',
+          );
+          this.markAllFailed(msg.chatJid, 'Task crashed \u{2014} retrying.');
+          continue; // Multi-group: continue checking other groups
+        }
+        continue;
+      }
+
+      if (!this.deps.isContainerAlive(msg.chatJid)) {
+        logger.warn(
+          { messageId: msg.messageId, chatJid: msg.chatJid },
+          'Heartbeat: container dead, marking failed',
+        );
+        this.markAllFailed(msg.chatJid, 'Task crashed \u{2014} retrying.');
+        continue; // Multi-group: continue checking other groups
+      }
+
+      if (now - msg.trackedAt > CONTAINER_TIMEOUT) {
+        logger.warn(
+          { messageId: msg.messageId, chatJid: msg.chatJid, age: now - msg.trackedAt },
+          'Heartbeat: message stuck beyond timeout',
+        );
+        this.markAllFailed(msg.chatJid, 'Task timed out \u{2014} retrying.');
+        continue; // Multi-group: continue checking other groups
+      }
+    }
+  }
+
+  private transition(
+    messageId: string,
+    newState: number,
+    emoji: string,
+  ): boolean {
+    const msg = this.tracked.get(messageId);
+    if (!msg) return false;
+    if (msg.terminal !== null) return false;
+    if (newState <= msg.state) return false;
+
+    msg.state = newState;
+    // Reset trackedAt on THINKING so heartbeat timeout measures from container start, not message receipt
+    if (newState === StatusState.THINKING) {
+      msg.trackedAt = Date.now();
+    }
+    this.enqueueSend(msg, emoji);
+    this.persist();
+    return true;
+  }
+
+  private transitionTerminal(
+    messageId: string,
+    terminal: 'done' | 'failed',
+    emoji: string,
+  ): boolean {
+    const msg = this.tracked.get(messageId);
+    if (!msg) return false;
+    if (msg.terminal !== null) return false;
+
+    msg.state = StatusState.DONE; // DONE and FAILED both = 3
+    msg.terminal = terminal;
+    this.enqueueSend(msg, emoji);
+    this.persist();
+    this.scheduleCleanup(messageId);
+    return true;
+  }
+
+  private enqueueSend(msg: TrackedMessage, emoji: string): void {
+    const key: MessageKey = {
+      id: msg.messageId,
+      remoteJid: msg.chatJid,
+      fromMe: msg.fromMe,
+    };
+    if (!msg.fromMe && msg.senderJid) {
+      key.participant = msg.senderJid;
+    }
+    msg.sendChain = msg.sendChain.then(async () => {
+      for (let attempt = 1; attempt <= REACTION_MAX_RETRIES; attempt++) {
+        try {
+          await this.deps.sendReaction(msg.chatJid, key, emoji);
+          // Ensure each transition is visible before the next one fires
+          await new Promise((r) => setTimeout(r, MIN_TRANSITION_DELAY_MS));
+          return;
+        } catch (err) {
+          if (attempt === REACTION_MAX_RETRIES) {
+            logger.error(
+              { messageId: msg.messageId, emoji, err, attempts: attempt },
+              'Failed to send status reaction after retries',
+            );
+          } else if (this._shuttingDown) {
+            logger.warn(
+              { messageId: msg.messageId, emoji, attempt, err },
+              'Reaction send failed, skipping retry (shutting down)',
+            );
+            return;
+          } else {
+            const delay = REACTION_BASE_DELAY_MS * Math.pow(2, attempt - 1);
+            logger.warn(
+              { messageId: msg.messageId, emoji, attempt, delay, err },
+              'Reaction send failed, retrying',
+            );
+            await new Promise((r) => setTimeout(r, delay));
+          }
+        }
+      }
+    });
+  }
+
+  /** Must remain async (setTimeout) — synchronous deletion would break iteration in markAllDone/markAllFailed. */
+  private scheduleCleanup(compositeKey: string): void {
+    setTimeout(() => {
+      this.tracked.delete(compositeKey);
+      this.persist();
+    }, CLEANUP_DELAY_MS);
+  }
+
+  private persist(): void {
+    try {
+      const entries: PersistedEntry[] = [];
+      for (const msg of this.tracked.values()) {
+        entries.push({
+          messageId: msg.messageId,
+          chatJid: msg.chatJid,
+          fromMe: msg.fromMe,
+          senderJid: msg.senderJid,
+          state: msg.state,
+          terminal: msg.terminal,
+          trackedAt: msg.trackedAt,
+        });
+      }
+      fs.mkdirSync(path.dirname(this.persistPath), { recursive: true });
+      fs.writeFileSync(this.persistPath, JSON.stringify(entries));
+    } catch (err) {
+      logger.warn({ err }, 'Failed to persist status tracker state');
+    }
+  }
+
+  private clearPersistence(): void {
+    try {
+      fs.writeFileSync(this.persistPath, '[]');
+    } catch {
+      // ignore
+    }
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,12 @@ export interface Channel {
   setTyping?(jid: string, isTyping: boolean): Promise<void>;
   // Optional: sync group/chat names from the platform.
   syncGroups?(force: boolean): Promise<void>;
+  // Optional: send emoji reaction to a specific message.
+  sendReaction?(
+    jid: string,
+    messageKey: { id: string; remoteJid: string; fromMe?: boolean; participant?: string },
+    emoji: string,
+  ): Promise<void>;
 }
 
 // Callback type that channels use to deliver inbound messages


### PR DESCRIPTION
## Summary

Add `StatusTracker` class that provides emoji lifecycle reactions on messages as they flow through the processing pipeline: 👀 (received) → 💭 (thinking) → 🔄 (working) → ✅ (done) / ❌ (failed).

- Supports **all registered groups**, not just the main group — trigger-gated groups only get reactions on trigger+allowlist-matching messages (context messages are processed but not reacted to)
- Composite tracking keys (`chatJid:messageId`) prevent cross-chat collisions
- `isRegisteredGroup` gates tracking; `isMainGroup` gates `[system]` error messages
- Per-JID non-terminal cap (20 messages) prevents runaway emoji spam
- Heartbeat check via IPC poll detects dead containers and marks stale messages as failed
- Crash recovery: persists non-terminal state to disk, marks orphaned entries as ❌ on restart
- Serialized per-message send chains with exponential retry (3 attempts)
- `sendReaction` added as optional method on `Channel` interface
- `isActive()` added to `GroupQueue` for heartbeat container liveness checks

## What changed

| File | Change |
|------|--------|
| `src/status-tracker.ts` | New — `StatusTracker` class with forward-only state machine, persistence, recovery, heartbeat |
| `src/status-tracker.test.ts` | New — 38 tests covering transitions, gating, batching, retry, recovery, heartbeat, caps |
| `src/index.ts` | Construct `StatusTracker`, integrate into `onMessage`, `processGroupMessages` (batch + piping paths), `recoverPendingMessages`, shutdown |
| `src/types.ts` | Add optional `sendReaction` to `Channel` interface |
| `src/group-queue.ts` | Add `isActive()` method for heartbeat liveness checks |
| `src/ipc.ts` | Add `statusHeartbeat` dep, call it each IPC poll cycle |

## Design decisions

- **Per-group trigger pattern**: Uses `getTriggerPattern(group.trigger)` (not a global `TRIGGER_PATTERN`) so each group's custom trigger is respected
- **Instant 👀 for non-trigger groups**: `onMessage` fires `markReceived` immediately for main groups and `requiresTrigger: false` groups; trigger-gated groups defer to the batch/piping paths where the trigger has been verified
- **Recovery after connect**: `statusTracker.recover()` runs after channels connect so `findChannel()` can resolve JIDs for sending ❌ reactions
- **Heartbeat in IPC loop**: Piggybacks on the existing 1s IPC poll cycle rather than adding a separate timer

## Test plan

- [x] `npm run build` — zero TypeScript errors
- [x] `npm test -- --run src/status-tracker.test.ts` — all 38 tests pass
- [ ] Manual: send message to main group, observe 👀→💭→🔄→✅ emoji lifecycle
- [ ] Manual: send trigger message to non-main group, observe reactions on trigger message only
- [ ] Manual: send non-trigger message to trigger-gated group, confirm no reaction
- [ ] Manual: kill container mid-processing, confirm ❌ appears after heartbeat
- [ ] Manual: restart NanoClaw with pending messages, confirm ❌ recovery + reprocessing

🤖 Generated with [Claude Code](https://claude.com/claude-code)