### PR TITLE
docs: breaking change entries for Apple Container and pino removal

### DIFF
--- a/.claude/skills/convert-to-apple-container/SKILL.md
+++ b/.claude/skills/convert-to-apple-container/SKILL.md
@@ -45,7 +45,7 @@ Apple Container requires macOS. It does not work on Linux.
 grep "CONTAINER_RUNTIME_BIN" src/container-runtime.ts
 ```
 
-If it already shows `'container'`, the runtime is already Apple Container. Skip to Phase 3.
+If it already shows `'container'`, the runtime is already Apple Container. Skip to Phase 4.
 
 ## Phase 2: Apply Code Changes
 
@@ -86,7 +86,44 @@ npm run build
 
 All tests must pass and build must be clean before proceeding.
 
-## Phase 3: Verify
+## Phase 3: Credential proxy network binding
+
+Apple Container uses a bridge network (bridge100) that only exists while containers are running. The credential proxy must start before any container, so it cannot bind to the bridge IP. It must bind to `0.0.0.0`, which exposes port 3001 on all network interfaces — anyone on your local network could route API requests through the proxy using your credentials.
+
+Use AskUserQuestion to ask the user:
+
+**"The credential proxy needs to bind to all interfaces (0.0.0.0). Is this Mac on a trusted private network?"**
+
+Options:
+1. **Yes, private/home network** — description: "No firewall rule needed."
+2. **No, shared/public network** — description: "Add a macOS firewall rule to block external access to port 3001."
+
+For both options, add `CREDENTIAL_PROXY_HOST=0.0.0.0` to `.env`:
+
+```bash
+grep -q 'CREDENTIAL_PROXY_HOST' .env 2>/dev/null || echo 'CREDENTIAL_PROXY_HOST=0.0.0.0' >> .env
+```
+
+If they chose the public network option, set up and persist the firewall rule:
+
+```bash
+echo "block in on en0 proto tcp to any port 3001" | sudo pfctl -ef -
+```
+
+```bash
+grep -q 'nanoclaw proxy' /etc/pf.conf 2>/dev/null || echo '# nanoclaw proxy — block LAN access to credential proxy
+block in on en0 proto tcp to any port 3001' | sudo tee -a /etc/pf.conf > /dev/null
+```
+
+Verify the rule is working:
+
+```bash
+curl -sf http://$(ipconfig getifaddr en0):3001 && echo "EXPOSED — rule not working" || echo "BLOCKED — rule active"
+```
+
+If the verification shows "EXPOSED", warn the user and retry. If "BLOCKED", confirm success and continue.
+
+## Phase 4: Verify
 
 ### Ensure Apple Container runtime is running
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to NanoClaw will be documented in this file.
 
 For detailed release notes, see the [full changelog on the documentation site](https://docs.nanoclaw.dev/changelog).
 
+## [1.2.36] - 2026-03-26
+
+- [BREAKING] Replaced pino logger with built-in logger. WhatsApp users must re-merge the WhatsApp fork to pick up the Baileys logger compatibility fix: `git fetch whatsapp main && git merge whatsapp/main`. If the `whatsapp` remote is not configured: `git remote add whatsapp https://github.com/qwibitai/nanoclaw-whatsapp.git`.
+
 ## [1.2.35] - 2026-03-26
 
-- [BREAKING] OneCLI Agent Vault replaces the built-in credential proxy. Existing `.env` credentials must be migrated to the vault. Run `/init-onecli` to install OneCLI and migrate credentials.
+- [BREAKING] OneCLI Agent Vault replaces the built-in credential proxy. Check your runtime: `grep CONTAINER_RUNTIME_BIN src/container-runtime.ts` — if it shows `'container'` you are on Apple Container, if `'docker'` you are on Docker. Docker users: run `/init-onecli` to install OneCLI and migrate `.env` credentials to the vault. Apple Container users: re-merge the skill branch (`git fetch upstream skill/apple-container && git merge upstream/skill/apple-container`) then run `/convert-to-apple-container` and follow all instructions (configures credential proxy networking) — do NOT run `/init-onecli`, it requires Docker.
 
 ## [1.2.21] - 2026-03-22
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -20,3 +20,7 @@ Thanks to everyone who has contributed to NanoClaw!
 - [leonalfredbot-ship-it](https://github.com/leonalfredbot-ship-it) — Alfred-the-buttler
 - [moktamd](https://github.com/moktamd)
 - [gurixs-carson](https://github.com/gurixs-carson)
+- [MrBlaise](https://github.com/MrBlaise) — Balázs Rostás
+- [lbsnrs](https://github.com/lbsnrs) — Andreas Liebschner
+- [spencer-whitman](https://github.com/spencer-whitman)
+- [lazure-ocean](https://github.com/lazure-ocean) — Cyril Ionov


### PR DESCRIPTION
## Summary
- Update OneCLI breaking change entry to note that Apple Container users should run `/convert-to-apple-container` instead of `/init-onecli`
- Add new breaking change for pino logger removal — WhatsApp users must re-merge `whatsapp/main` to pick up the Baileys logger compatibility fix
- Add Phase 3 (credential proxy network binding) to `/convert-to-apple-container` skill — asks if user is on private/public network, sets `CREDENTIAL_PROXY_HOST=0.0.0.0`, and configures + persists a macOS `pf` firewall rule on untrusted networks
- Add 4 contributors who independently identified and submitted fixes for the Apple Container networking issues (#887, #943, #1109, #1323)

Companion to #1609 (the code fix on `skill/apple-container`).

## Test plan
- [x] CHANGELOG entries follow `[BREAKING]` format for `/update-nanoclaw` detection
- [x] SKILL.md Phase 3 added with correct phase numbering

🤖 Generated with [Claude Code](https://claude.com/claude-code)