### PR TITLE
feat: add channel-agnostic attachment support

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -33,6 +33,11 @@ interface ContainerInput {
   isScheduledTask?: boolean;
   assistantName?: string;
   script?: string;
+  attachments?: Array<{
+    path: string; // Container-relative: attachments/{uuid}-{filename}
+    mimeType: string;
+    mode: 'inline' | 'file';
+  }>;
 }
 
 interface ContainerOutput {
@@ -53,9 +58,17 @@ interface SessionsIndex {
   entries: SessionEntry[];
 }
 
+type ImageMediaType = 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp';
+type DocumentMediaType = 'application/pdf';
+
+type ContentBlock =
+  | { type: 'text'; text: string }
+  | { type: 'image'; source: { type: 'base64'; media_type: ImageMediaType; data: string } }
+  | { type: 'document'; source: { type: 'base64'; media_type: DocumentMediaType; data: string }; title?: string };
+
 interface SDKUserMessage {
   type: 'user';
-  message: { role: 'user'; content: string };
+  message: { role: 'user'; content: string | ContentBlock[] };
   parent_tool_use_id: null;
   session_id: string;
 }
@@ -73,10 +86,10 @@ class MessageStream {
   private waiting: (() => void) | null = null;
   private done = false;
 
-  push(text: string): void {
+  push(content: string | ContentBlock[]): void {
     this.queue.push({
       type: 'user',
-      message: { role: 'user', content: text },
+      message: { role: 'user', content },
       parent_tool_use_id: null,
       session_id: '',
     });
@@ -384,7 +397,58 @@ async function runQuery(
   closedDuringQuery: boolean;
 }> {
   const stream = new MessageStream();
-  stream.push(prompt);
+
+  // Build initial message: multimodal if inline attachments exist, text-only otherwise
+  const inlineAttachments = containerInput.attachments?.filter((a) => a.mode === 'inline') ?? [];
+  if (inlineAttachments.length === 0) {
+    stream.push(prompt);
+  } else {
+    const blocks: ContentBlock[] = [{ type: 'text', text: prompt }];
+    for (const att of inlineAttachments) {
+      try {
+        const filePath = `/workspace/group/${att.path}`;
+        const isImage = att.mimeType.startsWith('image/');
+        const isText = att.mimeType.startsWith('text/');
+        // Host validates MIME types before sending to container
+        if (isText) {
+          const text = fs.readFileSync(filePath, 'utf-8');
+          const filename = att.path.split('/').pop();
+          blocks.push({ type: 'text', text: `[File: ${filename}]\n${text}` });
+        } else if (isImage) {
+          const data = fs.readFileSync(filePath).toString('base64');
+          blocks.push({
+            type: 'image',
+            source: {
+              type: 'base64',
+              media_type: att.mimeType as ImageMediaType,
+              data,
+            },
+          });
+        } else {
+          // PDF or other document
+          const data = fs.readFileSync(filePath).toString('base64');
+          blocks.push({
+            type: 'document',
+            source: {
+              type: 'base64',
+              media_type: att.mimeType as DocumentMediaType,
+              data,
+            },
+            title: att.path.split('/').pop(),
+          });
+        }
+      } catch (err) {
+        log(
+          `Failed to read attachment ${att.path}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        blocks.push({
+          type: 'text',
+          text: `[Failed to read attachment: ${att.path}]`,
+        });
+      }
+    }
+    stream.push(blocks);
+  }
 
   // Poll IPC for follow-up messages and _close sentinel during the query
   let ipcPolling = true;

--- a/scripts/cleanup-sessions.sh
+++ b/scripts/cleanup-sessions.sh
@@ -11,6 +11,7 @@
 #   Todo files:                     3 days
 #   Telemetry:                      7 days
 #   Group logs:                     7 days
+#   Attachments:                   14 days
 
 set -euo pipefail
 
@@ -140,6 +141,12 @@ done
 while IFS= read -r -d '' f; do
   remove "$f"
 done < <(find "$GROUPS_DIR"/*/logs -type f -mtime +7 -print0 2>/dev/null)
+
+# --- Prune attachments (>14 days) ---
+
+while IFS= read -r -d '' f; do
+  remove "$f"
+done < <(find "$GROUPS_DIR"/*/attachments -type f -mtime +14 -print0 2>/dev/null)
 
 # --- Summary ---
 

--- a/src/attachments.test.ts
+++ b/src/attachments.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+
+import { classifyMode, detectMimeType } from './attachments.js';
+
+describe('detectMimeType', () => {
+  it('detects JPEG from magic bytes', () => {
+    const buf = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+    expect(detectMimeType(buf)).toBe('image/jpeg');
+  });
+
+  it('detects PNG from magic bytes', () => {
+    const buf = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]);
+    expect(detectMimeType(buf)).toBe('image/png');
+  });
+
+  it('detects GIF from magic bytes', () => {
+    const buf = Buffer.from([0x47, 0x49, 0x46, 0x38, 0x39, 0x61]);
+    expect(detectMimeType(buf)).toBe('image/gif');
+  });
+
+  it('detects PDF from magic bytes', () => {
+    const buf = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31]);
+    expect(detectMimeType(buf)).toBe('application/pdf');
+  });
+
+  it('detects WebP from magic bytes at offset 8', () => {
+    // RIFF....WEBP
+    const buf = Buffer.alloc(16);
+    buf.write('RIFF', 0);
+    buf.write('WEBP', 8);
+    expect(detectMimeType(buf)).toBe('image/webp');
+  });
+
+  it('detects ZIP from magic bytes', () => {
+    const buf = Buffer.from([0x50, 0x4b, 0x03, 0x04]);
+    expect(detectMimeType(buf)).toBe('application/zip');
+  });
+
+  it('falls back to extension mapping for unknown magic bytes', () => {
+    const buf = Buffer.from([0x00, 0x01, 0x02, 0x03]);
+    expect(detectMimeType(buf, 'report.xlsx')).toBe(
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    );
+  });
+
+  it('detects text files by content + extension', () => {
+    const buf = Buffer.from('Hello, world! This is plain text.');
+    expect(detectMimeType(buf, 'notes.txt')).toBe('text/plain');
+  });
+
+  it('detects CSV text files', () => {
+    const buf = Buffer.from('name,age\nAlice,30\nBob,25');
+    expect(detectMimeType(buf, 'data.csv')).toBe('text/csv');
+  });
+
+  it('returns octet-stream for unknown content and no extension', () => {
+    const buf = Buffer.from([0x00, 0x01, 0x02, 0x03]);
+    expect(detectMimeType(buf)).toBe('application/octet-stream');
+  });
+
+  it('returns octet-stream for unknown extension with binary content', () => {
+    const buf = Buffer.from([0x00, 0x01, 0x02, 0x03]);
+    expect(detectMimeType(buf, 'data.xyz')).toBe('application/octet-stream');
+  });
+
+  it('prioritizes magic bytes over extension', () => {
+    // PNG magic bytes but .jpg extension — magic bytes win
+    const buf = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]);
+    expect(detectMimeType(buf, 'photo.jpg')).toBe('image/png');
+  });
+});
+
+describe('classifyMode', () => {
+  it('classifies images as inline', () => {
+    expect(classifyMode('image/jpeg')).toBe('inline');
+    expect(classifyMode('image/png')).toBe('inline');
+    expect(classifyMode('image/gif')).toBe('inline');
+    expect(classifyMode('image/webp')).toBe('inline');
+  });
+
+  it('classifies PDF as inline', () => {
+    expect(classifyMode('application/pdf')).toBe('inline');
+  });
+
+  it('classifies plain text as inline', () => {
+    expect(classifyMode('text/plain')).toBe('inline');
+  });
+
+  it('classifies office docs as file', () => {
+    expect(classifyMode('application/zip')).toBe('file');
+    expect(
+      classifyMode(
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      ),
+    ).toBe('file');
+  });
+
+  it('classifies unknown types as file', () => {
+    expect(classifyMode('application/octet-stream')).toBe('file');
+  });
+});

--- a/src/attachments.ts
+++ b/src/attachments.ts
@@ -1,0 +1,252 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+
+import { ATTACHMENT_MAX_SIZE } from './config.js';
+import { resolveGroupFolderPath } from './group-folder.js';
+import { logger } from './logger.js';
+import { Attachment, NewMessage } from './types.js';
+
+const INLINE_MIME_TYPES = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'application/pdf',
+  'text/plain',
+]);
+
+// Magic byte signatures for MIME detection
+const SIGNATURES: Array<{
+  bytes: number[];
+  offset?: number;
+  mime: string;
+}> = [
+  { bytes: [0xff, 0xd8, 0xff], mime: 'image/jpeg' },
+  { bytes: [0x89, 0x50, 0x4e, 0x47], mime: 'image/png' },
+  { bytes: [0x47, 0x49, 0x46, 0x38], mime: 'image/gif' },
+  // WebP: RIFF at 0, WEBP at 8
+  { bytes: [0x57, 0x45, 0x42, 0x50], offset: 8, mime: 'image/webp' },
+  { bytes: [0x25, 0x50, 0x44, 0x46], mime: 'application/pdf' },
+  // ZIP-based (xlsx, docx, pptx, etc.)
+  { bytes: [0x50, 0x4b, 0x03, 0x04], mime: 'application/zip' },
+];
+
+const EXTENSION_MAP: Record<string, string> = {
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.pdf': 'application/pdf',
+  '.txt': 'text/plain',
+  '.csv': 'text/csv',
+  '.html': 'text/html',
+  '.json': 'application/json',
+  '.xml': 'application/xml',
+  '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  '.docx':
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+};
+
+export interface SavedAttachment {
+  path: string; // Container-relative: attachments/{uuid}-{filename}
+  mimeType: string; // Validated via magic bytes
+  mode: 'inline' | 'file';
+}
+
+interface FailedAttachment {
+  error: string;
+}
+
+type DownloadResult = SavedAttachment | FailedAttachment;
+
+function isFailedAttachment(r: DownloadResult): r is FailedAttachment {
+  return 'error' in r;
+}
+
+export function detectMimeType(buffer: Buffer, filename?: string): string {
+  // Check magic bytes
+  for (const sig of SIGNATURES) {
+    const offset = sig.offset ?? 0;
+    if (buffer.length < offset + sig.bytes.length) continue;
+    if (sig.bytes.every((b, i) => buffer[offset + i] === b)) {
+      return sig.mime;
+    }
+  }
+
+  // Check if content looks like UTF-8 text (no null bytes in first 8KB)
+  const sampleSize = Math.min(buffer.length, 8192);
+  let looksLikeText = buffer.length > 0;
+  for (let i = 0; i < sampleSize; i++) {
+    if (buffer[i] === 0) {
+      looksLikeText = false;
+      break;
+    }
+  }
+
+  if (looksLikeText && filename) {
+    const ext = path.extname(filename).toLowerCase();
+    if (ext === '.txt' || ext === '.csv' || ext === '.html' || ext === '.md') {
+      return EXTENSION_MAP[ext] ?? 'text/plain';
+    }
+  }
+
+  // Fall back to extension mapping
+  if (filename) {
+    const ext = path.extname(filename).toLowerCase();
+    if (ext in EXTENSION_MAP) return EXTENSION_MAP[ext];
+  }
+
+  return 'application/octet-stream';
+}
+
+export function classifyMode(mimeType: string): 'inline' | 'file' {
+  return INLINE_MIME_TYPES.has(mimeType) ? 'inline' : 'file';
+}
+
+function sanitizeFilename(filename: string): string {
+  return (
+    filename
+      // Strip path separators and null bytes
+      .replace(/[/\\:\0]/g, '')
+      // Strip leading dots (no hidden files)
+      .replace(/^\.+/, '')
+      // Truncate
+      .slice(0, 100) || 'attachment'
+  );
+}
+
+function ensureAttachmentsDir(groupFolder: string): string {
+  const groupDir = resolveGroupFolderPath(groupFolder);
+  const attachmentsDir = path.join(groupDir, 'attachments');
+  fs.mkdirSync(attachmentsDir, { recursive: true });
+  return attachmentsDir;
+}
+
+async function downloadAndSave(
+  attachment: Attachment,
+  groupFolder: string,
+): Promise<DownloadResult> {
+  try {
+    const headers: Record<string, string> = {};
+    if (attachment.authHeaders) {
+      Object.assign(headers, attachment.authHeaders);
+    }
+
+    const response = await fetch(attachment.url, {
+      headers,
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!response.ok) {
+      return { error: `HTTP ${response.status}` };
+    }
+
+    // Stream body with size limit
+    const reader = response.body?.getReader();
+    if (!reader) return { error: 'no response body' };
+
+    const chunks: Uint8Array[] = [];
+    let totalSize = 0;
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalSize += value.byteLength;
+      if (totalSize > ATTACHMENT_MAX_SIZE) {
+        reader.cancel();
+        return {
+          error: `exceeds ${ATTACHMENT_MAX_SIZE / 1024 / 1024}MB limit`,
+        };
+      }
+      chunks.push(value);
+    }
+
+    const buffer = Buffer.concat(chunks);
+    const mimeType = detectMimeType(buffer, attachment.filename);
+    const mode = classifyMode(mimeType);
+
+    const attachmentsDir = ensureAttachmentsDir(groupFolder);
+
+    const id = crypto.randomUUID();
+    const safeName = sanitizeFilename(attachment.filename);
+    const diskFilename = `${id}-${safeName}`;
+    const diskPath = path.join(attachmentsDir, diskFilename);
+    fs.writeFileSync(diskPath, buffer);
+
+    logger.info(
+      {
+        groupFolder,
+        filename: safeName,
+        mimeType,
+        mode,
+        size: buffer.length,
+      },
+      'Attachment saved',
+    );
+
+    return {
+      path: `attachments/${diskFilename}`,
+      mimeType,
+      mode,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.warn(
+      { groupFolder, url: attachment.url, error: message },
+      'Attachment download failed',
+    );
+    return { error: message };
+  }
+}
+
+/**
+ * Download and annotate attachments for a batch of messages.
+ * Downloads in parallel. Returns saved attachments for multimodal content block construction.
+ */
+export async function processAttachments(
+  messages: NewMessage[],
+  groupFolder: string,
+  maxPerMessage: number,
+): Promise<SavedAttachment[]> {
+  const saved: SavedAttachment[] = [];
+  const jobs: Array<{
+    msg: NewMessage;
+    att: Attachment;
+    resultPromise: Promise<DownloadResult>;
+  }> = [];
+
+  for (const msg of messages) {
+    if (!msg.attachments?.length) continue;
+    for (const att of msg.attachments.slice(0, maxPerMessage)) {
+      jobs.push({
+        msg,
+        att,
+        resultPromise: downloadAndSave(att, groupFolder),
+      });
+    }
+  }
+
+  if (jobs.length === 0) return saved;
+
+  const results = await Promise.all(jobs.map((j) => j.resultPromise));
+
+  for (let i = 0; i < jobs.length; i++) {
+    const { msg, att } = jobs[i];
+    const result = results[i];
+
+    if (isFailedAttachment(result)) {
+      msg.content += `\n[Attachment failed: ${att.filename} — ${result.error}]`;
+    } else {
+      saved.push(result);
+      if (result.mode === 'inline') {
+        msg.content += `\n[Attached: ${att.filename}]`;
+      } else {
+        msg.content += `\n[File: ${att.filename} at /workspace/group/${result.path}]`;
+      }
+    }
+  }
+
+  return saved;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -94,3 +94,7 @@ function resolveConfigTimezone(): string {
   return 'UTC';
 }
 export const TIMEZONE = resolveConfigTimezone();
+
+// Attachment handling
+export const ATTACHMENT_MAX_SIZE = 15 * 1024 * 1024; // 15MB per file
+export const ATTACHMENT_MAX_PER_MESSAGE = 5;

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -27,6 +27,7 @@ import {
 import { OneCLI } from '@onecli-sh/sdk';
 import { validateAdditionalMounts } from './mount-security.js';
 import { RegisteredGroup } from './types.js';
+import { SavedAttachment } from './attachments.js';
 
 const onecli = new OneCLI({ url: ONECLI_URL });
 
@@ -43,6 +44,7 @@ export interface ContainerInput {
   isScheduledTask?: boolean;
   assistantName?: string;
   script?: string;
+  attachments?: SavedAttachment[];
 }
 
 export interface ContainerOutput {

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -142,6 +142,145 @@ describe('storeMessage', () => {
   });
 });
 
+// --- attachment persistence ---
+
+describe('attachments', () => {
+  it('stores and retrieves attachments via storeMessage', () => {
+    storeChatMetadata('group@g.us', '2024-01-01T00:00:00.000Z');
+
+    storeMessage({
+      id: 'att-1',
+      chat_jid: 'group@g.us',
+      sender: '123',
+      sender_name: 'Alice',
+      content: 'Check this out',
+      timestamp: '2024-01-01T00:00:01.000Z',
+      attachments: [
+        { url: 'https://example.com/photo.jpg', filename: 'photo.jpg' },
+      ],
+    });
+
+    const messages = getMessagesSince(
+      'group@g.us',
+      '2024-01-01T00:00:00.000Z',
+      'Andy',
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].attachments).toHaveLength(1);
+    expect(messages[0].attachments![0].filename).toBe('photo.jpg');
+    expect(messages[0].attachments![0].url).toBe(
+      'https://example.com/photo.jpg',
+    );
+  });
+
+  it('returns undefined attachments for messages without them', () => {
+    storeChatMetadata('group@g.us', '2024-01-01T00:00:00.000Z');
+
+    store({
+      id: 'no-att',
+      chat_jid: 'group@g.us',
+      sender: '123',
+      sender_name: 'Alice',
+      content: 'Just text',
+      timestamp: '2024-01-01T00:00:01.000Z',
+    });
+
+    const messages = getMessagesSince(
+      'group@g.us',
+      '2024-01-01T00:00:00.000Z',
+      'Andy',
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].attachments).toBeUndefined();
+  });
+
+  it('retrieves attachment-only messages (empty content)', () => {
+    storeChatMetadata('group@g.us', '2024-01-01T00:00:00.000Z');
+
+    storeMessage({
+      id: 'att-only',
+      chat_jid: 'group@g.us',
+      sender: '123',
+      sender_name: 'Alice',
+      content: '',
+      timestamp: '2024-01-01T00:00:01.000Z',
+      attachments: [
+        { url: 'https://example.com/doc.pdf', filename: 'doc.pdf' },
+      ],
+    });
+
+    const messages = getMessagesSince(
+      'group@g.us',
+      '2024-01-01T00:00:00.000Z',
+      'Andy',
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].attachments).toHaveLength(1);
+  });
+
+  it('retrieves attachments via getNewMessages', () => {
+    storeChatMetadata('group@g.us', '2024-01-01T00:00:00.000Z');
+
+    storeMessage({
+      id: 'att-2',
+      chat_jid: 'group@g.us',
+      sender: '456',
+      sender_name: 'Bob',
+      content: 'File attached',
+      timestamp: '2024-01-01T00:00:01.000Z',
+      attachments: [
+        {
+          url: 'https://example.com/report.xlsx',
+          filename: 'report.xlsx',
+          mimeType:
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        },
+      ],
+    });
+
+    const { messages } = getNewMessages(
+      ['group@g.us'],
+      '2024-01-01T00:00:00.000Z',
+      'Andy',
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].attachments![0].filename).toBe('report.xlsx');
+  });
+});
+
+// --- allowAttachments round-trip ---
+
+describe('registered group allowAttachments', () => {
+  it('persists allowAttachments=true through set/get round-trip', () => {
+    setRegisteredGroup('att-group@g.us', {
+      name: 'Media Group',
+      folder: 'whatsapp_media-group',
+      trigger: '@Andy',
+      added_at: '2024-01-01T00:00:00.000Z',
+      allowAttachments: true,
+    });
+
+    const groups = getAllRegisteredGroups();
+    const group = groups['att-group@g.us'];
+    expect(group).toBeDefined();
+    expect(group.allowAttachments).toBe(true);
+  });
+
+  it('omits allowAttachments for groups without it', () => {
+    setRegisteredGroup('no-att@g.us', {
+      name: 'Text Only',
+      folder: 'whatsapp_text-only',
+      trigger: '@Andy',
+      added_at: '2024-01-01T00:00:00.000Z',
+    });
+
+    const groups = getAllRegisteredGroups();
+    const group = groups['no-att@g.us'];
+    expect(group).toBeDefined();
+    expect(group.allowAttachments).toBeUndefined();
+  });
+});
+
 // --- reply context persistence ---
 
 describe('reply context', () => {

--- a/src/db.ts
+++ b/src/db.ts
@@ -6,6 +6,7 @@ import { ASSISTANT_NAME, DATA_DIR, STORE_DIR } from './config.js';
 import { isValidGroupFolder } from './group-folder.js';
 import { logger } from './logger.js';
 import {
+  Attachment,
   NewMessage,
   RegisteredGroup,
   ScheduledTask,
@@ -157,6 +158,25 @@ function createSchema(database: Database.Database): void {
   } catch {
     /* columns already exist */
   }
+
+  // Add attachments column to messages (migration for existing DBs)
+  try {
+    database.exec('ALTER TABLE messages ADD COLUMN attachments TEXT');
+  } catch {
+    /* column already exists */
+  }
+
+  // Add allow_attachments column to registered_groups (migration for existing DBs)
+  try {
+    database.exec(
+      'ALTER TABLE registered_groups ADD COLUMN allow_attachments INTEGER DEFAULT 0',
+    );
+    database.exec(
+      'UPDATE registered_groups SET allow_attachments = 1 WHERE is_main = 1',
+    );
+  } catch {
+    /* column already exists */
+  }
 }
 
 export function initDatabase(): void {
@@ -285,7 +305,7 @@ export function setLastGroupSync(): void {
  */
 export function storeMessage(msg: NewMessage): void {
   db.prepare(
-    `INSERT OR REPLACE INTO messages (id, chat_jid, sender, sender_name, content, timestamp, is_from_me, is_bot_message, reply_to_message_id, reply_to_message_content, reply_to_sender_name) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT OR REPLACE INTO messages (id, chat_jid, sender, sender_name, content, timestamp, is_from_me, is_bot_message, attachments, reply_to_message_id, reply_to_message_content, reply_to_sender_name) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     msg.id,
     msg.chat_jid,
@@ -295,6 +315,7 @@ export function storeMessage(msg: NewMessage): void {
     msg.timestamp,
     msg.is_from_me ? 1 : 0,
     msg.is_bot_message ? 1 : 0,
+    msg.attachments ? JSON.stringify(msg.attachments) : null,
     msg.reply_to_message_id ?? null,
     msg.reply_to_message_content ?? null,
     msg.reply_to_sender_name ?? null,
@@ -313,9 +334,10 @@ export function storeMessageDirect(msg: {
   timestamp: string;
   is_from_me: boolean;
   is_bot_message?: boolean;
+  attachments?: Attachment[];
 }): void {
   db.prepare(
-    `INSERT OR REPLACE INTO messages (id, chat_jid, sender, sender_name, content, timestamp, is_from_me, is_bot_message) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT OR REPLACE INTO messages (id, chat_jid, sender, sender_name, content, timestamp, is_from_me, is_bot_message, attachments) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     msg.id,
     msg.chat_jid,
@@ -325,7 +347,17 @@ export function storeMessageDirect(msg: {
     msg.timestamp,
     msg.is_from_me ? 1 : 0,
     msg.is_bot_message ? 1 : 0,
+    msg.attachments ? JSON.stringify(msg.attachments) : null,
   );
+}
+
+type MessageRow = NewMessage & { attachments?: string | null };
+
+function hydrateMessageRow(row: MessageRow): NewMessage {
+  return {
+    ...row,
+    attachments: row.attachments ? JSON.parse(row.attachments) : undefined,
+  };
 }
 
 export function getNewMessages(
@@ -342,12 +374,12 @@ export function getNewMessages(
   // Subquery takes the N most recent, outer query re-sorts chronologically.
   const sql = `
     SELECT * FROM (
-      SELECT id, chat_jid, sender, sender_name, content, timestamp, is_from_me,
+      SELECT id, chat_jid, sender, sender_name, content, timestamp, is_from_me, attachments,
              reply_to_message_id, reply_to_message_content, reply_to_sender_name
       FROM messages
       WHERE timestamp > ? AND chat_jid IN (${placeholders})
         AND is_bot_message = 0 AND content NOT LIKE ?
-        AND content != '' AND content IS NOT NULL
+        AND (content != '' AND content IS NOT NULL OR attachments IS NOT NULL)
       ORDER BY timestamp DESC
       LIMIT ?
     ) ORDER BY timestamp
@@ -355,14 +387,16 @@ export function getNewMessages(
 
   const rows = db
     .prepare(sql)
-    .all(lastTimestamp, ...jids, `${botPrefix}:%`, limit) as NewMessage[];
+    .all(lastTimestamp, ...jids, `${botPrefix}:%`, limit) as MessageRow[];
 
   let newTimestamp = lastTimestamp;
+  const messages: NewMessage[] = [];
   for (const row of rows) {
     if (row.timestamp > newTimestamp) newTimestamp = row.timestamp;
+    messages.push(hydrateMessageRow(row));
   }
 
-  return { messages: rows, newTimestamp };
+  return { messages, newTimestamp };
 }
 
 export function getMessagesSince(
@@ -376,19 +410,20 @@ export function getMessagesSince(
   // Subquery takes the N most recent, outer query re-sorts chronologically.
   const sql = `
     SELECT * FROM (
-      SELECT id, chat_jid, sender, sender_name, content, timestamp, is_from_me,
+      SELECT id, chat_jid, sender, sender_name, content, timestamp, is_from_me, attachments,
              reply_to_message_id, reply_to_message_content, reply_to_sender_name
       FROM messages
       WHERE chat_jid = ? AND timestamp > ?
         AND is_bot_message = 0 AND content NOT LIKE ?
-        AND content != '' AND content IS NOT NULL
+        AND (content != '' AND content IS NOT NULL OR attachments IS NOT NULL)
       ORDER BY timestamp DESC
       LIMIT ?
     ) ORDER BY timestamp
   `;
-  return db
+  const rows = db
     .prepare(sql)
-    .all(chatJid, sinceTimestamp, `${botPrefix}:%`, limit) as NewMessage[];
+    .all(chatJid, sinceTimestamp, `${botPrefix}:%`, limit) as MessageRow[];
+  return rows.map(hydrateMessageRow);
 }
 
 export function getLastBotMessageTimestamp(
@@ -609,6 +644,7 @@ export function getRegisteredGroup(
         container_config: string | null;
         requires_trigger: number | null;
         is_main: number | null;
+        allow_attachments: number | null;
       }
     | undefined;
   if (!row) return undefined;
@@ -631,6 +667,7 @@ export function getRegisteredGroup(
     requiresTrigger:
       row.requires_trigger === null ? undefined : row.requires_trigger === 1,
     isMain: row.is_main === 1 ? true : undefined,
+    allowAttachments: row.allow_attachments === 1 ? true : undefined,
   };
 }
 
@@ -639,8 +676,8 @@ export function setRegisteredGroup(jid: string, group: RegisteredGroup): void {
     throw new Error(`Invalid group folder "${group.folder}" for JID ${jid}`);
   }
   db.prepare(
-    `INSERT OR REPLACE INTO registered_groups (jid, name, folder, trigger_pattern, added_at, container_config, requires_trigger, is_main)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT OR REPLACE INTO registered_groups (jid, name, folder, trigger_pattern, added_at, container_config, requires_trigger, is_main, allow_attachments)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     jid,
     group.name,
@@ -650,6 +687,7 @@ export function setRegisteredGroup(jid: string, group: RegisteredGroup): void {
     group.containerConfig ? JSON.stringify(group.containerConfig) : null,
     group.requiresTrigger === undefined ? 1 : group.requiresTrigger ? 1 : 0,
     group.isMain ? 1 : 0,
+    group.allowAttachments ? 1 : 0,
   );
 }
 
@@ -663,6 +701,7 @@ export function getAllRegisteredGroups(): Record<string, RegisteredGroup> {
     container_config: string | null;
     requires_trigger: number | null;
     is_main: number | null;
+    allow_attachments: number | null;
   }>;
   const result: Record<string, RegisteredGroup> = {};
   for (const row of rows) {
@@ -684,6 +723,7 @@ export function getAllRegisteredGroups(): Record<string, RegisteredGroup> {
       requiresTrigger:
         row.requires_trigger === null ? undefined : row.requires_trigger === 1,
       isMain: row.is_main === 1 ? true : undefined,
+      allowAttachments: row.allow_attachments === 1 ? true : undefined,
     };
   }
   return result;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { OneCLI } from '@onecli-sh/sdk';
 
 import {
   ASSISTANT_NAME,
+  ATTACHMENT_MAX_PER_MESSAGE,
   DEFAULT_TRIGGER,
   getTriggerPattern,
   GROUPS_DIR,
@@ -64,6 +65,7 @@ import {
 import { startSessionCleanup } from './session-cleanup.js';
 import { startSchedulerLoop } from './task-scheduler.js';
 import { Channel, NewMessage, RegisteredGroup } from './types.js';
+import { processAttachments, SavedAttachment } from './attachments.js';
 import { logger } from './logger.js';
 
 // Re-export for backwards compatibility during refactor
@@ -251,6 +253,23 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     if (!hasTrigger) return true;
   }
 
+  // --- Process attachments ---
+  let savedAttachments: SavedAttachment[] = [];
+
+  if (group.allowAttachments) {
+    savedAttachments = await processAttachments(
+      missedMessages,
+      group.folder,
+      ATTACHMENT_MAX_PER_MESSAGE,
+    );
+  } else {
+    for (const msg of missedMessages) {
+      if (msg.attachments?.length && !msg.content.trim()) {
+        msg.content = '[Attachment(s) sent but not enabled for this group]';
+      }
+    }
+  }
+
   const prompt = formatMessages(missedMessages, TIMEZONE);
 
   // Advance cursor so the piping path in startMessageLoop won't re-fetch
@@ -283,32 +302,38 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   let hadError = false;
   let outputSentToUser = false;
 
-  const output = await runAgent(group, prompt, chatJid, async (result) => {
-    // Streaming output callback — called for each agent result
-    if (result.result) {
-      const raw =
-        typeof result.result === 'string'
-          ? result.result
-          : JSON.stringify(result.result);
-      // Strip <internal>...</internal> blocks — agent uses these for internal reasoning
-      const text = raw.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
-      logger.info({ group: group.name }, `Agent output: ${raw.length} chars`);
-      if (text) {
-        await channel.sendMessage(chatJid, text);
-        outputSentToUser = true;
+  const output = await runAgent(
+    group,
+    prompt,
+    chatJid,
+    async (result) => {
+      // Streaming output callback — called for each agent result
+      if (result.result) {
+        const raw =
+          typeof result.result === 'string'
+            ? result.result
+            : JSON.stringify(result.result);
+        // Strip <internal>...</internal> blocks — agent uses these for internal reasoning
+        const text = raw.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
+        logger.info({ group: group.name }, `Agent output: ${raw.length} chars`);
+        if (text) {
+          await channel.sendMessage(chatJid, text);
+          outputSentToUser = true;
+        }
+        // Only reset idle timer on actual results, not session-update markers (result: null)
+        resetIdleTimer();
       }
-      // Only reset idle timer on actual results, not session-update markers (result: null)
-      resetIdleTimer();
-    }
 
-    if (result.status === 'success') {
-      queue.notifyIdle(chatJid);
-    }
+      if (result.status === 'success') {
+        queue.notifyIdle(chatJid);
+      }
 
-    if (result.status === 'error') {
-      hadError = true;
-    }
-  });
+      if (result.status === 'error') {
+        hadError = true;
+      }
+    },
+    { attachments: savedAttachments },
+  );
 
   await channel.setTyping?.(chatJid, false);
   if (idleTimer) clearTimeout(idleTimer);
@@ -341,6 +366,7 @@ async function runAgent(
   prompt: string,
   chatJid: string,
   onOutput?: (output: ContainerOutput) => Promise<void>,
+  options?: { attachments?: SavedAttachment[] },
 ): Promise<'success' | 'error'> {
   const isMain = group.isMain === true;
   const sessionId = sessions[group.folder];
@@ -392,6 +418,9 @@ async function runAgent(
         chatJid,
         isMain,
         assistantName: ASSISTANT_NAME,
+        ...(options?.attachments?.length && {
+          attachments: options.attachments,
+        }),
       },
       (proc, containerName) =>
         queue.registerProcess(chatJid, proc, containerName, group.folder),
@@ -512,6 +541,16 @@ async function startMessageLoop(): Promise<void> {
           );
           const messagesToSend =
             allPending.length > 0 ? allPending : groupMessages;
+
+          // Process attachments for piped messages (downloads in parallel, annotates content)
+          if (group.allowAttachments) {
+            await processAttachments(
+              messagesToSend,
+              group.folder,
+              ATTACHMENT_MAX_PER_MESSAGE,
+            );
+          }
+
           const formatted = formatMessages(messagesToSend, TIMEZONE);
 
           if (queue.sendMessage(chatJid, formatted)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,14 @@ export interface AllowedRoot {
   description?: string;
 }
 
+export interface Attachment {
+  url: string; // Download URL (channel-specific)
+  filename: string; // Original filename or fallback
+  mimeType?: string; // Channel-reported hint (validated later via magic bytes)
+  size?: number; // Optional size hint
+  authHeaders?: Record<string, string>; // Optional auth headers for download
+}
+
 export interface ContainerConfig {
   additionalMounts?: AdditionalMount[];
   timeout?: number; // Default: 300000 (5 minutes)
@@ -40,6 +48,7 @@ export interface RegisteredGroup {
   containerConfig?: ContainerConfig;
   requiresTrigger?: boolean; // Default: true for groups, false for solo chats
   isMain?: boolean; // True for the main control group (no trigger, elevated privileges)
+  allowAttachments?: boolean; // Default: false. Enable to download and process file attachments.
 }
 
 export interface NewMessage {
@@ -51,6 +60,7 @@ export interface NewMessage {
   timestamp: string;
   is_from_me?: boolean;
   is_bot_message?: boolean;
+  attachments?: Attachment[];
   thread_id?: string;
   reply_to_message_id?: string;
   reply_to_message_content?: string;


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Adds a complete, channel-agnostic attachment pipeline so any channel can pass file attachments to the agent. This is core message infrastructure — the same class of change as the reply/quoted message context support (ee599b9).

**How it works:** Channels populate `msg.attachments` on `NewMessage` with download URLs. The orchestrator handles everything else — download, validation, classification, container delivery.

### Pipeline

1. **Download** — parallel fetch with streaming 15MB size limit and 30s timeout
2. **Validate** — magic-byte MIME detection (not trusting channel-reported types)
3. **Classify** — inline (images, PDF, text → multimodal content blocks) vs file (everything else → saved to disk for agent tool access)
4. **Deliver** — inline attachments sent as Claude multimodal content blocks; file attachments referenced in message text with container-relative paths

### Changes

| File | What |
|------|------|
| `src/types.ts` | `Attachment` interface, `allowAttachments` on `RegisteredGroup`, `attachments` on `NewMessage` |
| `src/config.ts` | `ATTACHMENT_MAX_SIZE`, `ATTACHMENT_MAX_PER_MESSAGE` |
| `src/attachments.ts` | Core module: download, MIME detection, classification, filename sanitization, batch processing |
| `src/db.ts` | DB migrations (`attachments` column, `allow_attachments`), hydration, updated queries |
| `src/container-runner.ts` | `attachments` on `ContainerInput` |
| `src/index.ts` | Attachment processing in both `processGroupMessages` and piped-message path |
| `container/agent-runner/src/index.ts` | Multimodal content block construction from inline attachments |
| `scripts/cleanup-sessions.sh` | Attachment cleanup (14-day retention) |

### Design decisions

- **`allowAttachments` per-group opt-in** — defaults to true for main, false for others (bandwidth/privacy)
- **`authHeaders` on Attachment** — channels set auth per-attachment rather than a method on Channel, so different channels (or even different attachment URLs within one channel) can use different auth
- **No audio support** — Claude can't consume audio natively; channels that want transcription add it separately (e.g., `/add-voice-transcription` skill)
- **Cleanup via existing script** — reuses `scripts/cleanup-sessions.sh` rather than a separate timer

### Testing

- 16 new tests: MIME detection (magic bytes, extension fallback, priority), mode classification, DB attachment persistence round-trips, `allowAttachments` group round-trip
- All 269 existing tests pass

### Prior art

Supersedes #850 (interface only, no pipeline) and relates to #902 (manager abstraction). This PR provides the full end-to-end pipeline that those PRs established the groundwork for.