### PR TITLE
fix: require CREDENTIAL_PROXY_HOST for Apple Container networking

### DIFF
--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -32,11 +32,17 @@ function detectHostGateway(): string {
 
 /**
  * Address the credential proxy binds to.
- * Binds to the bridge interface IP so only Apple Container VMs can reach it.
- * Never 0.0.0.0 — that would expose credentials to the local network.
+ * Must be set via CREDENTIAL_PROXY_HOST in .env — there is no safe default
+ * for Apple Container because bridge100 only exists while containers run,
+ * but the proxy must start before any container.
+ * The /convert-to-apple-container skill sets this during setup.
  */
-export const PROXY_BIND_HOST =
-  process.env.CREDENTIAL_PROXY_HOST || CONTAINER_HOST_GATEWAY;
+export const PROXY_BIND_HOST = process.env.CREDENTIAL_PROXY_HOST;
+if (!PROXY_BIND_HOST) {
+  throw new Error(
+    'CREDENTIAL_PROXY_HOST is not set in .env. Run /convert-to-apple-container to configure.',
+  );
+}
 
 /** CLI args needed for the container to resolve the host gateway. */
 export function hostGatewayArgs(): string[] {


### PR DESCRIPTION
## Summary
- Apple Container's bridge100 interface only exists while containers are running, but the credential proxy must start before any container
- Binding to the bridge IP (`CONTAINER_HOST_GATEWAY`) fails with `EADDRNOTAVAIL` on cold boot and first-time setup — service crash-loops
- Instead of silently falling back to `0.0.0.0` (exposes credentials to LAN), fail immediately with a clear error pointing to `/convert-to-apple-container`
- The skill will be updated (separate PR against main) to guide users through setting `CREDENTIAL_PROXY_HOST` with network security awareness

## Test plan
- [x] Cold boot: service fails fast with actionable error instead of crash-looping
- [x] With `CREDENTIAL_PROXY_HOST=0.0.0.0` in `.env`: service starts and containers can reach proxy
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)