### PR TITLE
feat: send working ack for piped messages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -522,9 +522,15 @@ async function startMessageLoop(): Promise<void> {
               messagesToSend[messagesToSend.length - 1].timestamp;
             saveState();
             channel
-              .sendMessage(chatJid, `:hourglass_flowing_sand: _Working on it..._`)
+              .sendMessage(
+                chatJid,
+                `:hourglass_flowing_sand: _Working on it..._`,
+              )
               .catch((err) =>
-                logger.debug({ chatJid, err }, 'Failed to send ack for piped message'),
+                logger.debug(
+                  { chatJid, err },
+                  'Failed to send ack for piped message',
+                ),
               );
             // Show typing indicator while the container processes the piped message
             channel

--- a/src/index.ts
+++ b/src/index.ts
@@ -521,6 +521,11 @@ async function startMessageLoop(): Promise<void> {
             lastAgentTimestamp[chatJid] =
               messagesToSend[messagesToSend.length - 1].timestamp;
             saveState();
+            channel
+              .sendMessage(chatJid, `:hourglass_flowing_sand: _Working on it..._`)
+              .catch((err) =>
+                logger.debug({ chatJid, err }, 'Failed to send ack for piped message'),
+              );
             // Show typing indicator while the container processes the piped message
             channel
               .setTyping?.(chatJid, true)


### PR DESCRIPTION
## Summary
- send `:hourglass_flowing_sand: _Working on it..._` when messages are piped to an already-active container
- keep behavior consistent with the new-container path where users already receive an explicit acknowledgement
- preserve existing typing indicator behavior

## Test plan
- [x] `npm test`
- [x] verify no behavior changes outside the `queue.sendMessage()` success path


Made with [Cursor](https://cursor.com)