### PR TITLE
feat: add SKILL_DATA_DIR for persistent container skill storage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ Single Node.js process with skill-based channel system. Channels (WhatsApp, Tele
 | `src/db.ts` | SQLite operations |
 | `groups/{name}/CLAUDE.md` | Per-group memory (isolated) |
 | `container/skills/` | Skills loaded inside agent containers (browser, status, formatting) |
+| `data/sessions/{group}/skill-data/` | Per-group persistent storage for container skills (`SKILL_DATA_DIR`) |
 
 ## Secrets / Credentials / Proxy (OneCLI)
 
@@ -43,6 +44,18 @@ Four types of skills exist in NanoClaw. See [CONTRIBUTING.md](CONTRIBUTING.md) f
 | `/init-onecli` | Install OneCLI Agent Vault and migrate `.env` credentials to it |
 | `/qodo-pr-resolver` | Fetch and fix Qodo PR review issues interactively or in batch |
 | `/get-qodo-rules` | Load org- and repo-level coding rules from Qodo before code tasks |
+
+## Container Skill Data
+
+Container skills that need persistent storage (caches, auth state, learned preferences) should use the `SKILL_DATA_DIR` environment variable. This points to `/workspace/skill-data` inside the container — a writable, per-group directory that survives container restarts.
+
+```bash
+# In a skill's bash commands:
+mkdir -p "$SKILL_DATA_DIR/my-skill"
+echo '{"token": "..."}' > "$SKILL_DATA_DIR/my-skill/auth.json"
+```
+
+Each group (user) gets an isolated `skill-data/` directory. Skills share the same code but never share data across groups. On the host, data lives at `data/sessions/{group}/skill-data/`.
 
 ## Contributing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,7 @@ Skills that run inside the agent container, not on the host. These teach the con
 - Follow the same SKILL.md + frontmatter format
 - Use `allowed-tools` frontmatter to scope tool permissions
 - Keep them focused — the agent's context window is shared across all container skills
+- For persistent data (caches, auth state, preferences), use `$SKILL_DATA_DIR/<skill-name>/` — never write to `/workspace/group/` or `/tmp/` for data that should survive restarts
 
 ### SKILL.md format
 

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -165,6 +165,19 @@ function buildVolumeMounts(
     readonly: false,
   });
 
+  // Per-group persistent data directory for skills.
+  // Skills that need to persist state across sessions (caches, auth tokens,
+  // learned preferences) write here instead of polluting /workspace/group/.
+  // Each group gets its own directory — no cross-group access.
+  // Exposed inside the container as SKILL_DATA_DIR=/workspace/skill-data.
+  const skillDataDir = path.join(DATA_DIR, 'sessions', group.folder, 'skill-data');
+  fs.mkdirSync(skillDataDir, { recursive: true });
+  mounts.push({
+    hostPath: skillDataDir,
+    containerPath: '/workspace/skill-data',
+    readonly: false,
+  });
+
   // Per-group IPC namespace: each group gets its own IPC directory
   // This prevents cross-group privilege escalation via IPC
   const groupIpcDir = resolveGroupIpcPath(group.folder);
@@ -232,6 +245,10 @@ async function buildContainerArgs(
 
   // Pass host timezone so container's local time matches the user's
   args.push('-e', `TZ=${TIMEZONE}`);
+
+  // Persistent storage for skills — survives container restarts.
+  // Skills use this env var to locate their data directory.
+  args.push('-e', 'SKILL_DATA_DIR=/workspace/skill-data');
 
   // OneCLI gateway handles credential injection — containers never see real secrets.
   // The gateway intercepts HTTPS traffic and injects API keys or OAuth tokens.


### PR DESCRIPTION
## Summary

- Adds a per-group `skill-data/` directory mounted at `/workspace/skill-data` inside containers
- Sets `SKILL_DATA_DIR` environment variable so skills can locate it
- Documents the convention in CLAUDE.md and CONTRIBUTING.md

## Motivation

Container skills that need persistent state (browser auth tokens, caches, learned preferences) currently have no designated storage location. They end up writing to `/workspace/group/` (pollutes user files) or `/tmp/` (lost on restart). This adds a clean, per-group-isolated directory following the same isolation model as `.claude/` and IPC directories.

## How it works

1. `buildVolumeMounts()` creates `data/sessions/{group}/skill-data/` and mounts it read-write
2. `buildContainerArgs()` sets `SKILL_DATA_DIR=/workspace/skill-data` as a container env var
3. Skills use `$SKILL_DATA_DIR/<skill-name>/` for their persistent data

Each group gets its own directory — no cross-group access, consistent with existing isolation.

## Test plan

- [x] `npm run build` — no new TypeScript errors (pre-existing `@onecli-sh/sdk` error unchanged)
- [x] `npm test` — all 227 tests pass (2 pre-existing failures from `@onecli-sh/sdk` unchanged)
- [x] Verified `skill-data/` path uses `group.folder` for per-user isolation
- [ ] Manual: send a message, verify `/workspace/skill-data` exists and `SKILL_DATA_DIR` is set
