### PR TITLE
fix: prevent 30-min deadlock when messages piped to active container

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -534,6 +534,14 @@ async function runQuery(
         result: textResult || null,
         newSessionId,
       });
+      // End the stream after each result to prevent deadlock: without this,
+      // the SDK waits for more messages from the open stream, but the host
+      // can't write _close until it receives the idle signal (result: null)
+      // emitted after runQuery() returns — creating a circular dependency.
+      // Subsequent piped messages are handled by waitForIpcMessage() in the
+      // outer loop.
+      ipcPolling = false;
+      stream.end();
     }
   }
 


### PR DESCRIPTION
## Summary

When a message is piped via soft-busy into an active query's `MessageStream`, the query deadlocks:

1. The SDK waits for more messages from the open stream
2. The host can't write `_close` without the idle signal (`result: null`)
3. The idle signal is only emitted after `runQuery()` returns — which requires the stream to end

This circular dependency causes the container to sit idle for the full `IDLE_TIMEOUT` (30 min) before any queued async jobs can run. Users see a ~30 minute delay between their message and the bot's response.

**Fix:** End the stream and stop IPC polling after each `result` event. Subsequent piped messages are handled by `waitForIpcMessage()` in the outer loop, preserving full session continuity.

## Reproduction

1. Send a message that triggers a container agent
2. While the agent is processing (within 60s grace window), send another message → gets piped via soft-busy into the active query's `MessageStream`
3. Agent responds to both messages but the container stays alive for 30 minutes
4. Any further messages during that time are queued as async jobs and delayed until the container times out

## Test plan

- [ ] Send a message, then quickly send another while agent is responding — second message should be processed promptly, not after 30 min
- [ ] Verify piped messages still work correctly (agent sees both messages)
- [ ] Verify async jobs drain immediately after the container goes idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)