### PR TITLE
feat: replies and quotes of bot messages trigger response in trigger-required groups

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -404,6 +404,21 @@ export function getLastBotMessageTimestamp(
   return row?.ts ?? undefined;
 }
 
+export function getMessageById(
+  messageId: string,
+  chatJid: string,
+): NewMessage | null {
+  const row = db
+    .prepare(
+      `SELECT id, chat_jid, sender, sender_name, content, timestamp, is_from_me,
+              is_bot_message, reply_to_message_id, reply_to_message_content, reply_to_sender_name
+       FROM messages
+       WHERE id = ? AND chat_jid = ?`,
+    )
+    .get(messageId, chatJid) as NewMessage | undefined;
+  return row ?? null;
+}
+
 export function createTask(
   task: Omit<ScheduledTask, 'last_run' | 'last_result'>,
 ): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ import {
   deleteSession,
   getAllTasks,
   getLastBotMessageTimestamp,
+  getMessageById,
   getMessagesSince,
   getNewMessages,
   getRouterState,
@@ -142,6 +143,20 @@ function saveState(): void {
   setRouterState('last_agent_timestamp', JSON.stringify(lastAgentTimestamp));
 }
 
+/**
+ * Check if a message is a reply to or quote of a bot message.
+ * Channels render quotes as "[Replying to NAME: ...]" prefixes,
+ * and some provide a reply_to_message_id field.
+ */
+function isReplyToBot(msg: NewMessage): boolean {
+  if (msg.content.startsWith(`[Replying to ${ASSISTANT_NAME}:`)) return true;
+  if (msg.reply_to_message_id) {
+    const original = getMessageById(msg.reply_to_message_id, msg.chat_jid);
+    if (original?.is_bot_message) return true;
+  }
+  return false;
+}
+
 function registerGroup(jid: string, group: RegisteredGroup): void {
   let groupDir: string;
   try {
@@ -245,7 +260,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     const allowlistCfg = loadSenderAllowlist();
     const hasTrigger = missedMessages.some(
       (m) =>
-        triggerPattern.test(m.content.trim()) &&
+        (triggerPattern.test(m.content.trim()) || isReplyToBot(m)) &&
         (m.is_from_me || isTriggerAllowed(chatJid, m.sender, allowlistCfg)),
     );
     if (!hasTrigger) return true;
@@ -495,7 +510,7 @@ async function startMessageLoop(): Promise<void> {
             const allowlistCfg = loadSenderAllowlist();
             const hasTrigger = groupMessages.some(
               (m) =>
-                triggerPattern.test(m.content.trim()) &&
+                (triggerPattern.test(m.content.trim()) || isReplyToBot(m)) &&
                 (m.is_from_me ||
                   isTriggerAllowed(chatJid, m.sender, allowlistCfg)),
             );


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change
- [x] **Fix** - bug fix or security fix to source code

## Description
In groups with `requiresTrigger`, replying to or quoting a bot message now also triggers a response. Adds `isReplyToBot()` helper that checks both the `[Replying to NAME:` content prefix (how channels render quotes) and `reply_to_message_id` resolution via a new `getMessageById()` in db.ts. Both trigger check locations (processGroupMessages and the message loop) are updated.

## AI Disclosure
Code developed with Claude Code (Opus). Human-reviewed and tested on a live NanoClaw deployment.