### PR TITLE
feat: GitHub Copilot SDK integration as alternative AI backend

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -140,9 +140,26 @@ Run `npx tsx setup/index.ts --step container -- --runtime <chosen>` and parse th
 
 ## 4. Credential System
 
-The credential system depends on the container runtime chosen in step 3.
+### 4-pre. Choose AI backend
 
-### 4a. Docker → OneCLI
+AskUserQuestion: Which AI backend do you want to use?
+
+1. **Claude (Anthropic)** — description: "Uses Anthropic's Claude models via the Claude Agent SDK. Requires a Claude subscription or Anthropic API key."
+2. **GitHub Copilot** — description: "Uses GitHub Copilot models (GPT-4.1, etc.) via the Copilot SDK. Requires a GitHub Copilot subscription."
+
+Set `NANOCLAW_SDK` in `.env`:
+- Claude: `NANOCLAW_SDK=claude` (or omit — it's the default)
+- Copilot: `NANOCLAW_SDK=copilot`
+
+For Copilot, also ask which model:
+```bash
+grep -q 'COPILOT_MODEL' .env 2>/dev/null || echo 'COPILOT_MODEL=gpt-4.1' >> .env
+```
+
+**If Claude:** continue to 4a.
+**If Copilot:** skip to 4c.
+
+### 4a. Claude + Docker → OneCLI
 
 Install OneCLI and its CLI tool:
 
@@ -213,6 +230,53 @@ Ask them to let you know when done.
 **If the user's response happens to contain a token or key** (starts with `sk-ant-`): handle it gracefully — run the `onecli secrets create` command with that value on their behalf.
 
 **After user confirms:** verify with `onecli secrets list` that an Anthropic secret exists. If not, ask again.
+
+### 4c. GitHub Copilot → Copilot CLI auth
+
+OneCLI is still needed (the container proxy infrastructure requires it), but no Anthropic secret is needed. Install OneCLI if not already installed (same commands as 4a), then configure:
+
+```bash
+grep -q 'ONECLI_URL' .env 2>/dev/null || echo 'ONECLI_URL=http://127.0.0.1:10254' >> .env
+```
+
+#### Copilot authentication
+
+The Copilot SDK reads OAuth credentials from `~/.copilot/config.json`, which is mounted read-only into containers. The user must authenticate with the Copilot CLI.
+
+Check if already authenticated:
+```bash
+test -f ~/.copilot/config.json && node -e "const c=JSON.parse(require('fs').readFileSync(require('os').homedir()+'/.copilot/config.json','utf-8')); console.log(c.copilot_tokens ? 'AUTHENTICATED' : 'NOT_AUTHENTICATED')" 2>/dev/null || echo "NOT_AUTHENTICATED"
+```
+
+**If NOT_AUTHENTICATED:**
+
+Tell the user:
+
+> You need to authenticate with the Copilot CLI. On Linux, the token must be stored as a file (not just in the system keyring) so Docker containers can read it.
+
+**Linux:**
+```bash
+DBUS_SESSION_BUS_ADDRESS= copilot login
+```
+The `DBUS_SESSION_BUS_ADDRESS=` prefix disables the system keyring so the token is saved to `~/.copilot/config.json` as a plain text file.
+
+**macOS:**
+```bash
+copilot login
+```
+macOS Keychain is not accessible from Docker containers, so also use the env var trick:
+```bash
+DBUS_SESSION_BUS_ADDRESS= copilot login
+```
+
+Wait for the user to confirm they've completed the login.
+
+**After login:** verify:
+```bash
+node -e "const c=JSON.parse(require('fs').readFileSync(require('os').homedir()+'/.copilot/config.json','utf-8')); console.log(c.copilot_tokens ? 'OK' : 'MISSING')"
+```
+
+If `MISSING`, ask the user to re-run `copilot login` with the `DBUS_SESSION_BUS_ADDRESS=` prefix.
 
 ### 4b. Apple Container → Native Credential Proxy
 

--- a/container/agent-runner/package-lock.json
+++ b/container/agent-runner/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.92",
+        "@github/copilot-sdk": "^0.2.0",
         "@modelcontextprotocol/sdk": "^1.12.1",
         "cron-parser": "^5.0.0",
         "zod": "^4.0.0"
@@ -19,9 +20,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.92",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.92.tgz",
-      "integrity": "sha512-loYyxVUC5gBwHjGi9Fv0b84mduJTp9Z3Pum+y/7IVQDb4NynKfVQl6l4VeDKZaW+1QTQtd25tY4hwUznD7Krqw==",
+      "version": "0.2.97",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.97.tgz",
+      "integrity": "sha512-754teaU0nfrn9BC0YWzPjSbJj253GfPUtuUnkrde7LGsaKtFSjEEuQJq5skJvpozqcn+B8frrtWVPkvFdnupTw==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.80.0",
@@ -72,6 +73,133 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@github/copilot": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.10.tgz",
+      "integrity": "sha512-RpHYMXYpyAgQLYQ3MB8ubV8zMn/zDatwaNmdxcC8ws7jqM+Ojy7Dz4KFKzyT0rCrWoUCAEBXsXoPbP0LY0FgLw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "bin": {
+        "copilot": "npm-loader.js"
+      },
+      "optionalDependencies": {
+        "@github/copilot-darwin-arm64": "1.0.10",
+        "@github/copilot-darwin-x64": "1.0.10",
+        "@github/copilot-linux-arm64": "1.0.10",
+        "@github/copilot-linux-x64": "1.0.10",
+        "@github/copilot-win32-arm64": "1.0.10",
+        "@github/copilot-win32-x64": "1.0.10"
+      }
+    },
+    "node_modules/@github/copilot-darwin-arm64": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.10.tgz",
+      "integrity": "sha512-MNlzwkTQ9iUgHQ+2Z25D0KgYZDEl4riEa1Z4/UCNpHXmmBiIY8xVRbXZTNMB69cnagjQ5Z8D2QM2BjI0kqeFPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-darwin-x64": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.10.tgz",
+      "integrity": "sha512-zAQBCbEue/n4xHBzE9T03iuupVXvLtu24MDMeXXtIC0d4O+/WV6j1zVJrp9Snwr0MBWYH+wUrV74peDDdd1VOQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-arm64": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.10.tgz",
+      "integrity": "sha512-7mJ3uLe7ITyRi2feM1rMLQ5d0bmUGTUwV1ZxKZwSzWCYmuMn05pg4fhIUdxZZZMkLbOl3kG/1J7BxMCTdS2w7A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-x64": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.10.tgz",
+      "integrity": "sha512-66NPaxroRScNCs6TZGX3h1RSKtzew0tcHBkj4J1AHkgYLjNHMdjjBwokGtKeMxzYOCAMBbmJkUDdNGkqsKIKUA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-sdk": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.2.0.tgz",
+      "integrity": "sha512-fCEpD9W9xqcaCAJmatyNQ1PkET9P9liK2P4Vk0raDFoMXcvpIdqewa5JQeKtWCBUsN/HCz7ExkkFP8peQuo+DA==",
+      "license": "MIT",
+      "dependencies": {
+        "@github/copilot": "^1.0.10",
+        "vscode-jsonrpc": "^8.2.1",
+        "zod": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@github/copilot-win32-arm64": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.10.tgz",
+      "integrity": "sha512-WC5M+M75sxLn4lvZ1wPA1Lrs/vXFisPXJPCKbKOMKqzwMLX/IbuybTV4dZDIyGEN591YmOdRIylUF0tVwO8Zmw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-arm64": "copilot.exe"
+      }
+    },
+    "node_modules/@github/copilot-win32-x64": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.10.tgz",
+      "integrity": "sha512-tUfIwyamd0zpm9DVTtbjIWF6j3zrA5A5IkkiuRgsy0HRJPQpeAV7ZYaHEZteHrynaULpl1Gn/Dq0IB4hYc4QtQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-x64": "copilot.exe"
       }
     },
     "node_modules/@hono/node-server": {
@@ -1531,6 +1659,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
+      "integrity": "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/which": {

--- a/container/agent-runner/package.json
+++ b/container/agent-runner/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.92",
+    "@github/copilot-sdk": "^0.2.0",
     "@modelcontextprotocol/sdk": "^1.12.1",
     "cron-parser": "^5.0.0",
     "zod": "^4.0.0"

--- a/container/agent-runner/src/copilot-query.ts
+++ b/container/agent-runner/src/copilot-query.ts
@@ -1,0 +1,221 @@
+/**
+ * GitHub Copilot SDK query adapter for NanoClaw
+ *
+ * Provides a query interface compatible with the agent-runner's main loop,
+ * using the GitHub Copilot SDK instead of the Anthropic Claude Agent SDK.
+ *
+ * The Copilot SDK supports MCP servers, tools, session resumption, and streaming,
+ * enabling feature parity with the Claude integration.
+ */
+
+import {
+  CopilotClient,
+  approveAll,
+  type SessionEvent,
+  type SessionConfig,
+  type MCPServerConfig,
+} from '@github/copilot-sdk';
+import fs from 'fs';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface ContainerInput {
+  prompt: string;
+  sessionId?: string;
+  groupFolder: string;
+  chatJid: string;
+  isMain: boolean;
+  isScheduledTask?: boolean;
+  assistantName?: string;
+}
+
+interface ContainerOutput {
+  status: 'success' | 'error';
+  result: string | null;
+  newSessionId?: string;
+  error?: string;
+}
+
+interface CopilotQueryResult {
+  newSessionId?: string;
+  closedDuringQuery: boolean;
+}
+
+type WriteOutputFn = (output: ContainerOutput) => void;
+type LogFn = (message: string) => void;
+type ShouldCloseFn = () => boolean;
+type DrainIpcFn = () => string[];
+
+// ---------------------------------------------------------------------------
+// Copilot client singleton (reused across queries within one container run)
+// ---------------------------------------------------------------------------
+
+let copilotClient: CopilotClient | null = null;
+
+function getCopilotClient(): CopilotClient {
+  if (!copilotClient) {
+    copilotClient = new CopilotClient({
+      autoStart: true,
+      logLevel: 'error',
+    });
+  }
+  return copilotClient;
+}
+
+export async function stopCopilotClient(): Promise<void> {
+  if (copilotClient) {
+    try {
+      await copilotClient.stop();
+    } catch {
+      // ignore stop errors
+    }
+    copilotClient = null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Query implementation
+// ---------------------------------------------------------------------------
+
+export async function runCopilotQuery(
+  prompt: string,
+  sessionId: string | undefined,
+  mcpServerPath: string,
+  containerInput: ContainerInput,
+  _sdkEnv: Record<string, string | undefined>,
+  writeOutput: WriteOutputFn,
+  log: LogFn,
+  shouldClose: ShouldCloseFn,
+  drainIpcInput: DrainIpcFn,
+  ipcPollMs: number,
+): Promise<CopilotQueryResult> {
+  const client = getCopilotClient();
+
+  // Log authentication method
+  if (process.env.GITHUB_TOKEN) {
+    log('Copilot auth: using GITHUB_TOKEN env var');
+  } else if (fs.existsSync('/home/node/.copilot')) {
+    log('Copilot auth: using OAuth credentials from ~/.copilot/');
+  } else {
+    log('Warning: No Copilot authentication found (set GITHUB_TOKEN or run copilot auth login)');
+  }
+
+  // Build MCP server config matching what Claude gets
+  const mcpServers: Record<string, MCPServerConfig> = {
+    nanoclaw: {
+      type: 'local',
+      tools: ['*'],
+      command: 'node',
+      args: [mcpServerPath],
+      env: {
+        NANOCLAW_CHAT_JID: containerInput.chatJid,
+        NANOCLAW_GROUP_FOLDER: containerInput.groupFolder,
+        NANOCLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
+      },
+    },
+  };
+
+  // Load global CLAUDE.md as system context
+  const globalClaudeMdPath = '/workspace/global/CLAUDE.md';
+  let systemMessage: string | undefined;
+  if (!containerInput.isMain && fs.existsSync(globalClaudeMdPath)) {
+    systemMessage = fs.readFileSync(globalClaudeMdPath, 'utf-8');
+  }
+
+  // Build session config
+  const model = process.env.COPILOT_MODEL || 'gpt-4.1';
+  const sessionConfig: SessionConfig = {
+    model,
+    streaming: true,
+    mcpServers,
+    onPermissionRequest: approveAll,
+    ...(systemMessage ? { systemMessage: { content: systemMessage } } : {}),
+  };
+
+  log(`Creating Copilot session (model: ${model}, resume: ${sessionId || 'new'})`);
+
+  // Create or resume session
+  const session = sessionId
+    ? await client.resumeSession(sessionId, { model, onPermissionRequest: approveAll })
+    : await client.createSession(sessionConfig);
+
+  const newSessionId = session.sessionId;
+  log(`Copilot session ready: ${newSessionId}`);
+
+  // Track IPC polling and close sentinel
+  let ipcPolling = true;
+  let closedDuringQuery = false;
+
+  const pollIpcDuringQuery = () => {
+    if (!ipcPolling) return;
+    if (shouldClose()) {
+      log('Close sentinel detected during Copilot query');
+      closedDuringQuery = true;
+      ipcPolling = false;
+      return;
+    }
+    const messages = drainIpcInput();
+    for (const text of messages) {
+      log(`Piping IPC message into Copilot session (${text.length} chars)`);
+      session.send({ prompt: text }).catch((err: Error) => {
+        log(`Failed to pipe IPC message: ${err.message}`);
+      });
+    }
+    setTimeout(pollIpcDuringQuery, ipcPollMs);
+  };
+  setTimeout(pollIpcDuringQuery, ipcPollMs);
+
+  // Send prompt and collect response via events
+  return new Promise<CopilotQueryResult>((resolve, reject) => {
+    let resultEmitted = false;
+
+    session.on((event: SessionEvent) => {
+      if (event.type === 'assistant.message') {
+        const content = event.data.content || '';
+        if (content) {
+          log(`Copilot result (${content.length} chars): ${content.slice(0, 200)}`);
+          writeOutput({
+            status: 'success',
+            result: content,
+            newSessionId,
+          });
+          resultEmitted = true;
+        }
+      } else if (event.type === 'assistant.message_delta') {
+        // Streaming delta — logged but not emitted as separate output.
+        // The final assistant.message contains the full content.
+      } else if (event.type === 'session.idle') {
+        ipcPolling = false;
+
+        if (!resultEmitted) {
+          // Session completed without emitting a result (e.g. tool-only turn)
+          writeOutput({
+            status: 'success',
+            result: null,
+            newSessionId,
+          });
+        }
+
+        resolve({ newSessionId, closedDuringQuery });
+      } else if (event.type === 'session.error') {
+        ipcPolling = false;
+        const errorMsg = event.data.message || 'Copilot session error';
+        log(`Copilot error: ${errorMsg}`);
+        writeOutput({
+          status: 'error',
+          result: null,
+          newSessionId,
+          error: errorMsg,
+        });
+        resolve({ newSessionId, closedDuringQuery });
+      }
+    });
+
+    session.send({ prompt }).catch((err: Error) => {
+      ipcPolling = false;
+      reject(err);
+    });
+  });
+}

--- a/container/agent-runner/src/copilot-query.ts
+++ b/container/agent-runner/src/copilot-query.ts
@@ -129,6 +129,7 @@ export async function runCopilotQuery(
   const sessionConfig: SessionConfig = {
     model,
     streaming: true,
+    workingDirectory: '/workspace/group',
     mcpServers,
     onPermissionRequest: approveAll,
     ...(systemMessage ? { systemMessage: { content: systemMessage } } : {}),

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -23,6 +23,7 @@ import {
   PreCompactHookInput,
 } from '@anthropic-ai/claude-agent-sdk';
 import { fileURLToPath } from 'url';
+import { runCopilotQuery, stopCopilotClient } from './copilot-query.js';
 
 interface ContainerInput {
   prompt: string;
@@ -63,6 +64,12 @@ interface SDKUserMessage {
 const IPC_INPUT_DIR = '/workspace/ipc/input';
 const IPC_INPUT_CLOSE_SENTINEL = path.join(IPC_INPUT_DIR, '_close');
 const IPC_POLL_MS = 500;
+
+/**
+ * Which SDK to use for agent queries.
+ * Set via NANOCLAW_SDK env var: 'claude' (default) or 'copilot'.
+ */
+const SDK_BACKEND = (process.env.NANOCLAW_SDK || 'claude').toLowerCase();
 
 /**
  * Push-based async iterable for streaming user messages to the SDK.
@@ -676,20 +683,30 @@ async function main(): Promise<void> {
 
   // Query loop: run query → wait for IPC message → run new query → repeat
   let resumeAt: string | undefined;
+  log(`Using SDK backend: ${SDK_BACKEND}`);
   try {
     while (true) {
       log(
         `Starting query (session: ${sessionId || 'new'}, resumeAt: ${resumeAt || 'latest'})...`,
       );
 
-      const queryResult = await runQuery(
-        prompt,
-        sessionId,
-        mcpServerPath,
-        containerInput,
-        sdkEnv,
-        resumeAt,
-      );
+      let queryResult: { newSessionId?: string; lastAssistantUuid?: string; closedDuringQuery: boolean };
+
+      if (SDK_BACKEND === 'copilot') {
+        queryResult = await runCopilotQuery(
+          prompt, sessionId, mcpServerPath, containerInput, sdkEnv,
+          writeOutput, log, shouldClose, drainIpcInput, IPC_POLL_MS,
+        );
+      } else {
+        queryResult = await runQuery(
+          prompt,
+          sessionId,
+          mcpServerPath,
+          containerInput,
+          sdkEnv,
+          resumeAt,
+        );
+      }
       if (queryResult.newSessionId) {
         sessionId = queryResult.newSessionId;
       }
@@ -730,6 +747,10 @@ async function main(): Promise<void> {
       error: errorMessage,
     });
     process.exit(1);
+  } finally {
+    if (SDK_BACKEND === 'copilot') {
+      await stopCopilotClient();
+    }
   }
 }
 

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -229,6 +229,16 @@ function buildVolumeMounts(
     readonly: false,
   });
 
+  // Mount Copilot CLI OAuth credentials if available (from `copilot auth login`)
+  const copilotAuthDir = path.join(process.env.HOME || '/root', '.copilot');
+  if (fs.existsSync(copilotAuthDir)) {
+    mounts.push({
+      hostPath: copilotAuthDir,
+      containerPath: '/home/node/.copilot',
+      readonly: true,
+    });
+  }
+
   // Additional mounts validated against external allowlist (tamper-proof from containers)
   if (group.containerConfig?.additionalMounts) {
     const validatedMounts = validateAdditionalMounts(
@@ -265,6 +275,22 @@ async function buildContainerArgs(
       { containerName },
       'OneCLI gateway not reachable — container will have no credentials',
     );
+  }
+
+  // Pass GITHUB_TOKEN for GitHub Copilot SDK and gh CLI
+  const githubToken = process.env.GITHUB_TOKEN;
+  if (githubToken) {
+    args.push('-e', `GITHUB_TOKEN=${githubToken}`);
+  }
+
+  // Pass SDK backend selection and Copilot model for container agents
+  const nanoclavSdk = process.env.NANOCLAW_SDK;
+  if (nanoclavSdk) {
+    args.push('-e', `NANOCLAW_SDK=${nanoclavSdk}`);
+  }
+  const copilotModel = process.env.COPILOT_MODEL;
+  if (copilotModel) {
+    args.push('-e', `COPILOT_MODEL=${copilotModel}`);
   }
 
   // Runtime-specific args for host gateway resolution

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -16,8 +16,15 @@ import {
   ONECLI_URL,
   TIMEZONE,
 } from './config.js';
+import { readEnvFile } from './env.js';
 import { resolveGroupFolderPath, resolveGroupIpcPath } from './group-folder.js';
 import { logger } from './logger.js';
+
+const copilotEnv = readEnvFile([
+  'NANOCLAW_SDK',
+  'COPILOT_MODEL',
+  'GITHUB_TOKEN',
+]);
 import {
   CONTAINER_RUNTIME_BIN,
   hostGatewayArgs,
@@ -278,19 +285,32 @@ async function buildContainerArgs(
   }
 
   // Pass GITHUB_TOKEN for GitHub Copilot SDK and gh CLI
-  const githubToken = process.env.GITHUB_TOKEN;
+  const githubToken = process.env.GITHUB_TOKEN || copilotEnv.GITHUB_TOKEN;
   if (githubToken) {
     args.push('-e', `GITHUB_TOKEN=${githubToken}`);
   }
 
   // Pass SDK backend selection and Copilot model for container agents
-  const nanoclavSdk = process.env.NANOCLAW_SDK;
+  const nanoclavSdk = process.env.NANOCLAW_SDK || copilotEnv.NANOCLAW_SDK;
   if (nanoclavSdk) {
     args.push('-e', `NANOCLAW_SDK=${nanoclavSdk}`);
   }
-  const copilotModel = process.env.COPILOT_MODEL;
+  const copilotModel = process.env.COPILOT_MODEL || copilotEnv.COPILOT_MODEL;
   if (copilotModel) {
     args.push('-e', `COPILOT_MODEL=${copilotModel}`);
+  }
+
+  // Copilot SDK talks to GitHub/Copilot endpoints, not Anthropic.
+  // Bypass the OneCLI proxy for these hosts so requests aren't intercepted.
+  if (nanoclavSdk === 'copilot') {
+    args.push(
+      '-e',
+      'NO_PROXY=api.github.com,*.githubcopilot.com,*.github.com,github.com',
+    );
+    args.push(
+      '-e',
+      'no_proxy=api.github.com,*.githubcopilot.com,*.github.com,github.com',
+    );
   }
 
   // Runtime-specific args for host gateway resolution

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -219,13 +219,21 @@ function buildVolumeMounts(
     'agent-runner-src',
   );
   if (fs.existsSync(agentRunnerSrc)) {
-    const srcIndex = path.join(agentRunnerSrc, 'index.ts');
-    const cachedIndex = path.join(groupAgentRunnerDir, 'index.ts');
-    const needsCopy =
-      !fs.existsSync(groupAgentRunnerDir) ||
-      !fs.existsSync(cachedIndex) ||
-      (fs.existsSync(srcIndex) &&
-        fs.statSync(srcIndex).mtimeMs > fs.statSync(cachedIndex).mtimeMs);
+    let needsCopy = !fs.existsSync(groupAgentRunnerDir);
+    if (!needsCopy) {
+      // Check if any source file is newer than its cached copy
+      for (const file of fs.readdirSync(agentRunnerSrc)) {
+        const srcFile = path.join(agentRunnerSrc, file);
+        const cachedFile = path.join(groupAgentRunnerDir, file);
+        if (
+          !fs.existsSync(cachedFile) ||
+          fs.statSync(srcFile).mtimeMs > fs.statSync(cachedFile).mtimeMs
+        ) {
+          needsCopy = true;
+          break;
+        }
+      }
+    }
     if (needsCopy) {
       fs.cpSync(agentRunnerSrc, groupAgentRunnerDir, { recursive: true });
     }


### PR DESCRIPTION
## Summary

Adds native GitHub Copilot SDK (`@github/copilot-sdk`) as an alternative AI backend alongside the existing Anthropic Claude Agent SDK. This lets NanoClaw run on Copilot models (GPT-4.1, Claude Sonnet, etc.) via a GitHub Copilot subscription — no separate Anthropic API key needed.

## Relationship to #1351

The first commit in this PR is @scottgl9's work from #1351, which provided the initial integration:

- `copilot-query.ts` adapter with session create/resume, MCP server support, and streaming
- SDK dispatch in `index.ts` (select `copilot` vs `claude` via `NANOCLAW_SDK` env var)
- `@github/copilot-sdk` dependency
- `~/.copilot` credentials mount and `GITHUB_TOKEN`/`NANOCLAW_SDK`/`COPILOT_MODEL` env passthrough in `container-runner.ts`

During end-to-end testing we discovered several issues that prevented the integration from actually working. The remaining commits in this PR fix those:

### Our fixes

- **System prompt loading** — Set `workingDirectory: '/workspace/group'` in the Copilot SDK session config so the CLI auto-discovers the group's `CLAUDE.md`. Without this, the agent had no personality and identified itself as "GitHub Copilot CLI".
- **Environment variable passthrough** — Read `NANOCLAW_SDK`, `COPILOT_MODEL`, and `GITHUB_TOKEN` from `.env` via `readEnvFile()` since systemd/launchd don't load `.env` into `process.env`. The original code only read from `process.env`, so containers never saw the Copilot config when running as a service.
- **OneCLI proxy bypass** — Set `NO_PROXY` for GitHub/Copilot domains (`api.github.com`, `*.githubcopilot.com`) when using the Copilot backend. The OneCLI credential proxy (used for Anthropic key injection) intercepts all container HTTP traffic, which breaks Copilot API authentication.
- **Agent-runner source sync** — Fixed the staleness check for the per-group `agent-runner-src` overlay to compare **all** source files, not just `index.ts`. Without this, changes to `copilot-query.ts` never synced to running containers after a rebuild.
- **Setup skill update** — Added Copilot as a backend option in the setup wizard with auth flow instructions, including a Linux keyring workaround (containers can't access the host keyring, so `copilot auth login` must store tokens as plain text in `~/.copilot/config.json`).

## Configuration

```bash
# .env
NANOCLAW_SDK=copilot        # or "claude" (default)
COPILOT_MODEL=gpt-4.1       # any Copilot-supported model
```

Authentication: `copilot auth login` (stores OAuth token in `~/.copilot/config.json`, mounted read-only into containers).

## Changes

| File | Description |
|------|-------------|
| `container/agent-runner/src/copilot-query.ts` | Copilot SDK query adapter (from #1351) + `workingDirectory` fix |
| `container/agent-runner/src/index.ts` | SDK backend dispatch (from #1351) |
| `container/agent-runner/package.json` | `@github/copilot-sdk` dependency (from #1351) |
| `src/container-runner.ts` | Env var passthrough, proxy bypass, improved source sync (partially from #1351, extended with fixes) |
| `.claude/skills/setup/SKILL.md` | Backend selection step + Copilot auth flow (new) |

## Testing

Tested end-to-end on Linux/WSL with Telegram channel, Copilot subscription (GPT-4.1 model), OneCLI credential proxy active. Bot responds with correct personality from `CLAUDE.md`.