### PR TITLE
fix(queue): evict idle task containers when messages arrive

### DIFF
--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -66,6 +66,14 @@ export class GroupQueue {
 
     if (state.active) {
       state.pendingMessages = true;
+      // If a task container is idle, close it so messages can be processed
+      if (state.idleWaiting && state.isTaskContainer) {
+        logger.info(
+          { groupJid },
+          'Closing idle task container for pending messages',
+        );
+        this.closeStdin(groupJid);
+      }
       logger.debug({ groupJid }, 'Container active, message queued');
       return;
     }


### PR DESCRIPTION
## Problem

When a scheduled task completes, its container enters an idle-wait state (up to 30 minutes by default). During this time, if a user sends a message to the same group, `enqueueMessageCheck()` sees `state.active` is true and queues the message -- but the active container is a task container, and `sendMessage()` skips task containers. The message sits unprocessed until the idle timeout expires.

This means after any scheduled task runs, interactive messages to that group are silently delayed by up to 30 minutes.

## Fix

When `enqueueMessageCheck()` detects that the active container is both idle-waiting (`state.idleWaiting`) and a task container (`state.isTaskContainer`), it sends the close sentinel via `closeStdin()`. This lets the existing drain logic tear down the task container and immediately spin up a message container.

## Details

- Single file change: `src/group-queue.ts` (8 additions)
- Only affects task containers that are already idle -- active task containers with work in progress are not touched
- The close sentinel triggers the normal container shutdown path, so cleanup (session save, process exit) happens gracefully

## Test plan

- [x] Scheduled task runs, completes, container enters idle wait
- [x] User sends message during idle wait -- task container is evicted, message container starts immediately
- [x] User sends message while task is actively running -- no eviction, message queued normally
- [x] `npm run build` passes clean