### PR TITLE
fix: pass ANTHROPIC_API_KEY and BASE_URL to agent containers

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,8 @@ import { isValidTimezone } from './timezone.js';
 const envConfig = readEnvFile([
   'ASSISTANT_NAME',
   'ASSISTANT_HAS_OWN_NUMBER',
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_BASE_URL',
   'ONECLI_URL',
   'TZ',
 ]);
@@ -51,6 +53,10 @@ export const CONTAINER_MAX_OUTPUT_SIZE = parseInt(
   process.env.CONTAINER_MAX_OUTPUT_SIZE || '10485760',
   10,
 ); // 10MB default
+export const ANTHROPIC_API_KEY =
+  process.env.ANTHROPIC_API_KEY || envConfig.ANTHROPIC_API_KEY || '';
+export const ANTHROPIC_BASE_URL =
+  process.env.ANTHROPIC_BASE_URL || envConfig.ANTHROPIC_BASE_URL || '';
 export const ONECLI_URL =
   process.env.ONECLI_URL || envConfig.ONECLI_URL || 'http://localhost:10254';
 export const MAX_MESSAGES_PER_PROMPT = Math.max(

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -8,6 +8,8 @@ const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
 
 // Mock config
 vi.mock('./config.js', () => ({
+  ANTHROPIC_API_KEY: '',
+  ANTHROPIC_BASE_URL: '',
   CONTAINER_IMAGE: 'nanoclaw-agent:latest',
   CONTAINER_MAX_OUTPUT_SIZE: 10485760,
   CONTAINER_TIMEOUT: 1800000, // 30min

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -7,6 +7,8 @@ import fs from 'fs';
 import path from 'path';
 
 import {
+  ANTHROPIC_API_KEY,
+  ANTHROPIC_BASE_URL,
   CONTAINER_IMAGE,
   CONTAINER_MAX_OUTPUT_SIZE,
   CONTAINER_TIMEOUT,
@@ -232,6 +234,14 @@ async function buildContainerArgs(
 
   // Pass host timezone so container's local time matches the user's
   args.push('-e', `TZ=${TIMEZONE}`);
+
+  // Pass custom API config into container if configured
+  if (ANTHROPIC_BASE_URL) {
+    args.push('-e', `ANTHROPIC_BASE_URL=${ANTHROPIC_BASE_URL}`);
+  }
+  if (ANTHROPIC_API_KEY) {
+    args.push('-e', `ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}`);
+  }
 
   // OneCLI gateway handles credential injection — containers never see real secrets.
   // The gateway intercepts HTTPS traffic and injects API keys or OAuth tokens.


### PR DESCRIPTION
## Summary
- Setting `ANTHROPIC_API_KEY` and `ANTHROPIC_BASE_URL` in the host environment per documentation has no effect on containerized agents — the variables are never forwarded to the container, so agents silently ignore the configured LLM
- This fix reads both variables from the host environment and passes them through to `container-runner` so agent containers actually use the configured provider
- Adds corresponding test mock coverage for the new env vars

## Test plan
- [x] `npm run build` passes
- [x] `npm run test` passes (container-runner test updated)
- [ ] Set `ANTHROPIC_API_KEY` and `ANTHROPIC_BASE_URL` in `.env`, verify containerized agent uses the configured LLM
- [ ] Verify existing OneCLI flow still works when env vars are absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)