### PR TITLE
fix: include Homebrew and node paths in service PATH

### DIFF
--- a/setup/service.ts
+++ b/setup/service.ts
@@ -101,7 +101,7 @@ function setupLaunchd(
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/usr/local/bin:/usr/bin:/bin:${homeDir}/.local/bin</string>
+        <string>${path.dirname(nodePath)}:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:${homeDir}/.local/bin</string>
         <key>HOME</key>
         <string>${homeDir}</string>
     </dict>
@@ -245,7 +245,7 @@ Restart=always
 RestartSec=5
 KillMode=process
 Environment=HOME=${homeDir}
-Environment=PATH=/usr/local/bin:/usr/bin:/bin:${homeDir}/.local/bin
+Environment=PATH=${path.dirname(nodePath)}:/usr/local/bin:/usr/bin:/bin:${homeDir}/.local/bin
 StandardOutput=append:${projectRoot}/logs/nanoclaw.log
 StandardError=append:${projectRoot}/logs/nanoclaw.error.log
 


### PR DESCRIPTION
## Summary

- The launchd plist and systemd unit generated by `setup/service.ts` use a hardcoded PATH missing `/opt/homebrew/bin` (Apple Silicon Homebrew) and the node binary's directory
- On Apple Silicon Macs, this causes the service to crash on boot because `container` (Apple Container) and `node` binaries aren't found
- Adds `path.dirname(nodePath)` and Homebrew paths to the generated PATH

## Test plan

- [ ] Run `/setup` step 7 (service) on Apple Silicon Mac with Homebrew-installed node
- [ ] Verify generated plist PATH includes `/opt/homebrew/bin` and node's directory
- [ ] Verify service starts without "command not found" errors
- [ ] Verify on Linux that systemd unit includes node's directory