### PR TITLE
fix: resolve project root from import.meta.url instead of process.cwd()

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ import os from 'os';
 import path from 'path';
 
 import { readEnvFile } from './env.js';
+import { PROJECT_ROOT } from './paths.js';
 import { isValidTimezone } from './timezone.js';
 
 // Read config values from .env (falls back to process.env).
@@ -21,7 +22,6 @@ export const POLL_INTERVAL = 2000;
 export const SCHEDULER_POLL_INTERVAL = 60000;
 
 // Absolute paths needed for container mounts
-const PROJECT_ROOT = process.cwd();
 const HOME_DIR = process.env.HOME || os.homedir();
 
 // Mount security: allowlist stored OUTSIDE project root, never mounted into containers

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -4,6 +4,7 @@
  */
 import { ChildProcess, spawn } from 'child_process';
 import fs from 'fs';
+import { fileURLToPath } from 'node:url';
 import path from 'path';
 
 import {
@@ -29,6 +30,19 @@ import { validateAdditionalMounts } from './mount-security.js';
 import { RegisteredGroup } from './types.js';
 
 const onecli = new OneCLI({ url: ONECLI_URL });
+
+/**
+ * Resolve the project root from the source file location rather than
+ * process.cwd(). This is reliable regardless of the working directory
+ * the process was started from (e.g., systemd, cron, wrapper scripts).
+ */
+function resolveProjectRoot(moduleUrl = import.meta.url): string {
+  const modulePath = fileURLToPath(moduleUrl);
+  // src/container-runner.ts -> project root is one level up
+  return path.resolve(path.dirname(modulePath), '..');
+}
+
+const PROJECT_ROOT = resolveProjectRoot();
 
 // Sentinel markers for robust output parsing (must match agent-runner)
 const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
@@ -63,7 +77,6 @@ function buildVolumeMounts(
   isMain: boolean,
 ): VolumeMount[] {
   const mounts: VolumeMount[] = [];
-  const projectRoot = process.cwd();
   const groupDir = resolveGroupFolderPath(group.folder);
 
   if (isMain) {
@@ -73,14 +86,14 @@ function buildVolumeMounts(
     // (src/, dist/, package.json, etc.) which would bypass the sandbox
     // entirely on next restart.
     mounts.push({
-      hostPath: projectRoot,
+      hostPath: PROJECT_ROOT,
       containerPath: '/workspace/project',
       readonly: true,
     });
 
     // Shadow .env so the agent cannot read secrets from the mounted project root.
     // Credentials are injected by the OneCLI gateway, never exposed to containers.
-    const envFile = path.join(projectRoot, '.env');
+    const envFile = path.join(PROJECT_ROOT, '.env');
     if (fs.existsSync(envFile)) {
       mounts.push({
         hostPath: '/dev/null',
@@ -91,7 +104,7 @@ function buildVolumeMounts(
 
     // Main gets writable access to the store (SQLite DB) so it can
     // query and write to the database directly.
-    const storeDir = path.join(projectRoot, 'store');
+    const storeDir = path.join(PROJECT_ROOT, 'store');
     mounts.push({
       hostPath: storeDir,
       containerPath: '/workspace/project/store',
@@ -158,7 +171,7 @@ function buildVolumeMounts(
   }
 
   // Sync skills from container/skills/ into each group's .claude/skills/
-  const skillsSrc = path.join(process.cwd(), 'container', 'skills');
+  const skillsSrc = path.join(PROJECT_ROOT, 'container', 'skills');
   const skillsDst = path.join(groupSessionsDir, 'skills');
   if (fs.existsSync(skillsSrc)) {
     for (const skillDir of fs.readdirSync(skillsSrc)) {
@@ -190,7 +203,7 @@ function buildVolumeMounts(
   // can customize it (add tools, change behavior) without affecting other
   // groups. Recompiled on container startup via entrypoint.sh.
   const agentRunnerSrc = path.join(
-    projectRoot,
+    PROJECT_ROOT,
     'container',
     'agent-runner',
     'src',

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -4,7 +4,6 @@
  */
 import { ChildProcess, spawn } from 'child_process';
 import fs from 'fs';
-import { fileURLToPath } from 'node:url';
 import path from 'path';
 
 import {
@@ -19,6 +18,7 @@ import {
 } from './config.js';
 import { resolveGroupFolderPath, resolveGroupIpcPath } from './group-folder.js';
 import { logger } from './logger.js';
+import { PROJECT_ROOT } from './paths.js';
 import {
   CONTAINER_RUNTIME_BIN,
   hostGatewayArgs,
@@ -30,19 +30,6 @@ import { validateAdditionalMounts } from './mount-security.js';
 import { RegisteredGroup } from './types.js';
 
 const onecli = new OneCLI({ url: ONECLI_URL });
-
-/**
- * Resolve the project root from the source file location rather than
- * process.cwd(). This is reliable regardless of the working directory
- * the process was started from (e.g., systemd, cron, wrapper scripts).
- */
-function resolveProjectRoot(moduleUrl = import.meta.url): string {
-  const modulePath = fileURLToPath(moduleUrl);
-  // src/container-runner.ts -> project root is one level up
-  return path.resolve(path.dirname(modulePath), '..');
-}
-
-const PROJECT_ROOT = resolveProjectRoot();
 
 // Sentinel markers for robust output parsing (must match agent-runner)
 const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';

--- a/src/db-migration.test.ts
+++ b/src/db-migration.test.ts
@@ -6,14 +6,14 @@ import { describe, expect, it, vi } from 'vitest';
 
 describe('database migrations', () => {
   it('defaults Telegram backfill chats to direct messages', async () => {
-    const repoRoot = process.cwd();
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-db-test-'));
+    const storeDir = path.join(tempDir, 'store');
+    const dataDir = path.join(tempDir, 'data');
+    fs.mkdirSync(storeDir, { recursive: true });
+    fs.mkdirSync(dataDir, { recursive: true });
 
     try {
-      process.chdir(tempDir);
-      fs.mkdirSync(path.join(tempDir, 'store'), { recursive: true });
-
-      const dbPath = path.join(tempDir, 'store', 'messages.db');
+      const dbPath = path.join(storeDir, 'messages.db');
       const legacyDb = new Database(dbPath);
       legacyDb.exec(`
         CREATE TABLE chats (
@@ -40,6 +40,16 @@ describe('database migrations', () => {
       legacyDb.close();
 
       vi.resetModules();
+
+      // Point config at the temp directory instead of relying on process.cwd().
+      // This matches the project-wide migration from process.cwd() to
+      // import.meta.url-based path resolution (see src/paths.ts).
+      vi.doMock('./config.js', () => ({
+        ASSISTANT_NAME: 'Andy',
+        DATA_DIR: dataDir,
+        STORE_DIR: storeDir,
+      }));
+
       const { initDatabase, getAllChats, _closeDatabase } =
         await import('./db.js');
 
@@ -61,7 +71,7 @@ describe('database migrations', () => {
 
       _closeDatabase();
     } finally {
-      process.chdir(repoRoot);
+      fs.rmSync(tempDir, { recursive: true, force: true });
     }
   });
 });

--- a/src/db.ts
+++ b/src/db.ts
@@ -149,15 +149,11 @@ function createSchema(database: Database.Database): void {
 
   // Add reply context columns if they don't exist (migration for existing DBs)
   try {
-    database.exec(
-      `ALTER TABLE messages ADD COLUMN reply_to_message_id TEXT`,
-    );
+    database.exec(`ALTER TABLE messages ADD COLUMN reply_to_message_id TEXT`);
     database.exec(
       `ALTER TABLE messages ADD COLUMN reply_to_message_content TEXT`,
     );
-    database.exec(
-      `ALTER TABLE messages ADD COLUMN reply_to_sender_name TEXT`,
-    );
+    database.exec(`ALTER TABLE messages ADD COLUMN reply_to_sender_name TEXT`);
   } catch {
     /* columns already exist */
   }

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { logger } from './logger.js';
+import { PROJECT_ROOT } from './paths.js';
 
 /**
  * Parse the .env file and return values for the requested keys.
@@ -9,7 +10,7 @@ import { logger } from './logger.js';
  * so they don't leak to child processes.
  */
 export function readEnvFile(keys: string[]): Record<string, string> {
-  const envFile = path.join(process.cwd(), '.env');
+  const envFile = path.join(PROJECT_ROOT, '.env');
   let content: string;
   try {
     content = fs.readFileSync(envFile, 'utf-8');

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,0 +1,21 @@
+/**
+ * Project root resolution.
+ *
+ * Derives the project root from the source file location (`import.meta.url`)
+ * rather than `process.cwd()`. This is reliable regardless of the working
+ * directory the process was started from (e.g., systemd, cron, wrapper
+ * scripts).
+ *
+ * Every module that needs project-relative paths should import PROJECT_ROOT
+ * from here instead of calling process.cwd().
+ */
+import { fileURLToPath } from 'node:url';
+import path from 'path';
+
+export function resolveProjectRoot(moduleUrl: string): string {
+  const modulePath = fileURLToPath(moduleUrl);
+  // src/paths.ts -> project root is one level up from src/
+  return path.resolve(path.dirname(modulePath), '..');
+}
+
+export const PROJECT_ROOT = resolveProjectRoot(import.meta.url);


### PR DESCRIPTION
## Summary

- Replace `process.cwd()` with `import.meta.url`-based resolution for the project root path across **all three modules** that derive paths from it: `container-runner.ts`, `config.ts`, and `env.ts`
- `process.cwd()` is fragile because it depends on the working directory at process startup, which breaks when the service is launched from a different directory (e.g., systemd services, cron jobs, or wrapper scripts that `cd` elsewhere before launching)
- `import.meta.url` always resolves relative to the source file's location, making it reliable regardless of how the process is started

## Changes

- **`src/paths.ts` (new)** — Shared utility that exports `resolveProjectRoot()` and a `PROJECT_ROOT` constant derived from `import.meta.url`. Zero dependencies on other project modules, so it can be imported anywhere without circular import risk.
- **`src/config.ts`** — Replaces `const PROJECT_ROOT = process.cwd()` with import from `paths.ts`. `STORE_DIR`, `GROUPS_DIR`, and `DATA_DIR` now all derive from the stable root.
- **`src/env.ts`** — Replaces `path.join(process.cwd(), '.env')` with `path.join(PROJECT_ROOT, '.env')`.
- **`src/container-runner.ts`** — Removes the local `resolveProjectRoot()` function (originally added in the first commit) and imports `PROJECT_ROOT` from `paths.ts` instead.
- **`src/db-migration.test.ts`** — Updated to mock `config.js` instead of using `process.chdir()` to manipulate path resolution. The old approach relied on the `process.cwd()` behavior that this PR eliminates.

## Test plan

- [x] `npm run build` compiles without errors
- [x] `npm test` — all 246 tests pass (18 test files)
- [x] Verified no remaining `process.cwd()` calls for project root derivation in config, env, or container-runner
- [x] No circular import risk — `paths.ts` depends only on `node:url` and `path`

Generated with [Claude Code](https://claude.com/claude-code)