### PR TITLE
fix: add .claude/settings.local.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ groups/global/*
 # IDE
 .idea/
 .vscode/
+.claude/settings.local.json
 
 # Skills system (local per-installation state)
 .nanoclaw/


### PR DESCRIPTION
Claude Code creates `.claude/settings.local.json` for per-user tool permissions and MCP server config. The `.claude/` directory itself needs to stay tracked (skills live there), but `settings.local.json` is user-specific state that shouldn't be committed.

Adds one line to `.gitignore` under the IDE section, since it's analogous to IDE workspace settings.

Fixes #1665

This contribution was developed with AI assistance (Claude Code).