### PR TITLE
feat: auto-prune stale session artifacts

### DIFF
--- a/scripts/cleanup-sessions.sh
+++ b/scripts/cleanup-sessions.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+#
+# Prune stale session artifacts (JSONLs, debug logs, todos, telemetry, group logs).
+# Safe to run while NanoClaw is live — active sessions are read from the DB.
+#
+# Usage:  ./scripts/cleanup-sessions.sh [--dry-run]
+#
+# Retention:
+#   Session JSONLs + tool-results:  7 days  (active session always kept)
+#   Debug logs:                     3 days
+#   Todo files:                     3 days
+#   Telemetry:                      7 days
+#   Group logs:                     7 days
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+STORE_DB="$PROJECT_ROOT/store/messages.db"
+SESSIONS_DIR="$PROJECT_ROOT/data/sessions"
+GROUPS_DIR="$PROJECT_ROOT/groups"
+
+DRY_RUN=false
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true
+
+TOTAL_FREED=0
+
+log() { echo "[cleanup] $*"; }
+
+remove() {
+  local target="$1"
+  if $DRY_RUN; then
+    if [ -d "$target" ]; then
+      size=$(du -sk "$target" 2>/dev/null | cut -f1)
+    else
+      size=$(stat -f%z "$target" 2>/dev/null || echo 0)
+      size=$((size / 1024))
+    fi
+    TOTAL_FREED=$((TOTAL_FREED + size))
+    log "would remove: $target (${size}K)"
+  else
+    if [ -d "$target" ]; then
+      size=$(du -sk "$target" 2>/dev/null | cut -f1)
+      rm -rf "$target"
+    else
+      size=$(stat -f%z "$target" 2>/dev/null || echo 0)
+      size=$((size / 1024))
+      rm -f "$target"
+    fi
+    TOTAL_FREED=$((TOTAL_FREED + size))
+  fi
+}
+
+# --- Collect active session IDs from the database ---
+
+if [ ! -f "$STORE_DB" ]; then
+  log "ERROR: database not found at $STORE_DB"
+  exit 1
+fi
+
+ACTIVE_IDS=$(sqlite3 "$STORE_DB" "SELECT session_id FROM sessions;" 2>/dev/null || true)
+
+is_active() {
+  echo "$ACTIVE_IDS" | grep -qF "$1"
+}
+
+# --- Prune session JSONLs and tool-results dirs ---
+
+for group_dir in "$SESSIONS_DIR"/*/; do
+  [ -d "$group_dir" ] || continue
+  jsonl_dir="$group_dir/.claude/projects/-workspace-group"
+  [ -d "$jsonl_dir" ] || continue
+
+  for jsonl in "$jsonl_dir"/*.jsonl; do
+    [ -f "$jsonl" ] || continue
+    id=$(basename "$jsonl" .jsonl)
+
+    # Never delete the active session
+    if is_active "$id"; then
+      continue
+    fi
+
+    # Only delete if older than 7 days
+    if [ -n "$(find "$jsonl" -mtime +7 2>/dev/null)" ]; then
+      remove "$jsonl"
+      # Remove matching tool-results directory
+      [ -d "$jsonl_dir/$id" ] && remove "$jsonl_dir/$id"
+    fi
+  done
+done
+
+# --- Prune debug logs (>3 days, skip files named after active sessions) ---
+
+for group_dir in "$SESSIONS_DIR"/*/; do
+  debug_dir="$group_dir/.claude/debug"
+  [ -d "$debug_dir" ] || continue
+  find "$debug_dir" -type f -mtime +3 ! -name "latest" -print0 2>/dev/null | while IFS= read -r -d '' f; do
+    fname=$(basename "$f" .txt)
+    is_active "$fname" && continue
+    remove "$f"
+  done
+done
+
+# --- Prune todo files (>3 days, skip files named after active sessions) ---
+
+for group_dir in "$SESSIONS_DIR"/*/; do
+  todos_dir="$group_dir/.claude/todos"
+  [ -d "$todos_dir" ] || continue
+  find "$todos_dir" -type f -mtime +3 -print0 2>/dev/null | while IFS= read -r -d '' f; do
+    fname=$(basename "$f" .json)
+    # Todo filenames are like {session_id}-agent-{session_id}.json
+    for aid in $ACTIVE_IDS; do
+      if [[ "$fname" == *"$aid"* ]]; then
+        continue 2
+      fi
+    done
+    remove "$f"
+  done
+done
+
+# --- Prune telemetry (>7 days, skip files named after active sessions) ---
+
+for group_dir in "$SESSIONS_DIR"/*/; do
+  telem_dir="$group_dir/.claude/telemetry"
+  [ -d "$telem_dir" ] || continue
+  find "$telem_dir" -type f -mtime +7 -print0 2>/dev/null | while IFS= read -r -d '' f; do
+    fname=$(basename "$f")
+    for aid in $ACTIVE_IDS; do
+      if [[ "$fname" == *"$aid"* ]]; then
+        continue 2
+      fi
+    done
+    remove "$f"
+  done
+done
+
+# --- Prune group logs (>7 days) ---
+
+find "$GROUPS_DIR"/*/logs -type f -mtime +7 -print0 2>/dev/null | while IFS= read -r -d '' f; do
+  remove "$f"
+done
+
+# --- Summary ---
+
+if $DRY_RUN; then
+  log "DRY RUN complete — would free ~${TOTAL_FREED}K"
+else
+  log "Done — freed ~${TOTAL_FREED}K"
+fi

--- a/scripts/cleanup-sessions.sh
+++ b/scripts/cleanup-sessions.sh
@@ -34,7 +34,7 @@ remove() {
     if [ -d "$target" ]; then
       size=$(du -sk "$target" 2>/dev/null | cut -f1)
     else
-      size=$(stat -f%z "$target" 2>/dev/null || echo 0)
+      size=$(wc -c < "$target" 2>/dev/null || echo 0)
       size=$((size / 1024))
     fi
     TOTAL_FREED=$((TOTAL_FREED + size))
@@ -44,7 +44,7 @@ remove() {
       size=$(du -sk "$target" 2>/dev/null | cut -f1)
       rm -rf "$target"
     else
-      size=$(stat -f%z "$target" 2>/dev/null || echo 0)
+      size=$(wc -c < "$target" 2>/dev/null || echo 0)
       size=$((size / 1024))
       rm -f "$target"
     fi
@@ -95,11 +95,11 @@ done
 for group_dir in "$SESSIONS_DIR"/*/; do
   debug_dir="$group_dir/.claude/debug"
   [ -d "$debug_dir" ] || continue
-  find "$debug_dir" -type f -mtime +3 ! -name "latest" -print0 2>/dev/null | while IFS= read -r -d '' f; do
+  while IFS= read -r -d '' f; do
     fname=$(basename "$f" .txt)
     is_active "$fname" && continue
     remove "$f"
-  done
+  done < <(find "$debug_dir" -type f -mtime +3 ! -name "latest" -print0 2>/dev/null)
 done
 
 # --- Prune todo files (>3 days, skip files named after active sessions) ---
@@ -107,7 +107,7 @@ done
 for group_dir in "$SESSIONS_DIR"/*/; do
   todos_dir="$group_dir/.claude/todos"
   [ -d "$todos_dir" ] || continue
-  find "$todos_dir" -type f -mtime +3 -print0 2>/dev/null | while IFS= read -r -d '' f; do
+  while IFS= read -r -d '' f; do
     fname=$(basename "$f" .json)
     # Todo filenames are like {session_id}-agent-{session_id}.json
     for aid in $ACTIVE_IDS; do
@@ -116,7 +116,7 @@ for group_dir in "$SESSIONS_DIR"/*/; do
       fi
     done
     remove "$f"
-  done
+  done < <(find "$todos_dir" -type f -mtime +3 -print0 2>/dev/null)
 done
 
 # --- Prune telemetry (>7 days, skip files named after active sessions) ---
@@ -124,7 +124,7 @@ done
 for group_dir in "$SESSIONS_DIR"/*/; do
   telem_dir="$group_dir/.claude/telemetry"
   [ -d "$telem_dir" ] || continue
-  find "$telem_dir" -type f -mtime +7 -print0 2>/dev/null | while IFS= read -r -d '' f; do
+  while IFS= read -r -d '' f; do
     fname=$(basename "$f")
     for aid in $ACTIVE_IDS; do
       if [[ "$fname" == *"$aid"* ]]; then
@@ -132,14 +132,14 @@ for group_dir in "$SESSIONS_DIR"/*/; do
       fi
     done
     remove "$f"
-  done
+  done < <(find "$telem_dir" -type f -mtime +7 -print0 2>/dev/null)
 done
 
 # --- Prune group logs (>7 days) ---
 
-find "$GROUPS_DIR"/*/logs -type f -mtime +7 -print0 2>/dev/null | while IFS= read -r -d '' f; do
+while IFS= read -r -d '' f; do
   remove "$f"
-done
+done < <(find "$GROUPS_DIR"/*/logs -type f -mtime +7 -print0 2>/dev/null)
 
 # --- Summary ---
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,7 @@ import {
   loadSenderAllowlist,
   shouldDropMessage,
 } from './sender-allowlist.js';
+import { startSessionCleanup } from './session-cleanup.js';
 import { startSchedulerLoop } from './task-scheduler.js';
 import { Channel, NewMessage, RegisteredGroup } from './types.js';
 import { logger } from './logger.js';
@@ -746,6 +747,7 @@ async function main(): Promise<void> {
       }
     },
   });
+  startSessionCleanup();
   queue.setProcessMessagesFn(processGroupMessages);
   recoverPendingMessages();
   startMessageLoop().catch((err) => {

--- a/src/session-cleanup.ts
+++ b/src/session-cleanup.ts
@@ -1,0 +1,25 @@
+import { execFile } from 'child_process';
+import path from 'path';
+
+import { logger } from './logger.js';
+
+const CLEANUP_INTERVAL = 24 * 60 * 60 * 1000; // 24 hours
+const SCRIPT_PATH = path.resolve(process.cwd(), 'scripts/cleanup-sessions.sh');
+
+function runCleanup(): void {
+  execFile('/bin/bash', [SCRIPT_PATH], { timeout: 60_000 }, (err, stdout) => {
+    if (err) {
+      logger.error({ err }, 'Session cleanup failed');
+      return;
+    }
+    const summary = stdout.trim().split('\n').pop();
+    if (summary) logger.info(summary);
+  });
+}
+
+export function startSessionCleanup(): void {
+  // Run once at startup (delayed 30s to not compete with init)
+  setTimeout(runCleanup, 30_000);
+  // Then every 24 hours
+  setInterval(runCleanup, CLEANUP_INTERVAL);
+}


### PR DESCRIPTION
## Summary
- Adds `scripts/cleanup-sessions.sh` — age-based pruning of old session JSONLs, debug logs, todos, telemetry, and group logs
- Protects active sessions by reading session IDs from `store/messages.db` before deleting anything
- Wires cleanup into the main process via `src/session-cleanup.ts` — runs 30s after startup, then every 24h
- Script supports `--dry-run` for manual previewing

**Retention policy:**
| Artifact | Retention |
|----------|-----------|
| Session JSONLs + tool-results | 7 days (active session always kept) |
| Debug logs | 3 days |
| Todo files | 3 days |
| Telemetry | 7 days |
| Group logs | 7 days |

**Context:** Session artifacts (especially from daily cron tasks) accumulate unboundedly. A single group with 4 daily scheduled tasks generates ~4 JSONL + debug + todo files per day. Over weeks this adds up to hundreds of MB with no cleanup.

## Test plan
- [x] `--dry-run` verified: correctly identifies stale files, reports expected savings
- [x] All 11 active sessions confirmed protected (no active session ID appears in dry-run output)
- [x] Live run freed ~85 MB on a real install
- [x] `npm run build` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)