### PR TITLE
feat(skill): add deep mode for long-running container sessions

### DIFF
--- a/.claude/skills/add-deep-mode/SKILL.md
+++ b/.claude/skills/add-deep-mode/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: add-deep-mode
+description: Add /deep and /end commands for long-running container sessions. Suppresses idle timeout so containers stay alive for extended work (coding, research, document collaboration). 4-hour safety max.
+---
+
+# Add Deep Mode (Long-Running Sessions)
+
+Adds `/deep` and `/end` commands that suppress idle timeout on containers, keeping them alive for extended work sessions. Containers normally die after 30 min idle. Deep mode extends idle to 1 hour and sets a 4-hour absolute max.
+
+## Phase 1: Pre-flight
+
+Check if deep mode is already applied:
+
+```bash
+grep -q 'DEEP_MODE_IDLE_TIMEOUT' src/config.ts && echo "Already applied" || echo "Not applied"
+```
+
+If already applied, skip to Phase 3 (Verify).
+
+## Phase 2: Apply Code Changes
+
+Merge the skill branch:
+
+```bash
+git fetch upstream skill/deep-mode
+git merge upstream/skill/deep-mode
+```
+
+> **Note:** `upstream` is the remote pointing to `qwibitai/nanoclaw`. If using a different remote name, substitute accordingly.
+
+This adds:
+- `DEEP_MODE_IDLE_TIMEOUT` and `DEEP_MODE_MAX_DURATION` constants in `src/config.ts`
+- Deep mode state (`deepMode`, `deepModeStarted`) and methods (`enterDeepMode`, `exitDeepMode`, `isDeepMode`) in `src/group-queue.ts`
+- `deepMode` field in `ContainerInput` interface and deep-mode-aware timeout logic in `src/container-runner.ts`
+- `/deep` and `/end` command interception, `handleDeepMode()` function, deep watchdog timer, and conditional idle timeout in `src/index.ts`
+
+### Validate
+
+```bash
+npm run build
+```
+
+### Restart service
+
+```bash
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw  # macOS
+# Linux: systemctl --user restart nanoclaw
+```
+
+## Phase 3: Verify
+
+### Integration Test
+
+1. Start NanoClaw in dev mode: `npm run dev`
+2. From the **main group**, send exactly: `/deep`
+3. Verify:
+   - The bot responds with "Deep mode activated. Container will stay alive (up to 4h). Send /end to exit."
+   - The container stays alive after completing a response (no 30-min idle kill)
+   - Sending `/deep` again responds with "Deep mode is already active."
+4. Send a follow-up message and verify the agent responds normally
+5. Send exactly: `/end`
+6. Verify:
+   - The bot responds with "Deep mode ended. Container will shut down after normal idle timeout."
+   - The container shuts down after the normal idle period
+   - Sending `/end` again responds with "Deep mode is not active."
+7. Verify the **4-hour safety max**: deep mode containers are force-closed after 4 hours regardless of activity
+8. From a **non-main group** as a non-admin user, send `/deep`:
+9. Verify:
+   - The command is ignored (only main group or device owner can activate deep mode)
+   - The message is stored normally and does not trigger deep mode
+
+## Configuration
+
+Environment variables (all optional, sensible defaults):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DEEP_MODE_IDLE_TIMEOUT` | `3600000` (1h) | Idle timeout while deep mode is active |
+| `DEEP_MODE_MAX_DURATION` | `14400000` (4h) | Absolute max duration for deep mode sessions |
+
+## Security Constraints
+
+- **Main-group or device owner only.** Deep mode is a privileged operation — untrusted users in non-main groups cannot activate it.
+- **Safety max enforced.** A 4-hour absolute ceiling prevents runaway containers even if the user forgets to `/end`.
+- **Container hard timeout extended.** The container runtime timeout is set to `DEEP_MODE_MAX_DURATION + 60s` to allow graceful shutdown.
+- **Deep mode resets on container exit.** If a container dies for any reason, deep mode state is cleared automatically.
+
+## What This Does NOT Do
+
+- No auto-activation based on message content or session length
+- No per-group deep mode configuration (all groups share the same timeouts)
+- No changes to the container image, Dockerfile, or build script
+- No persistent deep mode state across restarts (deep mode is session-scoped)

--- a/src/config.ts
+++ b/src/config.ts
@@ -58,6 +58,14 @@ export const MAX_MESSAGES_PER_PROMPT = Math.max(
 );
 export const IPC_POLL_INTERVAL = 1000;
 export const IDLE_TIMEOUT = parseInt(process.env.IDLE_TIMEOUT || '1800000', 10); // 30min default — how long to keep container alive after last result
+export const DEEP_MODE_IDLE_TIMEOUT = parseInt(
+  process.env.DEEP_MODE_IDLE_TIMEOUT || '3600000',
+  10,
+); // 1 hour idle timeout in deep mode
+export const DEEP_MODE_MAX_DURATION = parseInt(
+  process.env.DEEP_MODE_MAX_DURATION || '14400000',
+  10,
+); // 4 hour absolute max for deep mode sessions
 export const MAX_CONCURRENT_CONTAINERS = Math.max(
   1,
   parseInt(process.env.MAX_CONCURRENT_CONTAINERS || '5', 10) || 5,

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -12,6 +12,7 @@ import {
   CONTAINER_TIMEOUT,
   DATA_DIR,
   GROUPS_DIR,
+  DEEP_MODE_MAX_DURATION,
   IDLE_TIMEOUT,
   ONECLI_URL,
   TIMEZONE,
@@ -43,6 +44,7 @@ export interface ContainerInput {
   isScheduledTask?: boolean;
   assistantName?: string;
   script?: string;
+  deepMode?: boolean;
 }
 
 export interface ContainerOutput {
@@ -442,7 +444,10 @@ export async function runContainerAgent(
     const configTimeout = group.containerConfig?.timeout || CONTAINER_TIMEOUT;
     // Grace period: hard timeout must be at least IDLE_TIMEOUT + 30s so the
     // graceful _close sentinel has time to trigger before the hard kill fires.
-    const timeoutMs = Math.max(configTimeout, IDLE_TIMEOUT + 30_000);
+    // Deep mode uses a fixed ceiling based on DEEP_MODE_MAX_DURATION.
+    const timeoutMs = input.deepMode
+      ? DEEP_MODE_MAX_DURATION + 60_000
+      : Math.max(configTimeout, IDLE_TIMEOUT + 30_000);
 
     const killOnTimeout = () => {
       timedOut = true;
@@ -463,11 +468,14 @@ export async function runContainerAgent(
 
     let timeout = setTimeout(killOnTimeout, timeoutMs);
 
-    // Reset the timeout whenever there's activity (streaming output)
-    const resetTimeout = () => {
-      clearTimeout(timeout);
-      timeout = setTimeout(killOnTimeout, timeoutMs);
-    };
+    // Reset the timeout whenever there's activity (streaming output).
+    // In deep mode the ceiling is fixed — no resets (safety max).
+    const resetTimeout = input.deepMode
+      ? () => {}
+      : () => {
+          clearTimeout(timeout);
+          timeout = setTimeout(killOnTimeout, timeoutMs);
+        };
 
     container.on('close', (code) => {
       clearTimeout(timeout);

--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -25,6 +25,8 @@ interface GroupState {
   containerName: string | null;
   groupFolder: string | null;
   retryCount: number;
+  deepMode: boolean;
+  deepModeStarted: number;
 }
 
 export class GroupQueue {
@@ -49,6 +51,8 @@ export class GroupQueue {
         containerName: null,
         groupFolder: null,
         retryCount: 0,
+        deepMode: false,
+        deepModeStarted: 0,
       };
       this.groups.set(groupJid, state);
     }
@@ -104,7 +108,7 @@ export class GroupQueue {
 
     if (state.active) {
       state.pendingTasks.push({ id: taskId, groupJid, fn });
-      if (state.idleWaiting) {
+      if (state.idleWaiting && !state.deepMode) {
         this.closeStdin(groupJid);
       }
       logger.debug({ groupJid, taskId }, 'Container active, task queued');
@@ -193,6 +197,25 @@ export class GroupQueue {
     }
   }
 
+  enterDeepMode(groupJid: string): void {
+    const state = this.getGroup(groupJid);
+    state.deepMode = true;
+    state.deepModeStarted = Date.now();
+    logger.info({ groupJid }, 'Deep mode activated');
+  }
+
+  exitDeepMode(groupJid: string): void {
+    const state = this.getGroup(groupJid);
+    state.deepMode = false;
+    state.deepModeStarted = 0;
+    logger.info({ groupJid }, 'Deep mode deactivated');
+  }
+
+  isDeepMode(groupJid: string): boolean {
+    const state = this.groups.get(groupJid);
+    return state?.deepMode ?? false;
+  }
+
   private async runForGroup(
     groupJid: string,
     reason: 'messages' | 'drain',
@@ -226,6 +249,8 @@ export class GroupQueue {
       state.process = null;
       state.containerName = null;
       state.groupFolder = null;
+      state.deepMode = false;
+      state.deepModeStarted = 0;
       this.activeCount--;
       this.drainGroup(groupJid);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ import { OneCLI } from '@onecli-sh/sdk';
 import {
   ASSISTANT_NAME,
   DEFAULT_TRIGGER,
+  DEEP_MODE_IDLE_TIMEOUT,
+  DEEP_MODE_MAX_DURATION,
   getTriggerPattern,
   GROUPS_DIR,
   IDLE_TIMEOUT,
@@ -77,6 +79,7 @@ let messageLoopRunning = false;
 
 const channels: Channel[] = [];
 const queue = new GroupQueue();
+const pendingDeepMode = new Set<string>();
 
 const onecli = new OneCLI({ url: ONECLI_URL });
 
@@ -265,23 +268,48 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     'Processing messages',
   );
 
-  // Track idle timer for closing stdin when agent is idle
+  // Track idle timer for closing stdin when agent is idle.
+  // Deep mode uses a longer idle timeout to keep the container alive.
   let idleTimer: ReturnType<typeof setTimeout> | null = null;
+  let deepWatchdog: ReturnType<typeof setTimeout> | null = null;
 
   const resetIdleTimer = () => {
     if (idleTimer) clearTimeout(idleTimer);
+    const idleMs = queue.isDeepMode(chatJid)
+      ? DEEP_MODE_IDLE_TIMEOUT
+      : IDLE_TIMEOUT;
     idleTimer = setTimeout(() => {
       logger.debug(
-        { group: group.name },
+        { group: group.name, deepMode: queue.isDeepMode(chatJid) },
         'Idle timeout, closing container stdin',
       );
       queue.closeStdin(chatJid);
-    }, IDLE_TIMEOUT);
+    }, idleMs);
   };
+
+  // Safety watchdog: if deep mode is active, enforce absolute max duration
+  if (queue.isDeepMode(chatJid)) {
+    deepWatchdog = setTimeout(() => {
+      logger.warn(
+        { group: group.name },
+        'Deep mode max duration reached, closing container',
+      );
+      queue.exitDeepMode(chatJid);
+      pendingDeepMode.delete(chatJid);
+      queue.closeStdin(chatJid);
+    }, DEEP_MODE_MAX_DURATION);
+  }
 
   await channel.setTyping?.(chatJid, true);
   let hadError = false;
   let outputSentToUser = false;
+
+  // Activate pending deep mode when the container starts
+  const isDeep = pendingDeepMode.has(chatJid) || queue.isDeepMode(chatJid);
+  if (pendingDeepMode.has(chatJid)) {
+    pendingDeepMode.delete(chatJid);
+    queue.enterDeepMode(chatJid);
+  }
 
   const output = await runAgent(group, prompt, chatJid, async (result) => {
     // Streaming output callback — called for each agent result
@@ -308,10 +336,11 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     if (result.status === 'error') {
       hadError = true;
     }
-  });
+  }, isDeep);
 
   await channel.setTyping?.(chatJid, false);
   if (idleTimer) clearTimeout(idleTimer);
+  if (deepWatchdog) clearTimeout(deepWatchdog);
 
   if (output === 'error' || hadError) {
     // If we already sent output to the user, don't roll back the cursor —
@@ -341,6 +370,7 @@ async function runAgent(
   prompt: string,
   chatJid: string,
   onOutput?: (output: ContainerOutput) => Promise<void>,
+  deepMode?: boolean,
 ): Promise<'success' | 'error'> {
   const isMain = group.isMain === true;
   const sessionId = sessions[group.folder];
@@ -392,6 +422,7 @@ async function runAgent(
         chatJid,
         isMain,
         assistantName: ASSISTANT_NAME,
+        deepMode,
       },
       (proc, containerName) =>
         queue.registerProcess(chatJid, proc, containerName, group.folder),
@@ -435,6 +466,48 @@ async function runAgent(
   } catch (err) {
     logger.error({ group: group.name, err }, 'Agent error');
     return 'error';
+  }
+}
+
+/**
+ * Handle /deep and /end commands — toggle deep mode for a group's container.
+ * Deep mode suppresses idle timeout, keeping the container alive for extended
+ * work sessions (coding, research, document collaboration).
+ */
+async function handleDeepMode(
+  command: string,
+  chatJid: string,
+  channel: Channel,
+): Promise<void> {
+  if (command === '/deep') {
+    if (queue.isDeepMode(chatJid)) {
+      await channel.sendMessage(chatJid, 'Deep mode is already active.');
+      return;
+    }
+    // If no container is running yet, mark as pending so the next
+    // container launch picks it up.
+    pendingDeepMode.add(chatJid);
+    queue.enterDeepMode(chatJid);
+    const maxHours = DEEP_MODE_MAX_DURATION / 3_600_000;
+    await channel.sendMessage(
+      chatJid,
+      `Deep mode activated. Container will stay alive (up to ${maxHours}h). Send /end to exit.`,
+    );
+    logger.info({ chatJid }, 'Deep mode activated via /deep command');
+  } else {
+    // /end
+    if (!queue.isDeepMode(chatJid)) {
+      await channel.sendMessage(chatJid, 'Deep mode is not active.');
+      return;
+    }
+    pendingDeepMode.delete(chatJid);
+    queue.exitDeepMode(chatJid);
+    queue.closeStdin(chatJid);
+    await channel.sendMessage(
+      chatJid,
+      'Deep mode ended. Container will shut down after normal idle timeout.',
+    );
+    logger.info({ chatJid }, 'Deep mode deactivated via /end command');
   }
 }
 
@@ -644,6 +717,20 @@ async function main(): Promise<void> {
           logger.error({ err, chatJid }, 'Remote control command error'),
         );
         return;
+      }
+
+      // Deep mode commands — intercept before storage
+      if (trimmed === '/deep' || trimmed === '/end') {
+        const group = registeredGroups[chatJid];
+        if (group?.isMain || msg.is_from_me) {
+          const ch = findChannel(channels, chatJid);
+          if (ch) {
+            handleDeepMode(trimmed, chatJid, ch).catch((err) =>
+              logger.error({ err, chatJid }, 'Deep mode command error'),
+            );
+            return;
+          }
+        }
       }
 
       // Sender allowlist drop mode: discard messages from denied senders before storing


### PR DESCRIPTION
## Summary

- Adds `/deep` and `/end` commands for long-running container sessions
- Containers normally die after 30 min idle; deep mode extends to 1-hour idle with 4-hour absolute max
- Keeps the container alive across many message turns — preserving reasoning chain, tool call results, and progressive context (like a continuous Claude Code session)
- Scheduled tasks queue during deep mode and run after `/end`

Closes #1686

## How it works

The container already stays alive between messages via IPC polling (`waitForIpcMessage` loop in agent-runner). The only thing killing it is the idle timeout + hard timeout. Deep mode suppresses both:

- `DEEP_MODE_IDLE_TIMEOUT` (1 hour) replaces `IDLE_TIMEOUT` (30 min)
- `DEEP_MODE_MAX_DURATION` (4 hours) sets a fixed ceiling on the hard timeout (no reset on activity)
- `GroupState.deepMode` flag prevents task preemption of active sessions
- `pendingDeepMode` handles the case where no container is running when `/deep` is sent

## Files changed

| File | What |
|------|------|
| `src/config.ts` | `DEEP_MODE_IDLE_TIMEOUT`, `DEEP_MODE_MAX_DURATION` constants |
| `src/group-queue.ts` | `deepMode` state, `enterDeepMode()`/`exitDeepMode()`/`isDeepMode()` methods |
| `src/container-runner.ts` | `deepMode` in ContainerInput, extended hard timeout, no-op resetTimeout |
| `src/index.ts` | `/deep` + `/end` command handling, conditional idle timer, deep watchdog, `runAgent` threading |
| `.claude/skills/add-deep-mode/SKILL.md` | Feature skill for installation |

## How it was tested

- `/deep` in a Telegram topic → container stays alive past normal 30-min idle timeout
- Multiple messages over 35+ min → container persists, full reasoning chain maintained
- `/end` → container shuts down gracefully via `_close` sentinel
- Scheduled tasks queue during deep mode, run after exit
- `npm run build` passes cleanly

## Usage

```
/deep    — activate deep mode (container stays alive, 1h idle, 4h max)
/end     — exit deep mode, shut down container
```

Best for coding sessions, deep research, or multi-step document collaboration where losing context between invocations hurts quality.

## PR type

- [x] Feature skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)