### PR TITLE
feat: add doc-reader container skill for Office document attachments

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -24,6 +24,9 @@ RUN apt-get update && apt-get install -y \
     libxshmfence1 \
     curl \
     git \
+    pandoc \
+    python3 \
+    python3-openpyxl \
     && rm -rf /var/lib/apt/lists/*
 
 # Set Chromium path for agent-browser

--- a/container/skills/doc-reader/SKILL.md
+++ b/container/skills/doc-reader/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: doc-reader
+description: Read Office documents and common file types sent as Telegram attachments. When a message contains [Document: filename → /workspace/group/attachments/filename], use this skill to extract the text content. Supports Word (docx), Excel (xlsx), PowerPoint (pptx), CSV, plain text, and more.
+allowed-tools: Bash(doc-reader:*)
+---
+
+# Reading Document Attachments
+
+When a user sends a document via Telegram, it is automatically downloaded and the message contains a reference like:
+
+```
+[Document: report.docx → /workspace/group/attachments/report.docx]
+```
+
+Use the `doc-reader` command to extract the text:
+
+```bash
+doc-reader /workspace/group/attachments/report.docx
+```
+
+## Supported formats
+
+| Extension | Format |
+|-----------|--------|
+| `.docx`, `.doc`, `.odt`, `.rtf` | Word-compatible documents |
+| `.xlsx`, `.xls`, `.ods` | Spreadsheets (outputs CSV per sheet) |
+| `.pptx`, `.ppt`, `.odp` | Presentations (slide text + speaker notes) |
+| `.csv`, `.txt`, `.md` | Plain text (returned as-is) |
+
+## Workflow
+
+1. Spot the attachment reference in the message: `[Document: name → path]`
+2. Run `doc-reader <path>` to get the text
+3. Read, summarize, answer questions, or act on the content
+
+## Error handling
+
+- **Unsupported type** — exit code 1 with a list of supported formats. Tell the user which types are supported.
+- **File not found** — the download may have failed. Check the original message for a "download failed" notice.
+- **Spreadsheet with no text** — the file may contain only numbers or be empty. Report what you find.

--- a/container/skills/doc-reader/doc-reader
+++ b/container/skills/doc-reader/doc-reader
@@ -1,0 +1,47 @@
+#!/bin/bash
+# doc-reader: Extract plain text from Office and common document formats
+# Usage: doc-reader <file-path>
+set -euo pipefail
+
+FILE="$1"
+
+if [ ! -f "$FILE" ]; then
+  echo "Error: file not found: $FILE" >&2
+  exit 1
+fi
+
+EXT="${FILE##*.}"
+EXT="${EXT,,}"
+
+case "$EXT" in
+  docx|doc|odt|rtf)
+    pandoc -t plain --wrap=none "$FILE"
+    ;;
+  pptx|ppt|odp)
+    # pandoc extracts slide text and speaker notes
+    pandoc -t plain --wrap=none "$FILE"
+    ;;
+  xlsx|xls|ods)
+    python3 - "$FILE" <<'PYEOF'
+import sys
+import openpyxl
+
+path = sys.argv[1]
+wb = openpyxl.load_workbook(path, read_only=True, data_only=True)
+for sheet in wb.worksheets:
+    print(f"=== {sheet.title} ===")
+    for row in sheet.iter_rows(values_only=True):
+        cells = [str(c) if c is not None else "" for c in row]
+        if any(c.strip() for c in cells):
+            print(",".join(cells))
+PYEOF
+    ;;
+  csv|txt|md|text)
+    cat "$FILE"
+    ;;
+  *)
+    echo "Unsupported file type: .$EXT" >&2
+    echo "Supported: docx, doc, odt, rtf, pptx, ppt, odp, xlsx, xls, ods, csv, txt, md" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## What

Adds a `doc-reader` container skill and the required system packages (`pandoc`, `python3`, `python3-openpyxl`) to the agent container image.

## Why

Pairs with qwibitai/nanoclaw-telegram#138, which downloads Word/Excel/PowerPoint attachments sent via Telegram to the group's `attachments/` folder. This PR gives the agent the tools to read those files.

## How it works

When the Telegram channel downloads a file, the message content becomes:
```
[Document: report.docx → /workspace/group/attachments/report.docx]
```

The agent runs:
```bash
doc-reader /workspace/group/attachments/report.docx
```

The script dispatches by file extension:
- **docx, odt, rtf, pptx, odp** → `pandoc -t plain`
- **xlsx, xls, ods** → `python3` + `openpyxl` (CSV output per sheet)
- **csv, txt, md** → `cat`

## Files changed

- `container/Dockerfile` — adds `pandoc`, `python3`, `python3-openpyxl`
- `container/skills/doc-reader/doc-reader` — conversion script
- `container/skills/doc-reader/SKILL.md` — agent instructions and format reference

## How it was tested

Tested locally with docx, xlsx, and pptx files in a running container.

## Type of change

- [x] **Skill** — adds a new container skill in `container/skills/`