### PR TITLE
fix: inject ANTHROPIC_API_KEY into new group settings.json from process.env

### DIFF
--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -107,6 +107,7 @@ vi.mock('child_process', async () => {
 
 import { runContainerAgent, ContainerOutput } from './container-runner.js';
 import type { RegisteredGroup } from './types.js';
+import fs from 'fs';
 
 const testGroup: RegisteredGroup = {
   name: 'Test Group',
@@ -225,5 +226,100 @@ describe('container-runner timeout behavior', () => {
     const result = await resultPromise;
     expect(result.status).toBe('success');
     expect(result.newSessionId).toBe('session-456');
+  });
+});
+
+describe('settings.json ANTHROPIC_API_KEY injection', () => {
+  const originalEnv = process.env.ANTHROPIC_API_KEY;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fakeProc = createFakeProcess();
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    vi.mocked(fs.writeFileSync).mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (originalEnv !== undefined) {
+      process.env.ANTHROPIC_API_KEY = originalEnv;
+    } else {
+      delete process.env.ANTHROPIC_API_KEY;
+    }
+  });
+
+  function getSettingsJson(): Record<string, unknown> | undefined {
+    const calls = vi.mocked(fs.writeFileSync).mock.calls;
+    const settingsCall = calls.find(
+      (c) => typeof c[0] === 'string' && c[0].endsWith('settings.json'),
+    );
+    if (!settingsCall) return undefined;
+    return JSON.parse(settingsCall[1] as string);
+  }
+
+  it('injects ANTHROPIC_API_KEY when env var is set', async () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key-123';
+
+    const resultPromise = runContainerAgent(
+      testGroup,
+      testInput,
+      () => {},
+      async () => {},
+    );
+
+    emitOutputMarker(fakeProc, { status: 'success', result: 'ok' });
+    await vi.advanceTimersByTimeAsync(10);
+    fakeProc.emit('close', 0);
+    await vi.advanceTimersByTimeAsync(10);
+    await resultPromise;
+
+    const settings = getSettingsJson();
+    expect(settings).toBeDefined();
+    const env = (settings as any).env;
+    expect(env.ANTHROPIC_API_KEY).toBe('sk-ant-test-key-123');
+  });
+
+  it('omits ANTHROPIC_API_KEY when env var is not set', async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+
+    const resultPromise = runContainerAgent(
+      testGroup,
+      testInput,
+      () => {},
+      async () => {},
+    );
+
+    emitOutputMarker(fakeProc, { status: 'success', result: 'ok' });
+    await vi.advanceTimersByTimeAsync(10);
+    fakeProc.emit('close', 0);
+    await vi.advanceTimersByTimeAsync(10);
+    await resultPromise;
+
+    const settings = getSettingsJson();
+    expect(settings).toBeDefined();
+    const env = (settings as any).env;
+    expect(env).not.toHaveProperty('ANTHROPIC_API_KEY');
+  });
+
+  it('omits ANTHROPIC_API_KEY when env var is empty/whitespace', async () => {
+    process.env.ANTHROPIC_API_KEY = '   ';
+
+    const resultPromise = runContainerAgent(
+      testGroup,
+      testInput,
+      () => {},
+      async () => {},
+    );
+
+    emitOutputMarker(fakeProc, { status: 'success', result: 'ok' });
+    await vi.advanceTimersByTimeAsync(10);
+    fakeProc.emit('close', 0);
+    await vi.advanceTimersByTimeAsync(10);
+    await resultPromise;
+
+    const settings = getSettingsJson();
+    expect(settings).toBeDefined();
+    const env = (settings as any).env;
+    expect(env).not.toHaveProperty('ANTHROPIC_API_KEY');
   });
 });

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -159,6 +159,11 @@ function buildVolumeMounts(
             // Enable Claude's memory feature (persists user preferences between sessions)
             // https://code.claude.com/docs/en/memory#manage-auto-memory
             CLAUDE_CODE_DISABLE_AUTO_MEMORY: '0',
+            // Inject API key so agent containers can authenticate with Anthropic
+            ...(process.env.ANTHROPIC_API_KEY &&
+            process.env.ANTHROPIC_API_KEY.trim().length > 0
+              ? { ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY.trim() }
+              : {}),
           },
         },
         null,


### PR DESCRIPTION
## Problem

New group sessions are created without ANTHROPIC_API_KEY in their
.claude/settings.json, causing Claude Code to report "Not logged in"
on first message. This requires manual file editing for every new group
registration — a poor experience for fresh installs via Unraid CA or
any other deployment.

## Fix

Inject ANTHROPIC_API_KEY from process.env into settings.json at creation
time, when the var is set and non-empty. Whitespace-only values are
rejected. Only affects new file creation — existing settings.json files
are untouched.

## Tests

Three new test cases in container-runner.test.ts:
- injects ANTHROPIC_API_KEY when env var is set
- omits ANTHROPIC_API_KEY when env var is not set
- omits ANTHROPIC_API_KEY when env var is empty/whitespace

All 6 tests pass (3 existing + 3 new).

## Test plan

- [x] `npx vitest run src/container-runner.test.ts` — 6/6 pass
- [x] `npx tsc --noEmit` — clean
- [x] Existing settings.json files are not modified (guarded by `existsSync`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)