### PR TITLE
feat: isolated sessions skill — per-context session isolation within a group

### DIFF
--- a/.claude/skills/isolated-sessions/SKILL.md
+++ b/.claude/skills/isolated-sessions/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: isolated-sessions
+description: Add per-context session isolation to NanoClaw groups. Enables a single registered group to run independent Claude sessions for different contexts — Slack threads, email threads, per-user DMs, or any other channel-defined scope. Each context gets its own conversation history and IPC namespace while sharing the group's folder, CLAUDE.md, and container config.
+---
+
+# Isolated Sessions
+
+This skill adds the primitives needed for context-scoped session isolation within a group.
+
+## When to use this
+
+By default, each NanoClaw group has one shared Claude session. All messages in the group continue the same conversation. This is fine for most use cases.
+
+Use this skill when:
+- A Slack channel should give each **thread** its own independent conversation
+- A Gmail integration should give each **email** its own session rather than one long shared history
+- A group should give each **user** their own isolated session
+- Any channel needs to scope sessions by an opaque context identifier it controls
+
+## Phase 1: Apply Code Changes
+
+### Check if already applied
+
+```bash
+grep -q "isolatedSessions" src/types.ts && echo "already applied" || echo "not applied"
+```
+
+If already applied, skip to Phase 2.
+
+### Merge the skill branch
+
+```bash
+git fetch upstream skill/isolated-sessions
+git merge upstream/skill/isolated-sessions
+```
+
+Resolve any conflicts by reading both sides. The skill changes four files:
+- `src/types.ts` — adds `isolatedSessions?` to `RegisteredGroup`, `sessionContext?` to `NewMessage`
+- `src/db.ts` — migration for `session_context` on messages, `isolated_sessions` on groups; updated queries
+- `src/container-runner.ts` — adds `ipcKey?` to `ContainerInput`, threads it through IPC mount
+- `src/index.ts` — `subSessionRegistry`, `deriveSessionKey`, `deriveQueueKey`, updated message loop and `runAgent`
+
+### Validate
+
+```bash
+npm install
+npm run build
+npm test
+```
+
+All tests must pass and build must be clean before proceeding.
+
+## Phase 2: Configure a Group
+
+To enable isolation for a group, set `isolatedSessions: true` when registering it. This can be done via the IPC watcher's `/register-group` command or directly in the database.
+
+**Via database (immediate, no restart needed):**
+
+```bash
+sqlite3 store/messages.db \
+  "UPDATE registered_groups SET isolated_sessions = 1 WHERE jid = '<your-group-jid>'"
+```
+
+Then reload groups in the running process by restarting the service, or wait — groups are reloaded at startup.
+
+**Via registration (new groups):**
+
+When calling `registerGroup` in a channel or IPC handler, include `isolatedSessions: true` in the `RegisteredGroup` object:
+
+```typescript
+registerGroup(jid, {
+  name: 'My Channel',
+  folder: 'my_channel',
+  trigger: '@andy',
+  added_at: new Date().toISOString(),
+  isolatedSessions: true,
+});
+```
+
+## Phase 3: Supply sessionContext from a Channel
+
+The channel is responsible for deciding what the context boundary is. The core never interprets `sessionContext` — it's an opaque string used only to derive a stable session key.
+
+In any channel's inbound message handler, set `sessionContext` on the `NewMessage` before calling `onInboundMessage`:
+
+```typescript
+const msg: NewMessage = {
+  id: messageId,
+  chat_jid: channelJid,
+  sender: userId,
+  sender_name: userName,
+  content: text,
+  timestamp: new Date().toISOString(),
+  // Set this to whatever scopes the session for your channel:
+  sessionContext: threadId,   // e.g. Slack thread_ts
+  // sessionContext: emailId, // e.g. Gmail message/thread ID
+  // sessionContext: userId,  // e.g. per-user isolation
+};
+onInboundMessage(channelJid, msg);
+```
+
+If `sessionContext` is omitted, the group falls back to its normal single-session behaviour — so the change is backwards compatible.
+
+### How the isolation works
+
+When `group.isolatedSessions` is `true` and `msg.sessionContext` is set:
+
+1. A **session key** is derived: `${group.folder}_${sha256(sessionContext).slice(0,12)}`. This is used as the Claude session ID key in the database and as the IPC namespace directory.
+2. A **queue key** is derived: `${chatJid}::ctx::${sessionContext}`. This gives each context its own slot in the GroupQueue, so concurrent contexts run in separate containers without contention.
+3. `getMessagesSince` is called with the `sessionContext` filter, so each context only sees its own message history.
+
+The group folder, CLAUDE.md, container config, and `.claude/` settings directory are **shared** across all contexts. Only the session state and IPC namespace are isolated.
+
+## Usage Examples
+
+### Slack threads
+
+In `src/channels/slack.ts`, when handling a message event:
+
+```typescript
+const sessionContext = event.thread_ts ?? event.ts; // use thread root ts
+const msg: NewMessage = {
+  // ...other fields...
+  sessionContext,
+};
+```
+
+Register the Slack channel's group with `isolatedSessions: true`. Each thread now gets its own Claude session. Replies within the thread continue that session; new threads start fresh.
+
+### Gmail (per-email sessions)
+
+In a Gmail channel handler:
+
+```typescript
+const sessionContext = email.threadId; // Gmail thread ID
+```
+
+Each email thread maintains independent context. The agent handling a support ticket doesn't see unrelated emails.
+
+### Per-user isolation
+
+For a channel where each user should have their own session:
+
+```typescript
+const sessionContext = message.from; // sender identifier
+```
+
+## Troubleshooting
+
+### Sessions not isolating
+
+1. Confirm `isolated_sessions = 1` in the database for the group:
+   ```bash
+   sqlite3 store/messages.db "SELECT jid, isolated_sessions FROM registered_groups"
+   ```
+2. Confirm the channel is setting `sessionContext` on messages before calling `onInboundMessage`.
+3. Check logs for `sessionContext` in the "Processing messages" log line.
+
+### All contexts sharing one session
+
+The group's `isolatedSessions` flag is loaded at startup. If you updated the DB directly, restart the service:
+```bash
+# macOS
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+# Linux
+systemctl --user restart nanoclaw
+```
+
+### Sub-session state lost after restart
+
+`subSessionRegistry` is in-memory and rebuilt when messages arrive — this is by design. Session state (the Claude conversation ID) is persisted in the database and survives restarts. The cursor (message position) for a sub-session is recovered from the last bot reply timestamp on restart, which may replay a small number of messages.

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -43,6 +43,7 @@ export interface ContainerInput {
   isScheduledTask?: boolean;
   assistantName?: string;
   script?: string;
+  ipcKey?: string; // Override the IPC namespace key; defaults to groupFolder
 }
 
 export interface ContainerOutput {
@@ -61,6 +62,7 @@ interface VolumeMount {
 function buildVolumeMounts(
   group: RegisteredGroup,
   isMain: boolean,
+  ipcKey?: string,
 ): VolumeMount[] {
   const mounts: VolumeMount[] = [];
   const projectRoot = process.cwd();
@@ -165,9 +167,11 @@ function buildVolumeMounts(
     readonly: false,
   });
 
-  // Per-group IPC namespace: each group gets its own IPC directory
-  // This prevents cross-group privilege escalation via IPC
-  const groupIpcDir = resolveGroupIpcPath(group.folder);
+  // Per-group IPC namespace: each group gets its own IPC directory.
+  // ipcKey overrides group.folder when a group runs isolated sub-sessions
+  // (e.g. Slack threads, email threads) so concurrent containers don't share
+  // an IPC namespace even though they share the same group folder on disk.
+  const groupIpcDir = resolveGroupIpcPath(ipcKey ?? group.folder);
   fs.mkdirSync(path.join(groupIpcDir, 'messages'), { recursive: true });
   fs.mkdirSync(path.join(groupIpcDir, 'tasks'), { recursive: true });
   fs.mkdirSync(path.join(groupIpcDir, 'input'), { recursive: true });
@@ -285,7 +289,7 @@ export async function runContainerAgent(
   const groupDir = resolveGroupFolderPath(group.folder);
   fs.mkdirSync(groupDir, { recursive: true });
 
-  const mounts = buildVolumeMounts(group, input.isMain);
+  const mounts = buildVolumeMounts(group, input.isMain, input.ipcKey);
   const safeName = group.folder.replace(/[^a-zA-Z0-9-]/g, '-');
   const containerName = `nanoclaw-${safeName}-${Date.now()}`;
   // Main group uses the default OneCLI agent; others use their own agent.

--- a/src/db.ts
+++ b/src/db.ts
@@ -146,6 +146,26 @@ function createSchema(database: Database.Database): void {
   } catch {
     /* columns already exist */
   }
+
+  // Add session_context column if it doesn't exist (migration for existing DBs)
+  // Enables per-context session isolation (thread, email, user, etc.)
+  try {
+    database.exec(`ALTER TABLE messages ADD COLUMN session_context TEXT`);
+    database.exec(
+      `CREATE INDEX IF NOT EXISTS idx_session_context ON messages(chat_jid, session_context)`,
+    );
+  } catch {
+    /* column already exists */
+  }
+
+  // Add isolated_sessions column to registered_groups if it doesn't exist
+  try {
+    database.exec(
+      `ALTER TABLE registered_groups ADD COLUMN isolated_sessions INTEGER DEFAULT 0`,
+    );
+  } catch {
+    /* column already exists */
+  }
 }
 
 export function initDatabase(): void {
@@ -274,7 +294,7 @@ export function setLastGroupSync(): void {
  */
 export function storeMessage(msg: NewMessage): void {
   db.prepare(
-    `INSERT OR REPLACE INTO messages (id, chat_jid, sender, sender_name, content, timestamp, is_from_me, is_bot_message) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT OR REPLACE INTO messages (id, chat_jid, sender, sender_name, content, timestamp, is_from_me, is_bot_message, session_context) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     msg.id,
     msg.chat_jid,
@@ -284,6 +304,7 @@ export function storeMessage(msg: NewMessage): void {
     msg.timestamp,
     msg.is_from_me ? 1 : 0,
     msg.is_bot_message ? 1 : 0,
+    msg.sessionContext ?? null,
   );
 }
 
@@ -328,7 +349,7 @@ export function getNewMessages(
   // Subquery takes the N most recent, outer query re-sorts chronologically.
   const sql = `
     SELECT * FROM (
-      SELECT id, chat_jid, sender, sender_name, content, timestamp, is_from_me
+      SELECT id, chat_jid, sender, sender_name, content, timestamp, is_from_me, session_context
       FROM messages
       WHERE timestamp > ? AND chat_jid IN (${placeholders})
         AND is_bot_message = 0 AND content NOT LIKE ?
@@ -340,14 +361,22 @@ export function getNewMessages(
 
   const rows = db
     .prepare(sql)
-    .all(lastTimestamp, ...jids, `${botPrefix}:%`, limit) as NewMessage[];
+    .all(lastTimestamp, ...jids, `${botPrefix}:%`, limit) as Array<
+    NewMessage & { session_context: string | null }
+  >;
+
+  // Map session_context column back to the sessionContext field
+  const messages: NewMessage[] = rows.map((row) => ({
+    ...row,
+    sessionContext: row.session_context ?? undefined,
+  }));
 
   let newTimestamp = lastTimestamp;
   for (const row of rows) {
     if (row.timestamp > newTimestamp) newTimestamp = row.timestamp;
   }
 
-  return { messages: rows, newTimestamp };
+  return { messages, newTimestamp };
 }
 
 export function getMessagesSince(
@@ -355,24 +384,37 @@ export function getMessagesSince(
   sinceTimestamp: string,
   botPrefix: string,
   limit: number = 200,
+  sessionContext?: string,
 ): NewMessage[] {
   // Filter bot messages using both the is_bot_message flag AND the content
   // prefix as a backstop for messages written before the migration ran.
   // Subquery takes the N most recent, outer query re-sorts chronologically.
+  // When sessionContext is provided, restrict to messages for that context only.
+  const contextFilter =
+    sessionContext !== undefined ? `AND session_context = ?` : '';
   const sql = `
     SELECT * FROM (
-      SELECT id, chat_jid, sender, sender_name, content, timestamp, is_from_me
+      SELECT id, chat_jid, sender, sender_name, content, timestamp, is_from_me, session_context
       FROM messages
       WHERE chat_jid = ? AND timestamp > ?
         AND is_bot_message = 0 AND content NOT LIKE ?
         AND content != '' AND content IS NOT NULL
+        ${contextFilter}
       ORDER BY timestamp DESC
       LIMIT ?
     ) ORDER BY timestamp
   `;
-  return db
-    .prepare(sql)
-    .all(chatJid, sinceTimestamp, `${botPrefix}:%`, limit) as NewMessage[];
+  const params: unknown[] = [chatJid, sinceTimestamp, `${botPrefix}:%`];
+  if (sessionContext !== undefined) params.push(sessionContext);
+  params.push(limit);
+
+  const rows = db.prepare(sql).all(...params) as Array<
+    NewMessage & { session_context: string | null }
+  >;
+  return rows.map((row) => ({
+    ...row,
+    sessionContext: row.session_context ?? undefined,
+  }));
 }
 
 export function getLastBotMessageTimestamp(
@@ -593,6 +635,7 @@ export function getRegisteredGroup(
         container_config: string | null;
         requires_trigger: number | null;
         is_main: number | null;
+        isolated_sessions: number | null;
       }
     | undefined;
   if (!row) return undefined;
@@ -615,6 +658,7 @@ export function getRegisteredGroup(
     requiresTrigger:
       row.requires_trigger === null ? undefined : row.requires_trigger === 1,
     isMain: row.is_main === 1 ? true : undefined,
+    isolatedSessions: row.isolated_sessions === 1 ? true : undefined,
   };
 }
 
@@ -623,8 +667,8 @@ export function setRegisteredGroup(jid: string, group: RegisteredGroup): void {
     throw new Error(`Invalid group folder "${group.folder}" for JID ${jid}`);
   }
   db.prepare(
-    `INSERT OR REPLACE INTO registered_groups (jid, name, folder, trigger_pattern, added_at, container_config, requires_trigger, is_main)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT OR REPLACE INTO registered_groups (jid, name, folder, trigger_pattern, added_at, container_config, requires_trigger, is_main, isolated_sessions)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     jid,
     group.name,
@@ -634,6 +678,7 @@ export function setRegisteredGroup(jid: string, group: RegisteredGroup): void {
     group.containerConfig ? JSON.stringify(group.containerConfig) : null,
     group.requiresTrigger === undefined ? 1 : group.requiresTrigger ? 1 : 0,
     group.isMain ? 1 : 0,
+    group.isolatedSessions ? 1 : 0,
   );
 }
 
@@ -647,6 +692,7 @@ export function getAllRegisteredGroups(): Record<string, RegisteredGroup> {
     container_config: string | null;
     requires_trigger: number | null;
     is_main: number | null;
+    isolated_sessions: number | null;
   }>;
   const result: Record<string, RegisteredGroup> = {};
   for (const row of rows) {
@@ -668,6 +714,7 @@ export function getAllRegisteredGroups(): Record<string, RegisteredGroup> {
       requiresTrigger:
         row.requires_trigger === null ? undefined : row.requires_trigger === 1,
       isMain: row.is_main === 1 ? true : undefined,
+      isolatedSessions: row.isolated_sessions === 1 ? true : undefined,
     };
   }
   return result;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import fs from 'fs';
 import path from 'path';
 
@@ -74,6 +75,44 @@ let registeredGroups: Record<string, RegisteredGroup> = {};
 let lastAgentTimestamp: Record<string, string> = {};
 let messageLoopRunning = false;
 
+/**
+ * Maps a composite queue key back to its chatJid + sessionContext.
+ * Populated at message-dispatch time; entries are cheap and permanent
+ * (same key always maps to the same pair, memory use is bounded by
+ * the number of distinct session contexts seen since last restart).
+ */
+const subSessionRegistry = new Map<
+  string,
+  { chatJid: string; sessionContext: string }
+>();
+
+/**
+ * Derive a stable, folder-safe session key for an isolated sub-session.
+ * The key is used for session DB storage and IPC namespace isolation.
+ * It intentionally does NOT contain the raw sessionContext to avoid
+ * character-set issues; a short SHA-256 prefix is sufficient for uniqueness.
+ */
+function deriveSessionKey(
+  group: RegisteredGroup,
+  sessionContext: string,
+): string {
+  const hash = createHash('sha256')
+    .update(sessionContext)
+    .digest('hex')
+    .slice(0, 12);
+  // group.folder is at most 64 chars; leave room for underscore + 12-char hash
+  return `${group.folder.slice(0, 51)}_${hash}`;
+}
+
+/**
+ * Derive the queue key for a message arriving in an isolated-sessions group.
+ * The queue key is an opaque string used only as a Map key — no folder-name
+ * constraints apply here.
+ */
+function deriveQueueKey(chatJid: string, sessionContext: string): string {
+  return `${chatJid}::ctx::${sessionContext}`;
+}
+
 const channels: Channel[] = [];
 const queue = new GroupQueue();
 
@@ -116,20 +155,24 @@ function loadState(): void {
 }
 
 /**
- * Return the message cursor for a group, recovering from the last bot reply
- * if lastAgentTimestamp is missing (new group, corrupted state, restart).
+ * Return the message cursor for a queue slot, recovering from the last bot
+ * reply if lastAgentTimestamp is missing (new group, corrupted state, restart).
+ *
+ * queueKey  — the slot key in lastAgentTimestamp (equals chatJid for normal
+ *             groups; a composite key for isolated sub-sessions)
+ * chatJid   — the actual chat JID used for DB recovery lookups
  */
-function getOrRecoverCursor(chatJid: string): string {
-  const existing = lastAgentTimestamp[chatJid];
+function getOrRecoverCursor(queueKey: string, chatJid: string): string {
+  const existing = lastAgentTimestamp[queueKey];
   if (existing) return existing;
 
   const botTs = getLastBotMessageTimestamp(chatJid, ASSISTANT_NAME);
   if (botTs) {
     logger.info(
-      { chatJid, recoveredFrom: botTs },
+      { queueKey, chatJid, recoveredFrom: botTs },
       'Recovered message cursor from last bot reply',
     );
-    lastAgentTimestamp[chatJid] = botTs;
+    lastAgentTimestamp[queueKey] = botTs;
     saveState();
     return botTs;
   }
@@ -214,10 +257,18 @@ export function _setRegisteredGroups(
 }
 
 /**
- * Process all pending messages for a group.
- * Called by the GroupQueue when it's this group's turn.
+ * Process all pending messages for a group (or isolated sub-session).
+ * Called by the GroupQueue when it's this slot's turn.
+ *
+ * queueKey — the slot key; equals chatJid for normal groups, or a
+ *            composite derived by deriveQueueKey() for isolated sub-sessions.
  */
-async function processGroupMessages(chatJid: string): Promise<boolean> {
+async function processGroupMessages(queueKey: string): Promise<boolean> {
+  // Resolve the real chatJid and optional sessionContext from the queue key.
+  const sub = subSessionRegistry.get(queueKey);
+  const chatJid = sub?.chatJid ?? queueKey;
+  const sessionContext = sub?.sessionContext;
+
   const group = registeredGroups[chatJid];
   if (!group) return true;
 
@@ -231,9 +282,10 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
 
   const missedMessages = getMessagesSince(
     chatJid,
-    getOrRecoverCursor(chatJid),
+    getOrRecoverCursor(queueKey, chatJid),
     ASSISTANT_NAME,
     MAX_MESSAGES_PER_PROMPT,
+    sessionContext,
   );
 
   if (missedMessages.length === 0) return true;
@@ -254,13 +306,13 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
 
   // Advance cursor so the piping path in startMessageLoop won't re-fetch
   // these messages. Save the old cursor so we can roll back on error.
-  const previousCursor = lastAgentTimestamp[chatJid] || '';
-  lastAgentTimestamp[chatJid] =
+  const previousCursor = lastAgentTimestamp[queueKey] || '';
+  lastAgentTimestamp[queueKey] =
     missedMessages[missedMessages.length - 1].timestamp;
   saveState();
 
   logger.info(
-    { group: group.name, messageCount: missedMessages.length },
+    { group: group.name, messageCount: missedMessages.length, sessionContext },
     'Processing messages',
   );
 
@@ -274,7 +326,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
         { group: group.name },
         'Idle timeout, closing container stdin',
       );
-      queue.closeStdin(chatJid);
+      queue.closeStdin(queueKey);
     }, IDLE_TIMEOUT);
   };
 
@@ -282,32 +334,38 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   let hadError = false;
   let outputSentToUser = false;
 
-  const output = await runAgent(group, prompt, chatJid, async (result) => {
-    // Streaming output callback — called for each agent result
-    if (result.result) {
-      const raw =
-        typeof result.result === 'string'
-          ? result.result
-          : JSON.stringify(result.result);
-      // Strip <internal>...</internal> blocks — agent uses these for internal reasoning
-      const text = raw.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
-      logger.info({ group: group.name }, `Agent output: ${raw.length} chars`);
-      if (text) {
-        await channel.sendMessage(chatJid, text);
-        outputSentToUser = true;
+  const output = await runAgent(
+    group,
+    prompt,
+    chatJid,
+    sessionContext,
+    async (result) => {
+      // Streaming output callback — called for each agent result
+      if (result.result) {
+        const raw =
+          typeof result.result === 'string'
+            ? result.result
+            : JSON.stringify(result.result);
+        // Strip <internal>...</internal> blocks — agent uses these for internal reasoning
+        const text = raw.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
+        logger.info({ group: group.name }, `Agent output: ${raw.length} chars`);
+        if (text) {
+          await channel.sendMessage(chatJid, text);
+          outputSentToUser = true;
+        }
+        // Only reset idle timer on actual results, not session-update markers (result: null)
+        resetIdleTimer();
       }
-      // Only reset idle timer on actual results, not session-update markers (result: null)
-      resetIdleTimer();
-    }
 
-    if (result.status === 'success') {
-      queue.notifyIdle(chatJid);
-    }
+      if (result.status === 'success') {
+        queue.notifyIdle(queueKey);
+      }
 
-    if (result.status === 'error') {
-      hadError = true;
-    }
-  });
+      if (result.status === 'error') {
+        hadError = true;
+      }
+    },
+  );
 
   await channel.setTyping?.(chatJid, false);
   if (idleTimer) clearTimeout(idleTimer);
@@ -323,7 +381,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
       return true;
     }
     // Roll back cursor so retries can re-process these messages
-    lastAgentTimestamp[chatJid] = previousCursor;
+    lastAgentTimestamp[queueKey] = previousCursor;
     saveState();
     logger.warn(
       { group: group.name },
@@ -339,15 +397,31 @@ async function runAgent(
   group: RegisteredGroup,
   prompt: string,
   chatJid: string,
+  sessionContext?: string,
   onOutput?: (output: ContainerOutput) => Promise<void>,
 ): Promise<'success' | 'error'> {
   const isMain = group.isMain === true;
-  const sessionId = sessions[group.folder];
 
-  // Update tasks snapshot for container to read (filtered by group)
+  // sk is the session key: unique per isolated sub-session, or group.folder
+  // for normal groups. Used for session DB storage, IPC namespace, and
+  // GroupQueue registration so concurrent sub-sessions don't collide.
+  const sk =
+    group.isolatedSessions && sessionContext
+      ? deriveSessionKey(group, sessionContext)
+      : group.folder;
+
+  // queueKey matches what was passed to enqueueMessageCheck / registerProcess
+  const queueKey =
+    group.isolatedSessions && sessionContext
+      ? deriveQueueKey(chatJid, sessionContext)
+      : chatJid;
+
+  const sessionId = sessions[sk];
+
+  // IPC snapshots are written to the sk path so this container finds them
   const tasks = getAllTasks();
   writeTasksSnapshot(
-    group.folder,
+    sk,
     isMain,
     tasks.map((t) => ({
       id: t.id,
@@ -364,7 +438,7 @@ async function runAgent(
   // Update available groups snapshot (main group only can see all groups)
   const availableGroups = getAvailableGroups();
   writeGroupsSnapshot(
-    group.folder,
+    sk,
     isMain,
     availableGroups,
     new Set(Object.keys(registeredGroups)),
@@ -374,8 +448,8 @@ async function runAgent(
   const wrappedOnOutput = onOutput
     ? async (output: ContainerOutput) => {
         if (output.newSessionId) {
-          sessions[group.folder] = output.newSessionId;
-          setSession(group.folder, output.newSessionId);
+          sessions[sk] = output.newSessionId;
+          setSession(sk, output.newSessionId);
         }
         await onOutput(output);
       }
@@ -391,15 +465,16 @@ async function runAgent(
         chatJid,
         isMain,
         assistantName: ASSISTANT_NAME,
+        ipcKey: sk !== group.folder ? sk : undefined,
       },
       (proc, containerName) =>
-        queue.registerProcess(chatJid, proc, containerName, group.folder),
+        queue.registerProcess(queueKey, proc, containerName, sk),
       wrappedOnOutput,
     );
 
     if (output.newSessionId) {
-      sessions[group.folder] = output.newSessionId;
-      setSession(group.folder, output.newSessionId);
+      sessions[sk] = output.newSessionId;
+      setSession(sk, output.newSessionId);
     }
 
     if (output.status === 'error') {
@@ -419,8 +494,8 @@ async function runAgent(
           { group: group.name, staleSessionId: sessionId, error: output.error },
           'Stale session detected — clearing for next retry',
         );
-        delete sessions[group.folder];
-        deleteSession(group.folder);
+        delete sessions[sk];
+        deleteSession(sk);
       }
 
       logger.error(
@@ -462,18 +537,34 @@ async function startMessageLoop(): Promise<void> {
         lastTimestamp = newTimestamp;
         saveState();
 
-        // Deduplicate by group
-        const messagesByGroup = new Map<string, NewMessage[]>();
+        // Group messages by queue key.
+        // For normal groups the queue key is chatJid.
+        // For groups with isolatedSessions, messages with a sessionContext
+        // get their own queue key so each context runs in an isolated container.
+        const messagesByQueue = new Map<string, NewMessage[]>();
         for (const msg of messages) {
-          const existing = messagesByGroup.get(msg.chat_jid);
+          const group = registeredGroups[msg.chat_jid];
+          let queueKey = msg.chat_jid;
+          if (group?.isolatedSessions && msg.sessionContext) {
+            queueKey = deriveQueueKey(msg.chat_jid, msg.sessionContext);
+            subSessionRegistry.set(queueKey, {
+              chatJid: msg.chat_jid,
+              sessionContext: msg.sessionContext,
+            });
+          }
+          const existing = messagesByQueue.get(queueKey);
           if (existing) {
             existing.push(msg);
           } else {
-            messagesByGroup.set(msg.chat_jid, [msg]);
+            messagesByQueue.set(queueKey, [msg]);
           }
         }
 
-        for (const [chatJid, groupMessages] of messagesByGroup) {
+        for (const [queueKey, groupMessages] of messagesByQueue) {
+          const sub = subSessionRegistry.get(queueKey);
+          const chatJid = sub?.chatJid ?? queueKey;
+          const sessionContext = sub?.sessionContext;
+
           const group = registeredGroups[chatJid];
           if (!group) continue;
 
@@ -503,22 +594,25 @@ async function startMessageLoop(): Promise<void> {
 
           // Pull all messages since lastAgentTimestamp so non-trigger
           // context that accumulated between triggers is included.
+          // For isolated sub-sessions, filter by sessionContext so each
+          // context only sees its own message history.
           const allPending = getMessagesSince(
             chatJid,
-            getOrRecoverCursor(chatJid),
+            getOrRecoverCursor(queueKey, chatJid),
             ASSISTANT_NAME,
             MAX_MESSAGES_PER_PROMPT,
+            sessionContext,
           );
           const messagesToSend =
             allPending.length > 0 ? allPending : groupMessages;
           const formatted = formatMessages(messagesToSend, TIMEZONE);
 
-          if (queue.sendMessage(chatJid, formatted)) {
+          if (queue.sendMessage(queueKey, formatted)) {
             logger.debug(
-              { chatJid, count: messagesToSend.length },
+              { chatJid, queueKey, count: messagesToSend.length },
               'Piped messages to active container',
             );
-            lastAgentTimestamp[chatJid] =
+            lastAgentTimestamp[queueKey] =
               messagesToSend[messagesToSend.length - 1].timestamp;
             saveState();
             // Show typing indicator while the container processes the piped message
@@ -529,7 +623,7 @@ async function startMessageLoop(): Promise<void> {
               );
           } else {
             // No active container — enqueue for a new one
-            queue.enqueueMessageCheck(chatJid);
+            queue.enqueueMessageCheck(queueKey);
           }
         }
       }
@@ -548,7 +642,7 @@ function recoverPendingMessages(): void {
   for (const [chatJid, group] of Object.entries(registeredGroups)) {
     const pending = getMessagesSince(
       chatJid,
-      getOrRecoverCursor(chatJid),
+      getOrRecoverCursor(chatJid, chatJid),
       ASSISTANT_NAME,
       MAX_MESSAGES_PER_PROMPT,
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,7 @@ export interface RegisteredGroup {
   containerConfig?: ContainerConfig;
   requiresTrigger?: boolean; // Default: true for groups, false for solo chats
   isMain?: boolean; // True for the main control group (no trigger, elevated privileges)
+  isolatedSessions?: boolean; // When true, channels supply sessionContext per message to get isolated sessions
 }
 
 export interface NewMessage {
@@ -51,6 +52,7 @@ export interface NewMessage {
   timestamp: string;
   is_from_me?: boolean;
   is_bot_message?: boolean;
+  sessionContext?: string; // Opaque channel-supplied context for session isolation (thread ID, email ID, etc.)
 }
 
 export interface ScheduledTask {


### PR DESCRIPTION
## Type of Change

- [x] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

**What:** Adds the primitives for per-context session isolation within a group. A single registered group can now run independent Claude sessions for different contexts — Slack threads, email threads, per-user DMs, or any other scope the channel defines. Each context gets its own conversation history and IPC namespace while sharing the group's folder, `CLAUDE.md`, and container config.

**Why:** The current model gives every group one shared session. This breaks down for channels where messages from unrelated conversations arrive on the same JID — a Slack channel (many threads), a Gmail inbox (many email threads), or a multi-user DM bot. There was no clean way to isolate these without registering a separate group per context, which doesn't scale and requires in-memory hacks (as seen in some channel forks).

**How it works:**

Groups opt in with `isolatedSessions: true`. Channels supply an opaque `sessionContext` string on each `NewMessage` (e.g. `thread_ts`, `emailId`, `userId`). The core derives two things from that string:

- A **session key** — `${folder}_${sha256(sessionContext).slice(0,12)}` — used as the Claude session ID key in the database and as the IPC namespace directory. Always a valid folder name, deterministic across restarts.
- A **queue key** — `${chatJid}::ctx::${sessionContext}` — gives each context its own slot in `GroupQueue` so concurrent contexts run in separate containers without contention.

`getMessagesSince` is filtered by `sessionContext` so each context only sees its own message history.

For groups without `isolatedSessions` (the default), nothing changes — `sessionContext` is ignored and behaviour is identical to today.

**Changed files:**
- `src/types.ts` — `isolatedSessions?: boolean` on `RegisteredGroup`; `sessionContext?: string` on `NewMessage`
- `src/db.ts` — migration adds `session_context` column to `messages` and `isolated_sessions` to `registered_groups`; updated `storeMessage`, `getMessagesSince`, `getNewMessages`, and group accessors
- `src/container-runner.ts` — `ipcKey?` on `ContainerInput`; `buildVolumeMounts` uses it to override the IPC namespace
- `src/index.ts` — `subSessionRegistry`, `deriveSessionKey`, `deriveQueueKey`; message loop groups by queue key; `processGroupMessages` and `runAgent` thread `sessionContext` through

**How it was tested:** Full test suite passes (239 tests). TypeScript build is clean. The feature is designed to be a no-op for existing groups — no migration of live data is needed.

## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files)
- [x] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone