### PR TITLE
fix: abort hung SDK queries with AbortController idle timeout

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -59,6 +59,7 @@ interface SDKUserMessage {
 const IPC_INPUT_DIR = '/workspace/ipc/input';
 const IPC_INPUT_CLOSE_SENTINEL = path.join(IPC_INPUT_DIR, '_close');
 const IPC_POLL_MS = 500;
+const QUERY_IDLE_TIMEOUT_MS = parseInt(process.env.QUERY_IDLE_TIMEOUT || '300000', 10); // 5 min default
 
 /**
  * Push-based async iterable for streaming user messages to the SDK.
@@ -338,9 +339,19 @@ async function runQuery(
   containerInput: ContainerInput,
   sdkEnv: Record<string, string | undefined>,
   resumeAt?: string,
-): Promise<{ newSessionId?: string; lastAssistantUuid?: string; closedDuringQuery: boolean }> {
+): Promise<{ newSessionId?: string; lastAssistantUuid?: string; closedDuringQuery: boolean; aborted: boolean }> {
   const stream = new MessageStream();
   stream.push(prompt);
+
+  // Abort query if no SDK messages for QUERY_IDLE_TIMEOUT_MS
+  const abortController = new AbortController();
+  let aborted = false;
+  const startIdleTimer = () => setTimeout(() => {
+    log(`No SDK messages for ${QUERY_IDLE_TIMEOUT_MS}ms, aborting query`);
+    aborted = true;
+    abortController.abort();
+  }, QUERY_IDLE_TIMEOUT_MS);
+  let idleTimer = startIdleTimer();
 
   // Poll IPC for follow-up messages and _close sentinel during the query
   let ipcPolling = true;
@@ -429,8 +440,11 @@ async function runQuery(
       hooks: {
         PreCompact: [{ hooks: [createPreCompactHook(containerInput.assistantName)] }],
       },
+      abortController,
     }
   })) {
+    clearTimeout(idleTimer);
+    idleTimer = startIdleTimer();
     messageCount++;
     const msgType = message.type === 'system' ? `system/${(message as { subtype?: string }).subtype}` : message.type;
     log(`[msg #${messageCount}] type=${msgType}`);
@@ -461,9 +475,10 @@ async function runQuery(
     }
   }
 
+  clearTimeout(idleTimer);
   ipcPolling = false;
-  log(`Query done. Messages: ${messageCount}, results: ${resultCount}, lastAssistantUuid: ${lastAssistantUuid || 'none'}, closedDuringQuery: ${closedDuringQuery}`);
-  return { newSessionId, lastAssistantUuid, closedDuringQuery };
+  log(`Query done. Messages: ${messageCount}, results: ${resultCount}, lastAssistantUuid: ${lastAssistantUuid || 'none'}, closedDuringQuery: ${closedDuringQuery}, aborted: ${aborted}`);
+  return { newSessionId, lastAssistantUuid, closedDuringQuery, aborted };
 }
 
 interface ScriptResult {
@@ -596,6 +611,12 @@ async function main(): Promise<void> {
       if (queryResult.closedDuringQuery) {
         log('Close sentinel consumed during query, exiting');
         break;
+      }
+
+      // Query was aborted due to idle timeout — exit so host can retry
+      if (queryResult.aborted) {
+        writeOutput({ status: 'error', result: null, newSessionId: sessionId, error: 'Query idle timeout' });
+        process.exit(1);
       }
 
       // Emit session update so host can track it


### PR DESCRIPTION
## Problem

When the SDK `query()` hangs — due to rate limits, network failures, or any other reason — the container becomes unresponsive. The host's container-level timeout (default 30 min) resets on every output marker, so if a rate limit notice is emitted right before the hang, the timer resets and the user waits another 30 minutes with no response.

The host's existing retry logic (exponential backoff in GroupQueue) only triggers when the container exits with an error. A hung container never exits, so retries never fire.

## Alternatives considered

### Parse rate limit text from Claude output (#670)
Regex-parses `"resets Xam (Timezone)"` from the result text. Fragile — breaks if the output format changes. Also only covers rate limits, not network failures, SDK bugs, or any other hang scenario.

### Host-side input→output timeout
Track when the host sends a message and kill the container if no output arrives within N minutes. The host can't distinguish a legitimately long tool execution (e.g. a build) from a hang — both look like silence.

### Heartbeat from agent-runner
Emit periodic heartbeats to stderr. The SDK's `for await` loop is blocking — there's no opportunity to emit a heartbeat while waiting for the next message, which is exactly when the hang occurs. A worker thread could work but adds complexity for no benefit over AbortController.

## Solution

Use the SDK's built-in `abortController` option to set a per-query idle timeout. If no SDK messages arrive within 5 minutes (configurable via `QUERY_IDLE_TIMEOUT` env var), the query is aborted cleanly. The container exits with an error, and the host's existing retry logic handles the rest.

This works because SDK messages stream continuously during normal operation — tool invocations, intermediate output, system events all produce messages. Five minutes of complete silence means the query is stuck, regardless of the cause.

### Changes

- Add `QUERY_IDLE_TIMEOUT_MS` constant (default 5 min, env-configurable)
- Create `AbortController` per query, pass to SDK `query()` options
- Reset idle timer on every SDK message
- On timeout: abort query, emit error output, exit container

### What this covers

- Rate limit hangs
- Network failures
- SDK internal issues
- Any future cause of query hangs

### What this doesn't change

- No host-side code changes
- Container-level timeout preserved as safety net
- Existing retry logic (GroupQueue exponential backoff) reused as-is

## Test plan

- [ ] Deploy and trigger a rate limit to confirm the container aborts within 5 min instead of hanging for 30 min
- [ ] Verify normal long-running tasks (multi-step tool use, large file operations) complete without being aborted
- [ ] Confirm host retries the message after container exits

Closes #186