### PR TITLE
fix: chown .claude session dir so container user can write to it

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -58,6 +58,17 @@ interface VolumeMount {
   readonly: boolean;
 }
 
+function chownRecursive(dir: string, uid: number, gid: number): void {
+  fs.chownSync(dir, uid, gid);
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    fs.chownSync(fullPath, uid, gid);
+    if (entry.isDirectory()) {
+      chownRecursive(fullPath, uid, gid);
+    }
+  }
+}
+
 function buildVolumeMounts(
   group: RegisteredGroup,
   isMain: boolean,
@@ -178,6 +189,18 @@ function buildVolumeMounts(
       fs.cpSync(srcDir, dstDir, { recursive: true });
     }
   }
+  // Chown .claude session dir so the container user (node) can write to it.
+  // The orchestrator may create this dir as root; SDK needs to mkdir session-env/ inside.
+  const sessionUid = process.getuid?.();
+  const sessionGid = process.getgid?.();
+  if (sessionUid != null && sessionUid !== 0) {
+    try {
+      chownRecursive(groupSessionsDir, sessionUid, sessionGid ?? sessionUid);
+    } catch (err) {
+      logger.warn({ err, groupSessionsDir }, 'Failed to chown .claude session dir');
+    }
+  }
+
   mounts.push({
     hostPath: groupSessionsDir,
     containerPath: '/home/node/.claude',


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change
- [x] **Fix** - bug fix or security fix to source code

## Description
The orchestrator creates the per-group `.claude` dir as root (or the host user). The container runs as `node` (uid 1000). When the SDK tries to `mkdir session-env/` inside `.claude/`, it gets EACCES. Added a `chownRecursive()` helper and call it on `groupSessionsDir` before the mount, using the same `process.getuid()`/`process.getgid()` pattern already used for `--user` in the container args.

## AI Disclosure
Code developed with Claude Code (Opus). Human-reviewed and tested on a live NanoClaw deployment.