### PR TITLE
fix: trigger pattern matches anywhere in message, not just at start

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -68,7 +68,7 @@ function escapeRegex(str: string): string {
 }
 
 export function buildTriggerPattern(trigger: string): RegExp {
-  return new RegExp(`^${escapeRegex(trigger.trim())}\\b`, 'i');
+  return new RegExp(`(?:^|\\s)${escapeRegex(trigger.trim())}\\b`, 'i');
 }
 
 export const DEFAULT_TRIGGER = `@${ASSISTANT_NAME}`;


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change
- [x] **Fix** - bug fix or security fix to source code

## Description
The `^` anchor in `buildTriggerPattern()` required the trigger word at message start. Users naturally put triggers mid-sentence or after other @mentions (e.g., `@someone @Andy what do you think?`). Changed to `(?:^|\s)` to match at start or after whitespace.

## AI Disclosure
Code developed with Claude Code (Opus). Human-reviewed and tested on a live NanoClaw deployment.