### PR TITLE
simplify: replace hardcoded allowedTools with configurable registry

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -24,6 +24,8 @@ import {
 } from '@anthropic-ai/claude-agent-sdk';
 import { fileURLToPath } from 'url';
 
+import { loadRegistry, computeAllowedTools } from './tool-registry.js';
+
 interface ContainerInput {
   prompt: string;
   sessionId?: string;
@@ -449,27 +451,11 @@ async function runQuery(
             append: globalClaudeMd,
           }
         : undefined,
-      allowedTools: [
-        'Bash',
-        'Read',
-        'Write',
-        'Edit',
-        'Glob',
-        'Grep',
-        'WebSearch',
-        'WebFetch',
-        'Task',
-        'TaskOutput',
-        'TaskStop',
-        'TeamCreate',
-        'TeamDelete',
-        'SendMessage',
-        'TodoWrite',
-        'ToolSearch',
-        'Skill',
-        'NotebookEdit',
-        'mcp__nanoclaw__*',
-      ],
+      allowedTools: computeAllowedTools(
+        loadRegistry(containerInput.isMain, containerInput.groupFolder),
+        containerInput.isMain,
+        containerInput.groupFolder,
+      ),
       env: sdkEnv,
       permissionMode: 'bypassPermissions',
       allowDangerouslySkipPermissions: true,

--- a/container/agent-runner/src/tool-registry.test.ts
+++ b/container/agent-runner/src/tool-registry.test.ts
@@ -1,0 +1,384 @@
+/**
+ * Tool Registry tests
+ *
+ * Verifies:
+ * - loadRegistry returns defaults when no env var is set
+ * - loadRegistry parses NANOCLAW_TOOL_REGISTRY env var correctly
+ * - computeAllowedTools returns exact current defaults with no config
+ * - computeAllowedTools filters by mainOnly
+ * - computeAllowedTools filters by groups array
+ * - computeAllowedTools respects enabled: false
+ * - isToolAllowed returns correct results
+ * - Extra tools from config are added to defaults
+ * - MCP server prefixes are included
+ * - Invalid/malformed env var falls back to defaults
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  loadRegistry,
+  computeAllowedTools,
+  isToolAllowed,
+  type ToolRegistryConfig,
+} from './tool-registry.js';
+
+/**
+ * The exact allowedTools array from the original hardcoded index.ts.
+ * loadRegistry() with no config must produce this exact list.
+ */
+const ORIGINAL_ALLOWED_TOOLS = [
+  'Bash',
+  'Read', 'Write', 'Edit', 'Glob', 'Grep',
+  'WebSearch', 'WebFetch',
+  'Task', 'TaskOutput', 'TaskStop',
+  'TeamCreate', 'TeamDelete', 'SendMessage',
+  'TodoWrite', 'ToolSearch', 'Skill',
+  'NotebookEdit',
+  'mcp__nanoclaw__*',
+];
+
+describe('loadRegistry', () => {
+  afterEach(() => {
+    delete process.env.NANOCLAW_TOOL_REGISTRY;
+  });
+
+  it('returns defaults when no env var is set', () => {
+    delete process.env.NANOCLAW_TOOL_REGISTRY;
+    const registry = loadRegistry(false, 'test-group');
+
+    expect(registry.version).toBe(1);
+    expect(registry.defaults.builtins).toEqual([
+      'Bash',
+      'Read', 'Write', 'Edit', 'Glob', 'Grep',
+      'WebSearch', 'WebFetch',
+      'Task', 'TaskOutput', 'TaskStop',
+      'TeamCreate', 'TeamDelete', 'SendMessage',
+      'TodoWrite', 'ToolSearch', 'Skill',
+      'NotebookEdit',
+    ]);
+    expect(registry.defaults.mcpServers).toEqual([
+      'mcp__nanoclaw__*',
+    ]);
+    expect(registry.tools).toEqual([]);
+  });
+
+  it('parses env var JSON correctly', () => {
+    const config: ToolRegistryConfig = {
+      version: 1,
+      defaults: {
+        builtins: ['Bash', 'Read'],
+        mcpServers: ['mcp__nanoclaw__*'],
+      },
+      tools: [
+        { type: 'builtin', name: 'Write', enabled: true },
+        { type: 'mcp', name: 'mcp__custom__*', enabled: true, mainOnly: true },
+      ],
+    };
+    process.env.NANOCLAW_TOOL_REGISTRY = JSON.stringify(config);
+
+    const registry = loadRegistry(false, 'test-group');
+
+    expect(registry.version).toBe(1);
+    expect(registry.defaults.builtins).toEqual(['Bash', 'Read']);
+    expect(registry.defaults.mcpServers).toEqual(['mcp__nanoclaw__*']);
+    expect(registry.tools).toHaveLength(2);
+    expect(registry.tools[0].name).toBe('Write');
+    expect(registry.tools[1].mainOnly).toBe(true);
+  });
+
+  it('falls back to defaults on invalid JSON', () => {
+    process.env.NANOCLAW_TOOL_REGISTRY = '{not valid json';
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const registry = loadRegistry(false, 'test-group');
+
+    expect(registry.version).toBe(1);
+    expect(registry.defaults.builtins).toContain('Bash');
+    expect(registry.tools).toEqual([]);
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('falls back to defaults on unsupported version', () => {
+    const config = {
+      version: 99,
+      defaults: { builtins: ['Bash'], mcpServers: [] },
+      tools: [],
+    };
+    process.env.NANOCLAW_TOOL_REGISTRY = JSON.stringify(config);
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const registry = loadRegistry(false, 'test-group');
+
+    expect(registry.version).toBe(1);
+    expect(registry.defaults.builtins).toContain('Bash');
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('falls back to defaults when defaults structure is invalid', () => {
+    const config = {
+      version: 1,
+      defaults: { builtins: 'not-an-array', mcpServers: [] },
+      tools: [],
+    };
+    process.env.NANOCLAW_TOOL_REGISTRY = JSON.stringify(config);
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const registry = loadRegistry(false, 'test-group');
+
+    expect(registry.defaults.builtins).toContain('Bash');
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('falls back to defaults when tools is not an array', () => {
+    const config = {
+      version: 1,
+      defaults: { builtins: ['Bash'], mcpServers: [] },
+      tools: 'not-an-array',
+    };
+    process.env.NANOCLAW_TOOL_REGISTRY = JSON.stringify(config);
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const registry = loadRegistry(false, 'test-group');
+
+    expect(registry.defaults.builtins).toContain('Bash');
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('returns fresh copies on each call (no shared mutation)', () => {
+    delete process.env.NANOCLAW_TOOL_REGISTRY;
+
+    const a = loadRegistry(false, 'group-a');
+    const b = loadRegistry(false, 'group-b');
+
+    a.defaults.builtins.push('ExtraTool');
+    expect(b.defaults.builtins).not.toContain('ExtraTool');
+  });
+});
+
+describe('computeAllowedTools', () => {
+  it('returns exact current defaults with no config (backwards compatibility)', () => {
+    delete process.env.NANOCLAW_TOOL_REGISTRY;
+    const registry = loadRegistry(false, 'test-group');
+    const tools = computeAllowedTools(registry, false, 'test-group');
+
+    expect(tools.sort()).toEqual([...ORIGINAL_ALLOWED_TOOLS].sort());
+  });
+
+  it('includes MCP server prefixes in output', () => {
+    const registry = loadRegistry(false, 'test-group');
+    const tools = computeAllowedTools(registry, false, 'test-group');
+
+    expect(tools).toContain('mcp__nanoclaw__*');
+  });
+
+  it('adds extra enabled tools to defaults', () => {
+    const registry: ToolRegistryConfig = {
+      version: 1,
+      defaults: {
+        builtins: ['Bash', 'Read'],
+        mcpServers: ['mcp__nanoclaw__*'],
+      },
+      tools: [
+        { type: 'custom', name: 'MyCustomTool', enabled: true },
+        { type: 'mcp', name: 'mcp__extra__*', enabled: true },
+      ],
+    };
+
+    const tools = computeAllowedTools(registry, false, 'test-group');
+
+    expect(tools).toContain('Bash');
+    expect(tools).toContain('Read');
+    expect(tools).toContain('mcp__nanoclaw__*');
+    expect(tools).toContain('MyCustomTool');
+    expect(tools).toContain('mcp__extra__*');
+  });
+
+  it('does not add disabled tools', () => {
+    const registry: ToolRegistryConfig = {
+      version: 1,
+      defaults: {
+        builtins: ['Bash'],
+        mcpServers: [],
+      },
+      tools: [
+        { type: 'builtin', name: 'Write', enabled: false },
+        { type: 'custom', name: 'Allowed', enabled: true },
+      ],
+    };
+
+    const tools = computeAllowedTools(registry, false, 'test-group');
+
+    expect(tools).toContain('Bash');
+    expect(tools).toContain('Allowed');
+    expect(tools).not.toContain('Write');
+  });
+
+  it('filters by mainOnly: main=true gets the tool', () => {
+    const registry: ToolRegistryConfig = {
+      version: 1,
+      defaults: { builtins: ['Bash'], mcpServers: [] },
+      tools: [
+        { type: 'builtin', name: 'MainOnlyTool', enabled: true, mainOnly: true },
+      ],
+    };
+
+    const tools = computeAllowedTools(registry, true, 'main');
+
+    expect(tools).toContain('MainOnlyTool');
+  });
+
+  it('filters by mainOnly: main=false does NOT get the tool', () => {
+    const registry: ToolRegistryConfig = {
+      version: 1,
+      defaults: { builtins: ['Bash'], mcpServers: [] },
+      tools: [
+        { type: 'builtin', name: 'MainOnlyTool', enabled: true, mainOnly: true },
+      ],
+    };
+
+    const tools = computeAllowedTools(registry, false, 'other-group');
+
+    expect(tools).not.toContain('MainOnlyTool');
+  });
+
+  it('filters by groups array: included group gets the tool', () => {
+    const registry: ToolRegistryConfig = {
+      version: 1,
+      defaults: { builtins: ['Bash'], mcpServers: [] },
+      tools: [
+        { type: 'skill', name: 'GroupSpecificTool', enabled: true, groups: ['alpha', 'beta'] },
+      ],
+    };
+
+    const toolsAlpha = computeAllowedTools(registry, false, 'alpha');
+    const toolsBeta = computeAllowedTools(registry, false, 'beta');
+
+    expect(toolsAlpha).toContain('GroupSpecificTool');
+    expect(toolsBeta).toContain('GroupSpecificTool');
+  });
+
+  it('filters by groups array: excluded group does NOT get the tool', () => {
+    const registry: ToolRegistryConfig = {
+      version: 1,
+      defaults: { builtins: ['Bash'], mcpServers: [] },
+      tools: [
+        { type: 'skill', name: 'GroupSpecificTool', enabled: true, groups: ['alpha', 'beta'] },
+      ],
+    };
+
+    const tools = computeAllowedTools(registry, false, 'gamma');
+
+    expect(tools).not.toContain('GroupSpecificTool');
+  });
+
+  it('null/empty groups array means all groups get the tool', () => {
+    const registry: ToolRegistryConfig = {
+      version: 1,
+      defaults: { builtins: ['Bash'], mcpServers: [] },
+      tools: [
+        { type: 'custom', name: 'EveryoneTool', enabled: true, groups: [] },
+        { type: 'custom', name: 'NoGroupsField', enabled: true },
+      ],
+    };
+
+    const tools = computeAllowedTools(registry, false, 'any-group');
+
+    expect(tools).toContain('EveryoneTool');
+    expect(tools).toContain('NoGroupsField');
+  });
+
+  it('mainOnly + groups: both filters must pass', () => {
+    const registry: ToolRegistryConfig = {
+      version: 1,
+      defaults: { builtins: ['Bash'], mcpServers: [] },
+      tools: [
+        { type: 'custom', name: 'RestrictedTool', enabled: true, mainOnly: true, groups: ['main'] },
+      ],
+    };
+
+    // isMain=true AND groupFolder='main' -> passes
+    expect(computeAllowedTools(registry, true, 'main')).toContain('RestrictedTool');
+
+    // isMain=true BUT groupFolder='other' -> fails groups check
+    expect(computeAllowedTools(registry, true, 'other')).not.toContain('RestrictedTool');
+
+    // isMain=false AND groupFolder='main' -> fails mainOnly check
+    expect(computeAllowedTools(registry, false, 'main')).not.toContain('RestrictedTool');
+  });
+
+  it('deduplicates tools that appear in both defaults and tools array', () => {
+    const registry: ToolRegistryConfig = {
+      version: 1,
+      defaults: { builtins: ['Bash', 'Read'], mcpServers: ['mcp__nanoclaw__*'] },
+      tools: [
+        { type: 'builtin', name: 'Bash', enabled: true },
+        { type: 'mcp', name: 'mcp__nanoclaw__*', enabled: true },
+      ],
+    };
+
+    const tools = computeAllowedTools(registry, false, 'test-group');
+    const bashCount = tools.filter(t => t === 'Bash').length;
+    const mcpCount = tools.filter(t => t === 'mcp__nanoclaw__*').length;
+
+    expect(bashCount).toBe(1);
+    expect(mcpCount).toBe(1);
+  });
+});
+
+describe('isToolAllowed', () => {
+  it('returns true for tools in the computed allowed list', () => {
+    const registry = loadRegistry(false, 'test-group');
+
+    expect(isToolAllowed(registry, 'Bash', false, 'test-group')).toBe(true);
+    expect(isToolAllowed(registry, 'Read', false, 'test-group')).toBe(true);
+    expect(isToolAllowed(registry, 'mcp__nanoclaw__*', false, 'test-group')).toBe(true);
+  });
+
+  it('returns false for tools NOT in the computed allowed list', () => {
+    const registry = loadRegistry(false, 'test-group');
+
+    expect(isToolAllowed(registry, 'NonExistentTool', false, 'test-group')).toBe(false);
+    expect(isToolAllowed(registry, 'mcp__unknown__*', false, 'test-group')).toBe(false);
+  });
+
+  it('respects mainOnly filtering', () => {
+    const registry: ToolRegistryConfig = {
+      version: 1,
+      defaults: { builtins: ['Bash'], mcpServers: [] },
+      tools: [
+        { type: 'builtin', name: 'AdminTool', enabled: true, mainOnly: true },
+      ],
+    };
+
+    expect(isToolAllowed(registry, 'AdminTool', true, 'main')).toBe(true);
+    expect(isToolAllowed(registry, 'AdminTool', false, 'other')).toBe(false);
+  });
+
+  it('respects groups filtering', () => {
+    const registry: ToolRegistryConfig = {
+      version: 1,
+      defaults: { builtins: ['Bash'], mcpServers: [] },
+      tools: [
+        { type: 'skill', name: 'SpecialTool', enabled: true, groups: ['group-a'] },
+      ],
+    };
+
+    expect(isToolAllowed(registry, 'SpecialTool', false, 'group-a')).toBe(true);
+    expect(isToolAllowed(registry, 'SpecialTool', false, 'group-b')).toBe(false);
+  });
+
+  it('respects enabled: false', () => {
+    const registry: ToolRegistryConfig = {
+      version: 1,
+      defaults: { builtins: ['Bash'], mcpServers: [] },
+      tools: [
+        { type: 'builtin', name: 'DisabledTool', enabled: false },
+      ],
+    };
+
+    expect(isToolAllowed(registry, 'DisabledTool', false, 'test-group')).toBe(false);
+  });
+});

--- a/container/agent-runner/src/tool-registry.ts
+++ b/container/agent-runner/src/tool-registry.ts
@@ -1,0 +1,184 @@
+/**
+ * Tool Registry for NanoClaw Agent Runner
+ *
+ * Config-driven tool allowlist that replaces the hardcoded allowedTools array.
+ * Reads configuration from NANOCLAW_TOOL_REGISTRY env var (JSON string injected
+ * by container-runner). Falls back to hardcoded defaults when no config is present,
+ * preserving exact backwards compatibility.
+ *
+ * Local-only registry. No network calls, no external dependencies.
+ */
+
+export interface ToolRegistryConfig {
+  version: 1;
+  defaults: {
+    builtins: string[]; // default built-in tools for all groups
+    mcpServers: string[]; // MCP tool prefixes (e.g., "mcp__nanoclaw__*")
+  };
+  tools: Array<{
+    type: 'builtin' | 'mcp' | 'skill' | 'custom';
+    name: string;
+    enabled: boolean;
+    mainOnly?: boolean; // only available to main group
+    groups?: string[]; // restrict to specific group folders (null = all)
+  }>;
+}
+
+/**
+ * Hardcoded defaults that exactly match the current allowedTools array
+ * in container/agent-runner/src/index.ts (lines 409-418).
+ *
+ * When no config file exists and no env var is set, loadRegistry() returns
+ * these defaults so behavior is identical to the pre-registry codebase.
+ */
+const DEFAULT_BUILTINS: string[] = [
+  'Bash',
+  'Read',
+  'Write',
+  'Edit',
+  'Glob',
+  'Grep',
+  'WebSearch',
+  'WebFetch',
+  'Task',
+  'TaskOutput',
+  'TaskStop',
+  'TeamCreate',
+  'TeamDelete',
+  'SendMessage',
+  'TodoWrite',
+  'ToolSearch',
+  'Skill',
+  'NotebookEdit',
+];
+
+const DEFAULT_MCP_SERVERS: string[] = ['mcp__nanoclaw__*'];
+
+function getDefaultConfig(): ToolRegistryConfig {
+  return {
+    version: 1,
+    defaults: {
+      builtins: [...DEFAULT_BUILTINS],
+      mcpServers: [...DEFAULT_MCP_SERVERS],
+    },
+    tools: [],
+  };
+}
+
+/**
+ * Load the tool registry configuration.
+ *
+ * Resolution order:
+ * 1. NANOCLAW_TOOL_REGISTRY env var (JSON string, injected by container-runner)
+ * 2. Hardcoded defaults (backwards compatible — exact same allowedTools as before)
+ *
+ * @param _isMain - whether this is the main group (unused in loading, used in compute)
+ * @param _groupFolder - the group folder name (unused in loading, used in compute)
+ */
+export function loadRegistry(
+  _isMain: boolean,
+  _groupFolder: string,
+): ToolRegistryConfig {
+  const envJson = process.env.NANOCLAW_TOOL_REGISTRY;
+
+  if (envJson) {
+    try {
+      const parsed = JSON.parse(envJson) as ToolRegistryConfig;
+
+      // Basic validation
+      if (parsed.version !== 1) {
+        console.error(
+          `[tool-registry] Unsupported config version: ${parsed.version}, using defaults`,
+        );
+        return getDefaultConfig();
+      }
+      if (
+        !parsed.defaults ||
+        !Array.isArray(parsed.defaults.builtins) ||
+        !Array.isArray(parsed.defaults.mcpServers)
+      ) {
+        console.error(
+          '[tool-registry] Invalid config structure, using defaults',
+        );
+        return getDefaultConfig();
+      }
+      if (!Array.isArray(parsed.tools)) {
+        console.error('[tool-registry] Invalid tools array, using defaults');
+        return getDefaultConfig();
+      }
+
+      return parsed;
+    } catch (err) {
+      console.error(
+        `[tool-registry] Failed to parse NANOCLAW_TOOL_REGISTRY: ${err instanceof Error ? err.message : String(err)}, using defaults`,
+      );
+      return getDefaultConfig();
+    }
+  }
+
+  return getDefaultConfig();
+}
+
+/**
+ * Compute the final allowedTools array from a registry configuration.
+ *
+ * Algorithm:
+ * 1. Start with defaults.builtins + defaults.mcpServers
+ * 2. For each tool in tools[], if enabled AND group eligibility passes, add it
+ * 3. Return the final deduplicated array
+ *
+ * Group eligibility:
+ * - mainOnly=true: only included when isMain=true
+ * - groups=[...]: only included when groupFolder is in the array
+ * - Neither set: included for all groups
+ */
+export function computeAllowedTools(
+  registry: ToolRegistryConfig,
+  isMain: boolean,
+  groupFolder: string,
+): string[] {
+  // Start with defaults
+  const tools = new Set<string>([
+    ...registry.defaults.builtins,
+    ...registry.defaults.mcpServers,
+  ]);
+
+  // Add eligible tools from the tools array
+  for (const tool of registry.tools) {
+    if (!tool.enabled) continue;
+
+    // Check mainOnly filter
+    if (tool.mainOnly && !isMain) continue;
+
+    // Check groups filter (null/undefined/empty = all groups)
+    if (
+      tool.groups &&
+      tool.groups.length > 0 &&
+      !tool.groups.includes(groupFolder)
+    )
+      continue;
+
+    tools.add(tool.name);
+  }
+
+  return [...tools];
+}
+
+/**
+ * Quick check if a specific tool is allowed for the given context.
+ *
+ * @param registry - the loaded registry config
+ * @param toolName - the tool name to check
+ * @param isMain - whether this is the main group
+ * @param groupFolder - the group folder name
+ * @returns true if the tool is in the computed allowed list
+ */
+export function isToolAllowed(
+  registry: ToolRegistryConfig,
+  toolName: string,
+  isMain: boolean,
+  groupFolder: string,
+): boolean {
+  const allowed = computeAllowedTools(registry, isMain, groupFolder);
+  return allowed.includes(toolName);
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,6 +37,13 @@ export const SENDER_ALLOWLIST_PATH = path.join(
   'nanoclaw',
   'sender-allowlist.json',
 );
+// Tool registry: configurable tool allowlist, stored alongside other security config
+export const TOOL_REGISTRY_PATH = path.join(
+  HOME_DIR,
+  '.config',
+  'nanoclaw',
+  'tool-registry.json',
+);
 export const STORE_DIR = path.resolve(PROJECT_ROOT, 'store');
 export const GROUPS_DIR = path.resolve(PROJECT_ROOT, 'groups');
 export const DATA_DIR = path.resolve(PROJECT_ROOT, 'data');

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -15,6 +15,7 @@ import {
   IDLE_TIMEOUT,
   ONECLI_URL,
   TIMEZONE,
+  TOOL_REGISTRY_PATH,
 } from './config.js';
 import { resolveGroupFolderPath, resolveGroupIpcPath } from './group-folder.js';
 import { logger } from './logger.js';
@@ -241,6 +242,22 @@ async function buildContainerArgs(
 
   // Pass host timezone so container's local time matches the user's
   args.push('-e', `TZ=${TIMEZONE}`);
+
+  // Tool registry config — inject as env var if the config file exists.
+  // The agent-runner reads NANOCLAW_TOOL_REGISTRY to build its allowedTools array.
+  // When absent, the agent-runner falls back to hardcoded defaults (backwards compatible).
+  if (fs.existsSync(TOOL_REGISTRY_PATH)) {
+    try {
+      const registryJson = fs.readFileSync(TOOL_REGISTRY_PATH, 'utf-8');
+      JSON.parse(registryJson); // validate JSON before injecting
+      args.push('-e', `NANOCLAW_TOOL_REGISTRY=${registryJson}`);
+    } catch (err) {
+      logger.warn(
+        { path: TOOL_REGISTRY_PATH, error: err },
+        'Failed to read tool registry config, skipping injection',
+      );
+    }
+  }
 
   // OneCLI gateway handles credential injection — containers never see real secrets.
   // The gateway intercepts HTTPS traffic and injects API keys or OAuth tokens.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,10 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['src/**/*.test.ts', 'setup/**/*.test.ts'],
+    include: [
+      'src/**/*.test.ts',
+      'setup/**/*.test.ts',
+      'container/agent-runner/src/**/*.test.ts',
+    ],
   },
 });


### PR DESCRIPTION
<!-- contributing-guide: v1 -->

## Type of Change

- [x] **Simplification** — reduces/simplifies code

## What

Replace the hardcoded `allowedTools` array in `container/agent-runner/src/index.ts` with a configurable tool registry that reads from an optional JSON config file.

## Why

The current `allowedTools` array is hardcoded in source — changing which tools are available requires modifying code and rebuilding. This makes it impossible to:
- Restrict tools for non-main groups (e.g., remove `Bash` from untrusted groups)
- Add custom tools without forking
- Configure tool permissions per deployment

## How it works

New `container/agent-runner/src/tool-registry.ts` module with three functions:
- `loadRegistry()` — reads `NANOCLAW_TOOL_REGISTRY` env var (JSON), falls back to hardcoded defaults
- `computeAllowedTools()` — filters tools by group eligibility (mainOnly, groups, enabled)
- `isToolAllowed()` — quick boolean check for a specific tool name

Config file at `~/.config/nanoclaw/tool-registry.json` (same pattern as `mount-allowlist.json`):
```json
{
  "version": 1,
  "defaults": {
    "builtins": ["Bash", "Read", "Write", ...],
    "mcpServers": ["mcp__nanoclaw__*"]
  },
  "tools": [
    { "type": "custom", "name": "MyTool", "enabled": true, "mainOnly": true }
  ]
}
```

Host injects config via `-e NANOCLAW_TOOL_REGISTRY=<json>` in `container-runner.ts`, following the existing `MOUNT_ALLOWLIST_PATH` pattern.

## Backwards compatibility

When no config file exists and no env var is set, `loadRegistry()` returns defaults that produce **exactly** the same `allowedTools` array as the current hardcoded list. Zero config change required for existing deployments. The backwards-compatibility test verifies this explicitly.

## How it was tested

- 23 unit tests covering: default fallback, env var parsing, backwards compatibility, group filtering, mainOnly, enabled toggle, deduplication, isToolAllowed
- Manual test: verified container agents receive identical allowedTools with no config file present
- `npm run format:check` passes
- `npx vitest run` passes

## Files changed

| File | Change |
|------|--------|
| `container/agent-runner/src/tool-registry.ts` | NEW: registry module |
| `container/agent-runner/src/tool-registry.test.ts` | NEW: 23 tests |
| `container/agent-runner/src/index.ts` | Replace hardcoded array with `computeAllowedTools()` |
| `src/config.ts` | Add `TOOL_REGISTRY_PATH` constant |
| `src/container-runner.ts` | Inject `NANOCLAW_TOOL_REGISTRY` env var when config exists |
| `vitest.config.ts` | Add `container/agent-runner/src/**/*.test.ts` to test includes |