### PR TITLE
fix(gmail): add OneCLI credential mode detection

### DIFF
--- a/.claude/skills/add-gmail/SKILL.md
+++ b/.claude/skills/add-gmail/SKILL.md
@@ -85,11 +85,27 @@ All tests must pass (including the new Gmail tests) and build must be clean befo
 ls -la ~/.gmail-mcp/ 2>/dev/null || echo "No Gmail config found"
 ```
 
-If `credentials.json` already exists, skip to "Build and restart" below.
+If `credentials.json` already exists with real tokens (not `onecli-managed` values), skip to "Build and restart" below.
 
 ### GCP Project Setup
 
-Tell the user:
+Check if OneCLI is configured:
+
+```bash
+grep -q 'ONECLI_URL=.' .env 2>/dev/null && echo "onecli" || echo "manual"
+```
+
+**If OneCLI:** Tell the user to open `${ONECLI_URL}/connections?connect=gmail` to set up their Gmail connection. The dashboard walks them through creating a Google Cloud OAuth app and authorizing it. Ask them to let you know when done.
+
+Once the user confirms, run:
+
+```bash
+onecli apps get --provider gmail
+```
+
+Check that `config.hasCredentials` is `true` or `connection` is not null. The response `hint` field has instructions and a docs URL for what stub credential files to create under `~/.gmail-mcp/`. Follow the hint — never overwrite existing files that don't contain `onecli-managed` values.
+
+**If manual:** Tell the user:
 
 > I need you to set up Google Cloud OAuth credentials:
 >


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Updates the Gmail skill setup flow to auto-detect credential mode.
If OneCLI is configured, guides users through `onecli apps connect`.
Otherwise falls back to manual GCP OAuth (existing flow).

## For Skills

- [x] SKILL.md contains instructions, not inline code (code goes in separate files)
- [x] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone