### PR TITLE
fix: mount agent-runner source read-only inside containers

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -216,7 +216,7 @@ function buildVolumeMounts(
   mounts.push({
     hostPath: groupAgentRunnerDir,
     containerPath: '/app/src',
-    readonly: false,
+    readonly: true,
   });
 
   // Additional mounts validated against external allowlist (tamper-proof from containers)


### PR DESCRIPTION
The agent-runner source directory is mounted read-write at /app/src inside containers (container-runner.ts line 219). Since the agent runs with bypassPermissions, it can modify its own runner source via bash. The modification persists on the host (at data/sessions/{group}/agent-runner-src/) and executes on the next container run because the entrypoint recompiles from /app/src.

Tested: created a temp directory with the agent-runner source, mounted it read-write into the container, appended a line from inside the container. The change persisted on the host after the container exited. With read-only mount, tsc still compiles successfully since the entrypoint only needs to read the source.

Change: `readonly: false` to `readonly: true` on the /app/src mount.