### PR TITLE
feat: add RUNTIME_MODE=native for host-process agent execution

### DIFF
--- a/.claude/skills/enable-native-runner/SKILL.md
+++ b/.claude/skills/enable-native-runner/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: enable-native-runner
+description: Switch NanoClaw from Docker container mode to native host process mode, enabling tmux, Playwright, macOS APIs, and Ollama integrations.
+---
+
+# Enable Native Runner Mode
+
+This skill switches NanoClaw from Docker container mode (`RUNTIME_MODE=container`) to native mode (`RUNTIME_MODE=native`), where the agent-runner runs as a direct child process on the host instead of inside a Docker container.
+
+**When to use:** You want the agent to run tmux sessions, use Playwright with a real browser, call macOS-native tools (screen capture, camera, `osascript`), or access Ollama on localhost without the overhead of a container.
+
+**When not to use:** Multi-user or server deployments where isolation matters. Container mode is the secure default.
+
+## Phase 1: Apply Code Changes
+
+### Merge the skill branch
+
+```bash
+git remote -v
+```
+
+Check that the `upstream` remote points to `https://github.com/qwibitai/nanoclaw.git`. If not, add it:
+
+```bash
+git remote add upstream https://github.com/qwibitai/nanoclaw.git
+git fetch upstream
+```
+
+Merge the native runner branch:
+
+```bash
+git merge upstream/skill/native-runner --no-edit
+```
+
+If there are conflicts, resolve them and continue:
+
+```bash
+git add -A && git merge --continue
+```
+
+Build to confirm everything compiles:
+
+```bash
+npm run build
+```
+
+## Phase 2: Configure
+
+Add to your `.env`:
+
+```
+RUNTIME_MODE=native
+```
+
+**Optional — tmux socket for container mode** (only relevant if you switch back to containers):
+
+```
+MOUNT_TMUX_SOCKET=false
+```
+
+Set to `true` to mount the host tmux socket into containers. See `docs/NATIVE-MODE.md` for security trade-offs.
+
+## Phase 3: First-run setup
+
+On first start in native mode, NanoClaw will:
+
+1. Install `agent-runner` npm dependencies (once, takes ~10s on a cold start)
+2. Symlink each skill in `container/skills/` into `~/.claude/skills/`
+
+The agent-runner is executed via `tsx` — ensure it is available:
+
+```bash
+ls node_modules/.bin/tsx || echo "tsx not found — run: npm install"
+```
+
+## Phase 4: Restart NanoClaw
+
+**macOS (launchd):**
+
+```bash
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+```
+
+**Linux (systemd):**
+
+```bash
+systemctl --user restart nanoclaw
+```
+
+**Direct:**
+
+```bash
+npm run dev
+```
+
+## Phase 5: Verify
+
+Check the log for the native mode confirmation line:
+
+```bash
+grep "native mode" logs/nanoclaw.log | tail -3
+```
+
+You should see:
+
+```
+INFO: Running in native mode — skipping container runtime checks
+INFO: Native mode: agent-runner dependencies installed (or: already present)
+```
+
+Send a test message to any registered group to confirm the agent responds.
+
+## Troubleshooting
+
+See `docs/NATIVE-MODE.md` for full troubleshooting guidance covering:
+- `npx tsx` not found (Node version manager PATH issues)
+- Credentials not picked up (quoted `.env` values)
+- Skills not appearing (symlink vs real directory)
+- macOS launchd tmux socket path issues

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Runtime mode: 'container' (default, Docker-based isolation) or 'native' (host process, no Docker).
+# Use 'native' to enable host-level integrations: tmux, Playwright, macOS APIs, Ollama on localhost.
+# Security: native mode gives agents your full filesystem access. Only use on personal deployments.
+# See docs/NATIVE-MODE.md for setup instructions and security trade-offs.
+RUNTIME_MODE=container
+
+# Mount the host tmux socket into containers so agents can create tmux sessions on the host.
+# Only used in container mode. Requires tmux to be installed on the host.
+# Security: grants cross-session keystroke access to all your tmux sessions. Opt-in only.
+MOUNT_TMUX_SOCKET=false

--- a/docs/NATIVE-MODE.md
+++ b/docs/NATIVE-MODE.md
@@ -1,0 +1,86 @@
+# Native Runner Mode
+
+Native mode spawns the NanoClaw agent-runner as a direct child process on the host instead of inside a Docker container. This unlocks integrations that are impractical or impossible inside a Linux container.
+
+## When to use it
+
+| Capability | Container mode | Native mode |
+|---|---|---|
+| tmux sessions on host | Requires socket mount + version match | Native |
+| Claude Code interactive PTY | Blocked by container stdio | Native |
+| Playwright headed browser | No display server | Native (inherits display) |
+| macOS screen capture / camera | Linux container only | Native |
+| Ollama on localhost | Bridge network hop | Direct |
+| System notifications (`osascript`) | Blocked | Native |
+| `gh` auth / SSH keys | Requires explicit mounts | Inherits `~/.ssh`, `~/.config/gh` |
+| Git config / GPG signing | Requires mounts | Inherits `~/.gitconfig`, keychain |
+
+Use native mode when you are running NanoClaw as a personal assistant on a single-user machine and you want the agent to have the same host access you do.
+
+Use container mode (the default) for any deployment where isolation matters — multi-user setups, servers, or any environment where you do not want an agent to touch arbitrary files on the host.
+
+## Activation
+
+Add to your `.env`:
+
+```
+RUNTIME_MODE=native
+```
+
+Restart NanoClaw. On first start, native mode installs agent-runner npm dependencies (once only) and symlinks `container/skills/` into `~/.claude/skills/`.
+
+## How it works
+
+- The `container/agent-runner/src/index.ts` is executed directly with `tsx` as a child process
+- The same stdin/stdout JSON IPC protocol is used as in container mode — the agent-runner is unchanged
+- Per-group workspace directories (`data/sessions/<group>/`, IPC dirs) are created on the host exactly as they would be inside a container
+- `HOME` is set to the real user home directory so SSH keys, `gh` auth, and `~/.gitconfig` work
+- Skills in `container/skills/` are symlinked into `~/.claude/skills/` at startup. Symlinks update automatically after `git pull`. User-owned skills (real directories in `~/.claude/skills/`) are never overwritten.
+
+## Security trade-offs
+
+Native mode deliberately removes the Docker isolation boundary. Be aware:
+
+**Filesystem access**: The agent process runs as your user and can read and write any file you can. The `additionalMounts` allowlist still validates which paths are exposed via the `NANOCLAW_WORKSPACE_EXTRA` directory, but read-only constraints cannot be enforced — there is no container boundary to back them up. A warning is logged for each mount marked `readonly` in your config.
+
+**Process access**: The agent can spawn child processes with your full permissions — `sudo` prompts aside. This is intentional for use-cases like running `tmux new-session` or `gh` commands, but it means a misbehaving prompt could cause unintended system changes.
+
+**No network namespace isolation**: In container mode, the agent's network access can be restricted. In native mode, the agent has direct access to all interfaces including `localhost` services (databases, local APIs, Ollama).
+
+**Recommendation**: Only use native mode on machines you control, for personal use, with groups you trust. For any shared or production deployment, use container mode.
+
+## tmux in container mode (`MOUNT_TMUX_SOCKET`)
+
+If you prefer container mode but still need tmux access, set:
+
+```
+MOUNT_TMUX_SOCKET=true
+```
+
+This mounts the host tmux socket directory into containers. The socket path is resolved via `$TMUX_TMPDIR` (set by macOS launchd) with `/tmp/tmux-<uid>` as a fallback for Linux.
+
+**Security note**: Any container with the tmux socket can send keystrokes to any existing tmux session owned by your user, including sessions running in other groups. This grants cross-group host access. Only enable on single-user personal deployments where all groups are trusted.
+
+## Skills sync
+
+On startup, native mode symlinks each skill directory from `container/skills/<name>` into `~/.claude/skills/<name>`. This means:
+
+- Skills are always up-to-date after `git pull` — no manual copy step
+- No race conditions: symlinks are atomic, unlike recursive file copies
+- Your own skills (real directories in `~/.claude/skills/`) are never touched — only directories that are symlinks or don't yet exist are managed
+
+If you want to customize a skill locally, replace the symlink with a real directory. NanoClaw will detect the real directory and leave it alone on subsequent starts.
+
+## Troubleshooting
+
+**`npx tsx` not found on startup**
+Native mode resolves `npx` from the same directory as the Node.js binary (`process.execPath`). If you installed Node via a version manager, ensure the correct version is active when NanoClaw starts (especially relevant for launchd service setups).
+
+**Credentials not picked up**
+Native mode reads `CLAUDE_CODE_OAUTH_TOKEN` and `ANTHROPIC_API_KEY` from your `.env` file using the same parser as the rest of NanoClaw. Ensure values are not double-quoted (`KEY="value"` is fine; it handles quoting correctly). Check `logs/nanoclaw.log` for authentication errors.
+
+**Skills not appearing in the agent**
+Check that `~/.claude/skills/` contains symlinks pointing into `container/skills/`. If a skill directory exists as a real directory (not a symlink), native mode skips it. Run `ls -la ~/.claude/skills/` to inspect.
+
+**macOS launchd: wrong tmux socket path**
+macOS launchd sets `$TMUX_TMPDIR` to a path under `/private/var/folders/`. If `MOUNT_TMUX_SOCKET=true` logs a warning about the socket not being found, check `echo $TMUX_TMPDIR` in your shell and verify NanoClaw's launchd plist passes `TMUX_TMPDIR` in its `EnvironmentVariables` dict.

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,8 @@ const envConfig = readEnvFile([
   'ASSISTANT_HAS_OWN_NUMBER',
   'ONECLI_URL',
   'TZ',
+  'RUNTIME_MODE',
+  'MOUNT_TMUX_SOCKET',
 ]);
 
 export const ASSISTANT_NAME =
@@ -40,6 +42,37 @@ export const SENDER_ALLOWLIST_PATH = path.join(
 export const STORE_DIR = path.resolve(PROJECT_ROOT, 'store');
 export const GROUPS_DIR = path.resolve(PROJECT_ROOT, 'groups');
 export const DATA_DIR = path.resolve(PROJECT_ROOT, 'data');
+
+export type RuntimeMode = 'container' | 'native';
+
+/**
+ * Runtime mode controls whether agents run inside Docker containers (default)
+ * or as direct child processes on the host.
+ *
+ * Set RUNTIME_MODE=native in .env to bypass Docker and enable host-level
+ * integrations (tmux, Playwright, macOS APIs, Ollama on localhost).
+ * See docs/NATIVE-MODE.md for setup and security trade-offs.
+ */
+export const RUNTIME_MODE: RuntimeMode =
+  (process.env.RUNTIME_MODE || envConfig.RUNTIME_MODE || 'container') ===
+  'native'
+    ? 'native'
+    : 'container';
+
+/**
+ * When true, mounts the host tmux socket directory into containers so
+ * agents can create and attach to tmux sessions on the host.
+ *
+ * Only used in container mode. Security: any container with the tmux socket
+ * can send keystrokes to other sessions owned by this user. Opt-in only.
+ * Set MOUNT_TMUX_SOCKET=true in .env to enable.
+ */
+export const MOUNT_TMUX_SOCKET =
+  (
+    process.env.MOUNT_TMUX_SOCKET ||
+    envConfig.MOUNT_TMUX_SOCKET ||
+    ''
+  ).toLowerCase() === 'true';
 
 export const CONTAINER_IMAGE =
   process.env.CONTAINER_IMAGE || 'nanoclaw-agent:latest';

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -14,6 +14,7 @@ vi.mock('./config.js', () => ({
   DATA_DIR: '/tmp/nanoclaw-test-data',
   GROUPS_DIR: '/tmp/nanoclaw-test-groups',
   IDLE_TIMEOUT: 1800000, // 30min
+  MOUNT_TMUX_SOCKET: false,
   ONECLI_URL: 'http://localhost:10254',
   TIMEZONE: 'America/Los_Angeles',
 }));

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -13,6 +13,7 @@ import {
   DATA_DIR,
   GROUPS_DIR,
   IDLE_TIMEOUT,
+  MOUNT_TMUX_SOCKET,
   ONECLI_URL,
   TIMEZONE,
 } from './config.js';
@@ -228,6 +229,31 @@ function buildVolumeMounts(
     containerPath: '/app/src',
     readonly: false,
   });
+
+  // Mount host tmux socket — opt-in only (MOUNT_TMUX_SOCKET=true).
+  // When enabled, agents can spawn and attach to tmux sessions on the host,
+  // which is useful for Claude Code / Codex coding sessions.
+  //
+  // Security: the tmux socket grants the ability to send keystrokes to any
+  // existing session owned by this user, including sessions in other groups.
+  // Only enable on trusted single-user deployments. See docs/NATIVE-MODE.md.
+  if (MOUNT_TMUX_SOCKET) {
+    // Prefer $TMUX_TMPDIR (set by macOS launchd) before the Linux default
+    const tmuxTmpDir =
+      process.env.TMUX_TMPDIR || `/tmp/tmux-${process.getuid?.() ?? 0}`;
+    if (fs.existsSync(tmuxTmpDir)) {
+      mounts.push({
+        hostPath: tmuxTmpDir,
+        containerPath: tmuxTmpDir,
+        readonly: false,
+      });
+    } else {
+      logger.warn(
+        { tmuxTmpDir },
+        'MOUNT_TMUX_SOCKET is set but tmux socket directory not found — tmux will not be available in containers',
+      );
+    }
+  }
 
   // Additional mounts validated against external allowlist (tamper-proof from containers)
   if (group.containerConfig?.additionalMounts) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
   MAX_MESSAGES_PER_PROMPT,
   ONECLI_URL,
   POLL_INTERVAL,
+  RUNTIME_MODE,
   TIMEZONE,
 } from './config.js';
 import './channels/index.js';
@@ -25,6 +26,7 @@ import {
   writeGroupsSnapshot,
   writeTasksSnapshot,
 } from './container-runner.js';
+import { runNativeAgent, ensureNativeRunnerReady } from './native-runner.js';
 import {
   cleanupOrphans,
   ensureContainerRuntimeRunning,
@@ -81,7 +83,7 @@ const queue = new GroupQueue();
 const onecli = new OneCLI({ url: ONECLI_URL });
 
 function ensureOneCLIAgent(jid: string, group: RegisteredGroup): void {
-  if (group.isMain) return;
+  if (group.isMain || RUNTIME_MODE === 'native') return;
   const identifier = group.folder.toLowerCase().replace(/_/g, '-');
   onecli.ensureAgent({ name: group.name, identifier }).then(
     (res) => {
@@ -383,20 +385,20 @@ async function runAgent(
     : undefined;
 
   try {
-    const output = await runContainerAgent(
-      group,
-      {
-        prompt,
-        sessionId,
-        groupFolder: group.folder,
-        chatJid,
-        isMain,
-        assistantName: ASSISTANT_NAME,
-      },
-      (proc, containerName) =>
-        queue.registerProcess(chatJid, proc, containerName, group.folder),
-      wrappedOnOutput,
-    );
+    const agentInput = {
+      prompt,
+      sessionId,
+      groupFolder: group.folder,
+      chatJid,
+      isMain,
+      assistantName: ASSISTANT_NAME,
+    };
+    const onProc = (proc: import('child_process').ChildProcess, name: string) =>
+      queue.registerProcess(chatJid, proc, name, group.folder);
+    const output =
+      RUNTIME_MODE === 'native'
+        ? await runNativeAgent(group, agentInput, onProc, wrappedOnOutput)
+        : await runContainerAgent(group, agentInput, onProc, wrappedOnOutput);
 
     if (output.newSessionId) {
       sessions[group.folder] = output.newSessionId;
@@ -564,12 +566,19 @@ function recoverPendingMessages(): void {
 }
 
 function ensureContainerSystemRunning(): void {
+  if (RUNTIME_MODE === 'native') {
+    logger.info('Running in native mode — skipping container runtime checks');
+    return;
+  }
   ensureContainerRuntimeRunning();
   cleanupOrphans();
 }
 
 async function main(): Promise<void> {
   ensureContainerSystemRunning();
+  if (RUNTIME_MODE === 'native') {
+    await ensureNativeRunnerReady();
+  }
   initDatabase();
   logger.info('Database initialized');
   loadState();

--- a/src/native-runner.ts
+++ b/src/native-runner.ts
@@ -1,0 +1,565 @@
+/**
+ * Native Runner for NanoClaw
+ *
+ * Spawns the agent-runner as a direct child process on the host,
+ * bypassing Docker entirely. The IPC protocol (stdin/stdout JSON,
+ * OUTPUT_START/END markers) is identical to container mode so the
+ * agent-runner source is unchanged.
+ *
+ * Activate with RUNTIME_MODE=native in .env.
+ *
+ * Security trade-off: the agent process inherits the user's full
+ * filesystem access. Read-only mount constraints from the allowlist
+ * cannot be enforced without a container boundary. Use only on
+ * single-user personal deployments where host access is intentional.
+ *
+ * See docs/NATIVE-MODE.md for setup instructions and security notes.
+ */
+import { ChildProcess, spawn } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import {
+  CONTAINER_MAX_OUTPUT_SIZE,
+  CONTAINER_TIMEOUT,
+  DATA_DIR,
+  GROUPS_DIR,
+  IDLE_TIMEOUT,
+  TIMEZONE,
+} from './config.js';
+import { readEnvFile } from './env.js';
+import { resolveGroupFolderPath, resolveGroupIpcPath } from './group-folder.js';
+import { logger } from './logger.js';
+import { validateAdditionalMounts } from './mount-security.js';
+import { RegisteredGroup } from './types.js';
+import {
+  ContainerInput,
+  ContainerOutput,
+  writeTasksSnapshot,
+  writeGroupsSnapshot,
+  AvailableGroup,
+} from './container-runner.js';
+
+// Re-export types consumed by index.ts and task-scheduler.ts
+export {
+  ContainerInput,
+  ContainerOutput,
+  writeTasksSnapshot,
+  writeGroupsSnapshot,
+};
+export type { AvailableGroup };
+
+const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
+const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
+
+// ---------------------------------------------------------------------------
+// Startup initialization — call once from main() before any agent runs
+// ---------------------------------------------------------------------------
+
+let _startupDone = false;
+
+/**
+ * Ensure native-mode prerequisites are ready before the first agent run.
+ *
+ * Must be called once at process startup (not per-invocation) to avoid
+ * blocking the event loop with npm install or racing on skills sync.
+ */
+export async function ensureNativeRunnerReady(): Promise<void> {
+  if (_startupDone) return;
+  _startupDone = true;
+
+  await _ensureAgentRunnerDeps();
+  _syncNanoclawSkills();
+}
+
+/**
+ * Install agent-runner npm dependencies if they are missing.
+ * Runs synchronously but only once per process — never in the agent hot path.
+ */
+async function _ensureAgentRunnerDeps(): Promise<void> {
+  const agentRunnerDir = path.join(process.cwd(), 'container', 'agent-runner');
+  const nodeModules = path.join(agentRunnerDir, 'node_modules');
+  if (fs.existsSync(nodeModules)) return;
+
+  logger.info('Native mode: installing agent-runner dependencies...');
+  const { execSync } = await import('child_process');
+  try {
+    execSync('npm install', { cwd: agentRunnerDir, stdio: 'pipe' });
+    logger.info('Native mode: agent-runner dependencies installed');
+  } catch (err) {
+    // Log and continue — spawn will fail with a clear error if tsx is missing
+    logger.error({ err }, 'Native mode: npm install failed for agent-runner');
+  }
+}
+
+/**
+ * Sync container/skills/ into ~/.claude/skills/ using symlinks.
+ *
+ * Each skill directory is symlinked rather than copied so that:
+ *   - Updates take effect immediately after git pull (no re-copy needed)
+ *   - No file-by-file copy races when multiple groups fire simultaneously
+ *   - User-owned skills (real directories) are never overwritten
+ *
+ * Stale symlinks (pointing to removed skills) are cleaned up automatically.
+ */
+function _syncNanoclawSkills(): void {
+  const projectRoot = process.cwd();
+  const skillsSrc = path.join(projectRoot, 'container', 'skills');
+  const skillsDst = path.join(os.homedir(), '.claude', 'skills');
+
+  if (!fs.existsSync(skillsSrc)) return;
+
+  fs.mkdirSync(skillsDst, { recursive: true });
+
+  for (const skillDir of fs.readdirSync(skillsSrc)) {
+    const srcDir = path.join(skillsSrc, skillDir);
+    if (!fs.statSync(srcDir).isDirectory()) continue;
+
+    const dstPath = path.join(skillsDst, skillDir);
+
+    try {
+      const existing = fs.lstatSync(dstPath);
+      if (existing.isSymbolicLink()) {
+        const currentTarget = fs.readlinkSync(dstPath);
+        if (currentTarget === srcDir) continue; // already correct
+        fs.unlinkSync(dstPath); // stale symlink — re-create below
+      } else {
+        // Real directory: user may have customized it — leave it alone
+        logger.debug(
+          { skill: skillDir },
+          'Native skills sync: skipping user-owned directory',
+        );
+        continue;
+      }
+    } catch {
+      // Path does not exist — fall through to create symlink
+    }
+
+    try {
+      fs.symlinkSync(srcDir, dstPath);
+      logger.debug({ skill: skillDir }, 'Native skills sync: linked');
+    } catch (err) {
+      logger.warn({ skill: skillDir, err }, 'Native skills sync: symlink failed');
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-group workspace preparation (side effects, separated from env building)
+// ---------------------------------------------------------------------------
+
+interface GroupWorkspace {
+  groupDir: string;
+  groupIpcDir: string;
+  groupSessionsDir: string;
+  extraDir: string;
+  globalDir: string;
+}
+
+/**
+ * Create all per-group directories and initialize settings.json.
+ * Returns paths consumed by buildNativeEnv.
+ *
+ * Separated from buildNativeEnv so the env builder is a pure function
+ * and the side effects are explicit and testable.
+ */
+function prepareGroupWorkspace(
+  group: RegisteredGroup,
+  isMain: boolean,
+): GroupWorkspace {
+  const groupDir = resolveGroupFolderPath(group.folder);
+  const groupIpcDir = resolveGroupIpcPath(group.folder);
+  const groupSessionsDir = path.join(
+    DATA_DIR,
+    'sessions',
+    group.folder,
+    '.claude',
+  );
+
+  fs.mkdirSync(groupSessionsDir, { recursive: true });
+  fs.mkdirSync(path.join(groupIpcDir, 'messages'), { recursive: true });
+  fs.mkdirSync(path.join(groupIpcDir, 'tasks'), { recursive: true });
+  fs.mkdirSync(path.join(groupIpcDir, 'input'), { recursive: true });
+
+  const settingsFile = path.join(groupSessionsDir, 'settings.json');
+  if (!fs.existsSync(settingsFile)) {
+    fs.writeFileSync(
+      settingsFile,
+      JSON.stringify(
+        {
+          env: {
+            CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1',
+            CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: '1',
+            CLAUDE_CODE_DISABLE_AUTO_MEMORY: '0',
+          },
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+  }
+
+  // Symlink additional mounts into a per-group extra dir.
+  // Note: read-only constraints cannot be enforced without container isolation.
+  // A warning is logged for each mount marked readonly so operators are aware.
+  const extraDir = path.join(DATA_DIR, 'native-extra', group.folder);
+  fs.mkdirSync(extraDir, { recursive: true });
+
+  if (group.containerConfig?.additionalMounts) {
+    const validatedMounts = validateAdditionalMounts(
+      group.containerConfig.additionalMounts,
+      group.name,
+      isMain,
+    );
+    for (const mount of validatedMounts) {
+      if (mount.readonly) {
+        logger.warn(
+          { mount: mount.containerPath },
+          'Native mode: read-only mount constraint cannot be enforced without container isolation — mount is writable',
+        );
+      }
+      const linkName =
+        mount.containerPath.split('/').pop() || path.basename(mount.hostPath);
+      const linkPath = path.join(extraDir, linkName);
+      try {
+        if (fs.existsSync(linkPath)) fs.unlinkSync(linkPath);
+        fs.symlinkSync(mount.hostPath, linkPath);
+      } catch (err) {
+        logger.warn({ mount, err }, 'Failed to symlink additional mount');
+      }
+    }
+  }
+
+  const globalDir = path.join(GROUPS_DIR, 'global');
+
+  return { groupDir, groupIpcDir, groupSessionsDir, extraDir, globalDir };
+}
+
+// ---------------------------------------------------------------------------
+// Environment builder — pure function, no filesystem side effects
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the environment for the native agent-runner process.
+ *
+ * Credentials are read via readEnvFile() (the same parser used by config.ts)
+ * to correctly handle quoted values and multi-form .env syntax.
+ * The host environment is inherited so tools like git, gh, and SSH work.
+ */
+function buildNativeEnv(
+  isMain: boolean,
+  workspace: GroupWorkspace,
+): Record<string, string> {
+  const { groupDir, groupIpcDir, groupSessionsDir, extraDir, globalDir } =
+    workspace;
+
+  // Use the shared .env parser — handles quoting, comments, blank lines
+  const credentials = readEnvFile([
+    'CLAUDE_CODE_OAUTH_TOKEN',
+    'ANTHROPIC_API_KEY',
+  ]);
+
+  return {
+    // Inherit host environment (PATH, SSH_AUTH_SOCK, DISPLAY, etc.)
+    ...(process.env as Record<string, string>),
+    // Workspace path remapping consumed by the agent-runner
+    NANOCLAW_WORKSPACE_GROUP: groupDir,
+    NANOCLAW_WORKSPACE_GLOBAL: globalDir,
+    NANOCLAW_WORKSPACE_EXTRA: extraDir,
+    NANOCLAW_WORKSPACE_PROJECT: isMain ? process.cwd() : '',
+    NANOCLAW_CLAUDE_HOME: groupSessionsDir,
+    NANOCLAW_IPC_INPUT: path.join(groupIpcDir, 'input'),
+    NANOCLAW_IPC_DIR: groupIpcDir,
+    TZ: TIMEZONE,
+    // SDK credentials — injected directly; no OneCLI proxy in native mode
+    ...(credentials.CLAUDE_CODE_OAUTH_TOKEN
+      ? { CLAUDE_CODE_OAUTH_TOKEN: credentials.CLAUDE_CODE_OAUTH_TOKEN }
+      : {}),
+    ...(credentials.ANTHROPIC_API_KEY
+      ? { ANTHROPIC_API_KEY: credentials.ANTHROPIC_API_KEY }
+      : {}),
+    CLAUDE_CODE_AUTO_COMPACT_WINDOW: '165000',
+    // Keep HOME as the real user home so SSH keys, gh auth, and git config work.
+    // The Claude SDK reads ~/.claude/skills from here (symlinked from container/skills/).
+    HOME: os.homedir(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Agent-runner path resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the path to the agent-runner entry point.
+ *
+ * In native mode, all groups share the canonical agent-runner source in
+ * container/agent-runner/src/. Per-group copies are not needed because
+ * there is no filesystem namespace isolation between groups on the host.
+ */
+function getAgentRunnerPath(): string {
+  return path.join(
+    process.cwd(),
+    'container',
+    'agent-runner',
+    'src',
+    'index.ts',
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+export async function runNativeAgent(
+  group: RegisteredGroup,
+  input: ContainerInput,
+  onProcess: (proc: ChildProcess, name: string) => void,
+  onOutput?: (output: ContainerOutput) => Promise<void>,
+): Promise<ContainerOutput> {
+  const startTime = Date.now();
+
+  const workspace = prepareGroupWorkspace(group, input.isMain);
+  fs.mkdirSync(workspace.groupDir, { recursive: true });
+
+  const safeName = group.folder.replace(/[^a-zA-Z0-9-]/g, '-');
+  const processName = `nanoclaw-native-${safeName}-${Date.now()}`;
+  const env = buildNativeEnv(input.isMain, workspace);
+  const agentRunnerPath = getAgentRunnerPath();
+
+  const agentRunnerDir = path.join(process.cwd(), 'container', 'agent-runner');
+  const agentRunnerNodeModules = path.join(agentRunnerDir, 'node_modules');
+
+  logger.info(
+    {
+      group: group.name,
+      processName,
+      isMain: input.isMain,
+      agentRunner: agentRunnerPath,
+    },
+    'Spawning native agent',
+  );
+
+  const logsDir = path.join(workspace.groupDir, 'logs');
+  fs.mkdirSync(logsDir, { recursive: true });
+
+  return new Promise((resolve) => {
+    // Run agent-runner TypeScript directly via tsx.
+    // Use process.execPath's directory to locate npx so the correct Node
+    // version is used even in launchd/systemd environments without a full PATH.
+    const nodeBinDir = path.dirname(process.execPath);
+    const npxPath = path.join(nodeBinDir, 'npx');
+
+    const proc = spawn(npxPath, ['tsx', agentRunnerPath], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: {
+        ...env,
+        PATH: `${nodeBinDir}:${env.PATH || ''}`,
+        NODE_PATH: agentRunnerNodeModules,
+      },
+      cwd: agentRunnerDir,
+    });
+
+    onProcess(proc, processName);
+
+    let stdout = '';
+    let stderr = '';
+    let stdoutTruncated = false;
+    let stderrTruncated = false;
+
+    proc.stdin.write(JSON.stringify(input));
+    proc.stdin.end();
+
+    // Streaming output parsing — identical protocol to container-runner.ts
+    let parseBuffer = '';
+    let newSessionId: string | undefined;
+    let outputChain = Promise.resolve();
+    let hadStreamingOutput = false;
+
+    let timedOut = false;
+    const configTimeout = group.containerConfig?.timeout || CONTAINER_TIMEOUT;
+    const timeoutMs = Math.max(configTimeout, IDLE_TIMEOUT + 30_000);
+
+    const killOnTimeout = () => {
+      timedOut = true;
+      logger.error(
+        { group: group.name, processName },
+        'Native agent timeout, killing',
+      );
+      proc.kill('SIGTERM');
+      setTimeout(() => {
+        if (!proc.killed) proc.kill('SIGKILL');
+      }, 5000);
+    };
+
+    let timeout = setTimeout(killOnTimeout, timeoutMs);
+    const resetTimeout = () => {
+      clearTimeout(timeout);
+      timeout = setTimeout(killOnTimeout, timeoutMs);
+    };
+
+    proc.stdout.on('data', (data) => {
+      const chunk = data.toString();
+
+      if (!stdoutTruncated) {
+        const remaining = CONTAINER_MAX_OUTPUT_SIZE - stdout.length;
+        if (chunk.length > remaining) {
+          stdout += chunk.slice(0, remaining);
+          stdoutTruncated = true;
+        } else {
+          stdout += chunk;
+        }
+      }
+
+      if (onOutput) {
+        parseBuffer += chunk;
+        let startIdx: number;
+        while ((startIdx = parseBuffer.indexOf(OUTPUT_START_MARKER)) !== -1) {
+          const endIdx = parseBuffer.indexOf(OUTPUT_END_MARKER, startIdx);
+          if (endIdx === -1) break;
+
+          const jsonStr = parseBuffer
+            .slice(startIdx + OUTPUT_START_MARKER.length, endIdx)
+            .trim();
+          parseBuffer = parseBuffer.slice(endIdx + OUTPUT_END_MARKER.length);
+
+          try {
+            const parsed: ContainerOutput = JSON.parse(jsonStr);
+            if (parsed.newSessionId) {
+              newSessionId = parsed.newSessionId;
+            }
+            hadStreamingOutput = true;
+            resetTimeout();
+            outputChain = outputChain.then(() => onOutput(parsed));
+          } catch (err) {
+            logger.warn(
+              { group: group.name, error: err },
+              'Failed to parse streamed output chunk',
+            );
+          }
+        }
+      }
+    });
+
+    proc.stderr.on('data', (data) => {
+      const chunk = data.toString();
+      const lines = chunk.trim().split('\n');
+      for (const line of lines) {
+        if (line) logger.debug({ process: group.folder }, line);
+      }
+      if (stderrTruncated) return;
+      const remaining = CONTAINER_MAX_OUTPUT_SIZE - stderr.length;
+      if (chunk.length > remaining) {
+        stderr += chunk.slice(0, remaining);
+        stderrTruncated = true;
+      } else {
+        stderr += chunk;
+      }
+    });
+
+    proc.on('close', (code) => {
+      clearTimeout(timeout);
+      const duration = Date.now() - startTime;
+
+      if (timedOut) {
+        if (hadStreamingOutput) {
+          outputChain.then(() => {
+            resolve({ status: 'success', result: null, newSessionId });
+          });
+          return;
+        }
+        resolve({
+          status: 'error',
+          result: null,
+          error: `Native agent timed out after ${configTimeout}ms`,
+        });
+        return;
+      }
+
+      // Write run log on error (mirrors container-runner behaviour)
+      if (code !== 0) {
+        const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+        const logFile = path.join(logsDir, `native-${timestamp}.log`);
+        fs.writeFileSync(
+          logFile,
+          [
+            `=== Native Agent Run Log ===`,
+            `Timestamp: ${new Date().toISOString()}`,
+            `Group: ${group.name}`,
+            `Duration: ${duration}ms`,
+            `Exit Code: ${code}`,
+            ``,
+            `=== Stderr ===`,
+            stderr,
+            ``,
+            `=== Stdout ===`,
+            stdout,
+          ].join('\n'),
+        );
+
+        logger.error(
+          { group: group.name, code, duration },
+          'Native agent exited with error',
+        );
+        resolve({
+          status: 'error',
+          result: null,
+          error: `Native agent exited with code ${code}: ${stderr.slice(-200)}`,
+        });
+        return;
+      }
+
+      // Streaming mode: all output delivered via onOutput callbacks
+      if (onOutput) {
+        outputChain.then(() => {
+          logger.info(
+            { group: group.name, duration, newSessionId },
+            'Native agent completed',
+          );
+          resolve({ status: 'success', result: null, newSessionId });
+        });
+        return;
+      }
+
+      // Legacy mode: parse the last OUTPUT_START/END pair from stdout
+      try {
+        const startIdx = stdout.indexOf(OUTPUT_START_MARKER);
+        const endIdx = stdout.indexOf(OUTPUT_END_MARKER);
+        let jsonLine: string;
+        if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
+          jsonLine = stdout
+            .slice(startIdx + OUTPUT_START_MARKER.length, endIdx)
+            .trim();
+        } else {
+          const lines = stdout.trim().split('\n');
+          jsonLine = lines[lines.length - 1];
+        }
+        const output: ContainerOutput = JSON.parse(jsonLine);
+        logger.info(
+          { group: group.name, duration, status: output.status },
+          'Native agent completed',
+        );
+        resolve(output);
+      } catch (err) {
+        resolve({
+          status: 'error',
+          result: null,
+          error: `Failed to parse native agent output: ${err instanceof Error ? err.message : String(err)}`,
+        });
+      }
+    });
+
+    proc.on('error', (err) => {
+      clearTimeout(timeout);
+      logger.error(
+        { group: group.name, error: err },
+        'Native agent spawn error',
+      );
+      resolve({
+        status: 'error',
+        result: null,
+        error: `Native agent spawn error: ${err.message}`,
+      });
+    });
+  });
+}

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -2,12 +2,18 @@ import { ChildProcess } from 'child_process';
 import { CronExpressionParser } from 'cron-parser';
 import fs from 'fs';
 
-import { ASSISTANT_NAME, SCHEDULER_POLL_INTERVAL, TIMEZONE } from './config.js';
+import {
+  ASSISTANT_NAME,
+  RUNTIME_MODE,
+  SCHEDULER_POLL_INTERVAL,
+  TIMEZONE,
+} from './config.js';
 import {
   ContainerOutput,
   runContainerAgent,
   writeTasksSnapshot,
 } from './container-runner.js';
+import { runNativeAgent } from './native-runner.js';
 import {
   getAllTasks,
   getDueTasks,
@@ -170,20 +176,24 @@ async function runTask(
   };
 
   try {
-    const output = await runContainerAgent(
+    const taskInput = {
+      prompt: task.prompt,
+      sessionId,
+      groupFolder: task.group_folder,
+      chatJid: task.chat_jid,
+      isMain,
+      isScheduledTask: true,
+      assistantName: ASSISTANT_NAME,
+      script: task.script || undefined,
+    };
+    const onProc = (proc: ChildProcess, name: string) =>
+      deps.onProcess(task.chat_jid, proc, name, task.group_folder);
+    const runAgent =
+      RUNTIME_MODE === 'native' ? runNativeAgent : runContainerAgent;
+    const output = await runAgent(
       group,
-      {
-        prompt: task.prompt,
-        sessionId,
-        groupFolder: task.group_folder,
-        chatJid: task.chat_jid,
-        isMain,
-        isScheduledTask: true,
-        assistantName: ASSISTANT_NAME,
-        script: task.script || undefined,
-      },
-      (proc, containerName) =>
-        deps.onProcess(task.chat_jid, proc, containerName, task.group_folder),
+      taskInput,
+      onProc,
       async (streamedOutput: ContainerOutput) => {
         if (streamedOutput.result) {
           result = streamedOutput.result;


### PR DESCRIPTION
## Summary

Adds `RUNTIME_MODE=native` — an opt-in mode that spawns the agent-runner as a direct child process on the host instead of inside a Docker container. Resolves the portability issues described in #1732 (tmux, Playwright, macOS APIs, Ollama on localhost).

Follows the feature skill pattern per CONTRIBUTING.md: code lives on this `skill/native-runner` branch; `.claude/skills/enable-native-runner/SKILL.md` on `main` provides user-facing setup instructions.

## Changes

- **`src/native-runner.ts`** — NativeRunner: `ensureNativeRunnerReady()` (startup deps + skills symlink), `prepareGroupWorkspace()` (side effects separated from env building), `buildNativeEnv()` (pure, uses `readEnvFile()` for correct quoted-value handling), `runNativeAgent()` (same IPC protocol as container mode)
- **`src/config.ts`** — `RUNTIME_MODE: 'container' | 'native'` and `MOUNT_TMUX_SOCKET` exports
- **`src/container-runner.ts`** — opt-in tmux socket mount (`MOUNT_TMUX_SOCKET=true`); resolves `$TMUX_TMPDIR` before `/tmp/tmux-<uid>` fallback (fixes macOS launchd)
- **`src/index.ts`** — `RUNTIME_MODE` dispatch in `runAgent` and `ensureContainerSystemRunning`; skip OneCLI provisioning in native mode; call `ensureNativeRunnerReady()` at startup
- **`src/task-scheduler.ts`** — `RUNTIME_MODE` dispatch for scheduled tasks
- **`.env.example`** — document both new config vars with security notes
- **`docs/NATIVE-MODE.md`** — setup guide, capability comparison table, security trade-offs, skills sync behaviour, troubleshooting
- **`.claude/skills/enable-native-runner/SKILL.md`** — user-facing setup skill

## Design decisions

**Skills sync via symlinks, not file copy.** On startup, `container/skills/<name>` is symlinked into `~/.claude/skills/<name>`. Symlinks are atomic (no copy races when concurrent groups fire), update automatically after `git pull`, and user-owned real directories are left untouched.

**`ensureNativeRunnerReady()` called once at startup.** Previously `npm install` and skills sync ran inside `runNativeAgent()` on every invocation — blocking the event loop for up to 60s on cold start. Now they run once in `main()` before the message loop starts.

**No per-group agent-runner source copies.** Container mode copies `agent-runner/src/` per group so containers can have group-specific runner customizations. In native mode there is no filesystem namespace isolation between groups, so the canonical source is used directly, reducing churn.

**`readEnvFile()` for credentials.** The prior implementation used a hand-rolled regex that did not strip quotes — quoted `ANTHROPIC_API_KEY="sk-..."` in `.env` would pass the surrounding quotes to the SDK, causing authentication failures. Now uses the shared `readEnvFile()` parser.

**tmux socket mount is opt-in.** Previously mounted unconditionally into every container. Now requires `MOUNT_TMUX_SOCKET=true` and resolves `$TMUX_TMPDIR` (set by macOS launchd) before falling back to the Linux-default path.

## Security

Native mode intentionally removes the Docker isolation boundary. This is documented in `docs/NATIVE-MODE.md` and `SKILL.md`. Read-only `additionalMounts` constraints cannot be enforced — a `logger.warn()` is emitted per affected mount. Default remains `RUNTIME_MODE=container`.

## Test plan

- [ ] `npm test` passes (246 tests, clean from `upstream/main`)
- [ ] `npm run build` compiles cleanly
- [ ] Set `RUNTIME_MODE=native` in `.env`, restart NanoClaw, confirm log: `Running in native mode — skipping container runtime checks`
- [ ] Send message to registered group, confirm agent responds
- [ ] Confirm `~/.claude/skills/` contains symlinks to `container/skills/` entries after first run
- [ ] Set `MOUNT_TMUX_SOCKET=true`, confirm tmux socket appears in `docker inspect` mounts for next container run
- [ ] Existing container mode unaffected: `RUNTIME_MODE=container` (default) behaviour unchanged

Closes #1732