### PR TITLE
fix: always write _close sentinel in notifyIdle

### DIFF
--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -148,9 +148,10 @@ export class GroupQueue {
   notifyIdle(groupJid: string): void {
     const state = this.getGroup(groupJid);
     state.idleWaiting = true;
-    if (state.pendingTasks.length > 0) {
-      this.closeStdin(groupJid);
-    }
+    // Always write _close so the container's for-await loop can exit its current
+    // query and transition to waitForIpcMessage. Without this the SDK generator
+    // never closes and the container gets stuck after every response.
+    this.closeStdin(groupJid);
   }
 
   /**


### PR DESCRIPTION
## Summary

- `notifyIdle` was only writing the `_close` sentinel when pending tasks existed
- Without it, the container's `for-await` loop over the SDK query never exits after the first response
- The stale IPC poller from the completed query stays active and silently consumes any follow-up messages written to the IPC input directory
- The container appears healthy but stops responding after the first message in every warm session

## Root cause

The container agent runs a `while(true)` loop: run query → wait for `_close` → transition to `waitForIpcMessage` → run next query. If `_close` is never written, the loop stays stuck in the completed query's async iterator, which is still polling IPC. Follow-up messages get picked up by that dead poller, deleted from disk, and never processed.

## Fix

Unconditionally call `closeStdin` in `notifyIdle`. This was previously conditional on `pendingTasks.length > 0` — the original intent may have been to keep the container alive for tasks, but the container correctly handles `_close` mid-query and the task queue drains independently.

## Test plan

- Send a message to a registered group, receive a response
- Send a follow-up message within the idle timeout window
- Verify the follow-up is received and processed (previously it was silently dropped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)