### PR TITLE
fix: match trigger after media prefixes like [Photo], [Video]

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -68,7 +68,8 @@ function escapeRegex(str: string): string {
 }
 
 export function buildTriggerPattern(trigger: string): RegExp {
-  return new RegExp(`^${escapeRegex(trigger.trim())}\\b`, 'i');
+  // Match trigger at start of message OR after a media prefix like [Photo], [Video], [Document: x.pdf]
+  return new RegExp(`(?:^|\\]\\s*)${escapeRegex(trigger.trim())}\\b`, 'i');
 }
 
 export const DEFAULT_TRIGGER = `@${ASSISTANT_NAME}`;

--- a/src/trigger-pattern.test.ts
+++ b/src/trigger-pattern.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+
+import { buildTriggerPattern, getTriggerPattern } from './config.js';
+
+describe('buildTriggerPattern', () => {
+  const pattern = buildTriggerPattern('@Carson');
+
+  it('matches trigger at start of message', () => {
+    expect(pattern.test('@Carson hello')).toBe(true);
+  });
+
+  it('matches trigger case-insensitively', () => {
+    expect(pattern.test('@carson hello')).toBe(true);
+  });
+
+  it('does not match trigger mid-word', () => {
+    expect(pattern.test('email@Carson.com')).toBe(false);
+  });
+
+  it('matches trigger after media prefix like [Photo]', () => {
+    expect(pattern.test('[Photo] @Carson what is this?')).toBe(true);
+  });
+
+  it('matches trigger after [Video] prefix', () => {
+    expect(pattern.test('[Video] @Carson check this')).toBe(true);
+  });
+
+  it('matches trigger after [Audio] prefix', () => {
+    expect(pattern.test('[Audio] @Carson listen to this')).toBe(true);
+  });
+
+  it('matches trigger after [Document: file.pdf] prefix', () => {
+    expect(pattern.test('[Document: report.pdf] @Carson review this')).toBe(
+      true,
+    );
+  });
+
+  it('does not match without trigger word', () => {
+    expect(pattern.test('hello world')).toBe(false);
+  });
+
+  it('does not match partial trigger', () => {
+    expect(pattern.test('@Carsonify something')).toBe(false);
+  });
+});
+
+describe('getTriggerPattern', () => {
+  it('uses custom trigger when provided', () => {
+    const pattern = getTriggerPattern('@Bot');
+    expect(pattern.test('@Bot hello')).toBe(true);
+    expect(pattern.test('@Carson hello')).toBe(false);
+  });
+
+  it('handles trigger after media prefix', () => {
+    const pattern = getTriggerPattern('@Bot');
+    expect(pattern.test('[Photo] @Bot what is this?')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Forwarded media messages prepend a bracketed prefix (e.g. `[Photo] @Bot hello`). The `^` anchor in `buildTriggerPattern` prevented matching after these prefixes, silently ignoring triggered messages with attachments.
- Replace start-of-string anchor with `(?:^|\]\s*)` to also match after a closing bracket.

## Test plan
- [x] Added `src/trigger-pattern.test.ts` with 11 tests covering: start-of-line match, case insensitivity, `[Photo]`, `[Video]`, `[Audio]`, `[Document: file.pdf]` prefixes, negative cases
- [x] All 11 new tests pass
- [x] Full test suite passes (369 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)