### PR TITLE
fix: harden OneCLI setup for public servers

### DIFF
--- a/.claude/skills/init-onecli/SKILL.md
+++ b/.claude/skills/init-onecli/SKILL.md
@@ -93,6 +93,64 @@ onecli config set api-host http://127.0.0.1:10254
 grep -q 'ONECLI_URL' .env 2>/dev/null || echo 'ONECLI_URL=http://127.0.0.1:10254' >> .env
 ```
 
+### Harden OneCLI for public servers
+
+Docker bypasses UFW/iptables — any port in docker-compose `ports:` is open to the internet regardless of firewall rules. The OneCLI installer creates a `docker-compose.yml` with PostgreSQL and app ports exposed on `0.0.0.0`. This must be fixed before proceeding.
+
+Find the OneCLI docker-compose file:
+
+```bash
+find ~/.onecli /opt/onecli -name 'docker-compose.yml' 2>/dev/null | head -1
+```
+
+**1. Remove PostgreSQL port mapping.** Postgres is only used by the OneCLI app service via internal Docker networking — it does not need a host port. Remove the entire `ports:` section from the `postgres` service (not from `app`).
+
+**2. Set a real PostgreSQL password.** Check if `~/.onecli/.env` exists and has a non-default `POSTGRES_PASSWORD`. If not:
+
+```bash
+PG_PASS=$(openssl rand -base64 24 | tr -d '/+=' | head -c 32)
+echo "POSTGRES_PASSWORD=$PG_PASS" >> ~/.onecli/.env
+```
+
+If the database volume already exists with the old default password, also change it inside the running database:
+
+```bash
+docker exec onecli-postgres-1 psql -U onecli -d onecli -c "ALTER USER onecli WITH PASSWORD '$PG_PASS';"
+```
+
+**3. Block OneCLI app ports from external access (Linux only).** NanoClaw containers access OneCLI via the Docker bridge gateway (~172.17.0.1), so the ports must stay on `0.0.0.0` but be blocked from the internet:
+
+```bash
+sudo iptables -I DOCKER-USER -p tcp --dport 10254 -s 172.17.0.0/16 -j RETURN
+sudo iptables -I DOCKER-USER -p tcp --dport 10254 -s 127.0.0.1 -j RETURN
+sudo iptables -A DOCKER-USER -p tcp --dport 10254 -j DROP
+sudo iptables -I DOCKER-USER -p tcp --dport 10255 -s 172.17.0.0/16 -j RETURN
+sudo iptables -I DOCKER-USER -p tcp --dport 10255 -s 127.0.0.1 -j RETURN
+sudo iptables -A DOCKER-USER -p tcp --dport 10255 -j DROP
+```
+
+Persist the rules:
+
+```bash
+sudo apt-get install -y iptables-persistent 2>/dev/null && sudo netfilter-persistent save
+```
+
+Skip this step on macOS — Docker Desktop for Mac does not expose ports to the network the same way.
+
+**4. Recreate containers** with the updated config:
+
+```bash
+cd ~/.onecli && docker compose down && docker compose up -d
+```
+
+Wait for both containers to become healthy before proceeding.
+
+**5. Run security check** if the script exists:
+
+```bash
+[ -f scripts/security-check.sh ] && bash scripts/security-check.sh
+```
+
 ### Wait for gateway readiness
 
 The gateway may take a moment to start after installation. Poll for up to 15 seconds:

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -146,6 +146,14 @@ grep -q '.local/bin' ~/.zshrc 2>/dev/null || echo 'export PATH="$HOME/.local/bin
 
 Then re-verify with `onecli version`.
 
+**Harden OneCLI (critical on public servers).** Docker bypasses UFW/iptables — any port in docker-compose `ports:` is open to the internet regardless of firewall rules. Find the OneCLI docker-compose file (`~/.onecli/docker-compose.yml`) and:
+
+1. **Remove the `ports:` section from the `postgres` service** — it communicates with the app via internal Docker networking and does not need a host port.
+2. **Generate a real PostgreSQL password** in `~/.onecli/.env` (`POSTGRES_PASSWORD=<random>`). If the DB volume already exists with the old password, also run `ALTER USER` inside the container to update it.
+3. **On Linux: block OneCLI app ports from external access** via iptables DOCKER-USER chain — allow `172.17.0.0/16` and `127.0.0.1`, DROP everything else for ports 10254 and 10255. Persist with `iptables-persistent`. Skip on macOS.
+4. Recreate containers: `cd ~/.onecli && docker compose down && docker compose up -d`
+5. Run `bash scripts/security-check.sh` if it exists.
+
 Point the CLI at the local OneCLI instance (it defaults to the cloud service otherwise):
 ```bash
 onecli config set api-host http://127.0.0.1:10254

--- a/scripts/security-check.sh
+++ b/scripts/security-check.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Security check for NanoClaw VPS deployment.
+# Verifies that Docker hasn't exposed internal ports to the internet.
+# Run after deploy, after docker compose changes, or on a schedule.
+#
+# Exit codes: 0 = ok, 1 = security issue found
+
+set -euo pipefail
+
+FAIL=0
+
+echo "==> Security check"
+
+# 1. Check for Docker-exposed ports that should be internal-only.
+#    Docker bypasses UFW/firewall — ports in docker-compose "ports:" are
+#    open to the internet even if UFW says otherwise.
+EXPOSED=$(ss -tlnp 2>/dev/null | grep -E '0\.0\.0\.0:(5432|3306|6379|27017)' || true)
+if [ -n "$EXPOSED" ]; then
+  echo "FAIL: Database ports exposed on 0.0.0.0 (Docker bypasses UFW!):"
+  echo "$EXPOSED"
+  echo "  Fix: remove 'ports:' from docker-compose.yml for internal services"
+  FAIL=1
+fi
+
+# 2. Check that OneCLI ports are blocked from external access via DOCKER-USER.
+for PORT in 10254 10255; do
+  RULE=$(sudo iptables -L DOCKER-USER -n 2>/dev/null | grep "tcp dpt:$PORT" | grep DROP || true)
+  if [ -z "$RULE" ]; then
+    echo "FAIL: Port $PORT has no DROP rule in DOCKER-USER chain"
+    echo "  Fix: sudo iptables -A DOCKER-USER -p tcp --dport $PORT -j DROP"
+    FAIL=1
+  fi
+done
+
+# 3. Check that OneCLI PostgreSQL has a non-default password.
+ONECLI_ENV="$HOME/.onecli/.env"
+if [ -f "$ONECLI_ENV" ]; then
+  if grep -q 'POSTGRES_PASSWORD=onecli' "$ONECLI_ENV" 2>/dev/null; then
+    echo "FAIL: OneCLI PostgreSQL still using default password"
+    FAIL=1
+  fi
+else
+  # Check if OneCLI is running at all before flagging
+  if docker ps --format '{{.Names}}' 2>/dev/null | grep -q onecli; then
+    echo "FAIL: OneCLI running but no .env with custom password ($ONECLI_ENV missing)"
+    FAIL=1
+  fi
+fi
+
+# 4. Check that .ssh is not in mount allowlist.
+ALLOWLIST="$HOME/.config/nanoclaw/mount-allowlist.json"
+if [ -f "$ALLOWLIST" ]; then
+  if grep -qi '\.ssh\|/home.*ssh' "$ALLOWLIST"; then
+    echo "FAIL: .ssh appears in mount allowlist — agents could access SSH keys"
+    FAIL=1
+  fi
+fi
+
+if [ "$FAIL" -eq 0 ]; then
+  echo "  All checks passed"
+else
+  echo ""
+  echo "SECURITY ISSUES FOUND — fix before continuing"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- The OneCLI installer creates a `docker-compose.yml` with PostgreSQL (5432) and gateway (10254/10255) ports exposed on `0.0.0.0`. On public servers, Docker bypasses UFW/iptables — these ports are open to the internet regardless of firewall rules. With default credentials (`onecli:onecli`), this exposes the credential vault (including stored API keys) to anyone who knows the server IP.
- The `/setup` and `/init-onecli` skills now include hardening steps: remove postgres port mapping, generate a real password, and set up `DOCKER-USER` iptables rules on Linux.
- Added `scripts/security-check.sh` as a reusable safety net that verifies port security.

## How it was tested

Deployed NanoClaw on a DigitalOcean VPS with Telegram channel. Discovered the vulnerability during a security audit — PostgreSQL with default credentials was accessible from the internet. Applied the hardening steps, verified ports are closed externally while OneCLI remains accessible from Docker containers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)