### PR TITLE
fix: pass ANTHROPIC_BASE_URL and auth vars from .env to agent containers

### DIFF
--- a/.claude/skills/use-custom-model/SKILL.md
+++ b/.claude/skills/use-custom-model/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: use-custom-model
+description: Configure NanoClaw to use a non-Anthropic LLM provider (e.g. Moonshot Kimi K2.5, Ollama, Together AI) via an Anthropic-compatible API endpoint. Guides through .env setup, OneCLI credential configuration, and verification.
+---
+
+# Use Custom Model
+
+Configure NanoClaw agents to call a non-Anthropic LLM through any Anthropic-compatible API endpoint.
+
+**Important:** NanoClaw runs on the Claude Agent SDK, which is optimised for Claude. Non-Anthropic providers must expose an Anthropic-compatible API (messages endpoint, SSE streaming, tool use). Kimi K2.5 via Moonshot AI is confirmed working. Others may work but are untested.
+
+For full background on why the naive approaches fail, see [docs/kimi-k2-integration.md](../../../docs/kimi-k2-integration.md).
+
+## Step 1 — Collect provider details
+
+Ask the user for:
+1. **API base URL** — the Anthropic-compatible endpoint (e.g. `https://api.moonshot.ai/anthropic`)
+2. **API key** — their key for that provider
+3. **Model name** — the model identifier (e.g. `kimi-k2.5`)
+4. **Auth header format** — ask: "Does your provider's documentation show `ANTHROPIC_API_KEY` or `ANTHROPIC_AUTH_TOKEN`?"
+   - `ANTHROPIC_API_KEY` → sends `x-api-key: <value>` header (Anthropic default)
+   - `ANTHROPIC_AUTH_TOKEN` → sends `Authorization: Bearer <value>` header (Moonshot, most others)
+   - If unsure, default to `ANTHROPIC_AUTH_TOKEN`
+
+## Step 2 — Update `.env`
+
+Add or update these lines in `.env`. Use `ANTHROPIC_AUTH_TOKEN` unless the user confirmed `ANTHROPIC_API_KEY`:
+
+```bash
+ANTHROPIC_BASE_URL=<their-api-base-url>
+ANTHROPIC_AUTH_TOKEN=<their-api-key>        # or ANTHROPIC_API_KEY if confirmed
+ANTHROPIC_MODEL=<their-model-name>
+```
+
+Leave any existing `ANTHROPIC_API_KEY` commented out if switching away from Anthropic:
+
+```bash
+# ANTHROPIC_API_KEY=sk-ant-...   # disabled while using custom model
+```
+
+## Step 3 — Configure OneCLI
+
+OneCLI intercepts all container HTTPS traffic. It must know about the provider's hostname to allow connections through.
+
+Check existing secrets:
+```bash
+onecli secrets list
+```
+
+Remove any old Anthropic secret pointing to `api.anthropic.com` (it will conflict):
+```bash
+onecli secrets delete --id <old-secret-id>
+```
+
+Create a new secret for the custom provider:
+```bash
+onecli secrets create \
+  --name "<ProviderName>" \
+  --type anthropic \
+  --value "<their-api-key>" \
+  --host-pattern "<hostname-only, e.g. api.moonshot.ai>" \
+  --path-pattern "/anthropic*"
+```
+
+> **Note:** `--host-pattern` takes a hostname only (no path, no protocol). Use `--path-pattern` for the path prefix.
+
+## Step 4 — Rebuild and restart
+
+```bash
+npm run build
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw   # macOS
+# or: systemctl --user restart nanoclaw             # Linux
+```
+
+## Step 5 — Verify
+
+### Confirm env vars reach the container
+
+Send a test message to any registered group, then while the container is running:
+
+```bash
+docker ps | grep nanoclaw   # get container name
+docker exec <container-name> env | grep ANTHROPIC
+```
+
+Expected:
+```
+ANTHROPIC_BASE_URL=https://your-provider.com/anthropic
+ANTHROPIC_AUTH_TOKEN=your-key
+ANTHROPIC_MODEL=your-model
+```
+
+### Confirm API calls go to the right host
+
+```bash
+docker logs onecli 2>&1 | grep -E "moonshot|anthropic|your-hostname" | tail -10
+```
+
+A successful call shows `status=200` on your provider's hostname:
+```
+MITM method=POST url=https://your-hostname:443/anthropic/v1/messages status=200
+```
+
+If you still see `status=401`, the auth header format is wrong — try switching between `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN`.
+
+## Reverting to Anthropic Claude
+
+1. In `.env` — restore `ANTHROPIC_API_KEY`, remove or comment out `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_MODEL`
+2. In OneCLI — delete the custom provider secret, create a new one with `--host-pattern api.anthropic.com`
+3. Rebuild and restart
+
+## Troubleshooting
+
+**`system/api_retry` in container logs, then failure:**
+The API is reachable but rejecting auth. Switch between `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN`.
+
+**`status=401` in OneCLI logs:**
+Wrong auth header. See above.
+
+**No traffic to provider in OneCLI logs at all:**
+`ANTHROPIC_BASE_URL` is not reaching the container. Confirm `npm run build` completed after editing `src/container-runner.ts`, and that the service was restarted.
+
+**Provider responds but output is garbled:**
+The provider may not fully support all Claude API features (tool use, streaming). Check provider documentation for known limitations.

--- a/README.md
+++ b/README.md
@@ -169,19 +169,23 @@ We don't want configuration sprawl. Every user should customize NanoClaw so that
 
 **Can I use third-party or open-source models?**
 
-Yes. NanoClaw supports any Claude API-compatible model endpoint. Set these environment variables in your `.env` file:
+Yes. NanoClaw supports any Claude API-compatible model endpoint. Run `/use-custom-model` for a guided setup, or manually set these environment variables in your `.env` file:
 
 ```bash
 ANTHROPIC_BASE_URL=https://your-api-endpoint.com
 ANTHROPIC_AUTH_TOKEN=your-token-here
+ANTHROPIC_MODEL=model-name
 ```
 
 This allows you to use:
 - Local models via [Ollama](https://ollama.ai) with an API proxy
 - Open-source models hosted on [Together AI](https://together.ai), [Fireworks](https://fireworks.ai), etc.
+- Commercial providers like [Moonshot AI (Kimi K2.5)](https://moonshot.cn)
 - Custom model deployments with Anthropic-compatible APIs
 
-Note: The model must support the Anthropic API format for best compatibility.
+The `/use-custom-model` skill handles the full setup: collecting provider details, configuring `.env`, setting up [OneCLI](https://github.com/onecli/onecli) credentials, and verifying the connection. See [docs/kimi-k2-integration.md](docs/kimi-k2-integration.md) for a detailed technical walkthrough.
+
+Note: The model must support the Anthropic API format (messages endpoint, streaming, tool use) for best compatibility.
 
 **How do I debug issues?**
 

--- a/docs/kimi-k2-integration.md
+++ b/docs/kimi-k2-integration.md
@@ -1,0 +1,232 @@
+# Using NanoClaw with Kimi K2.5 (Moonshot AI)
+
+This document explains how to configure NanoClaw to use Moonshot AI's Kimi K2.5 model instead of Anthropic's Claude. It covers why the obvious approaches fail, the root cause, and the working solution.
+
+---
+
+## Background
+
+NanoClaw uses the **Claude Agent SDK** (`@anthropic-ai/claude-code`) inside each container. The SDK supports a custom API endpoint via `ANTHROPIC_BASE_URL`, which Moonshot AI exposes as an Anthropic-compatible endpoint.
+
+However, NanoClaw's credential system (OneCLI Agent Vault) adds complexity that makes the naive approach fail in non-obvious ways.
+
+---
+
+## Why the Obvious Approaches Don't Work
+
+### Attempt 1: Set `ANTHROPIC_BASE_URL` in `.env`
+
+```bash
+ANTHROPIC_BASE_URL=https://api.moonshot.ai/anthropic
+ANTHROPIC_API_KEY=sk-your-moonshot-key
+```
+
+**Why it fails:** NanoClaw's `setup/index.ts` only extracts `ANTHROPIC_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN` from `.env` and writes them to `data/env/env`. `ANTHROPIC_BASE_URL` is deliberately excluded — it never reaches the container.
+
+---
+
+### Attempt 2: Configure OneCLI to proxy Moonshot
+
+```bash
+onecli secrets create --name Anthropic --type anthropic \
+  --value "sk-your-moonshot-key" \
+  --host-pattern "api.moonshot.ai" \
+  --path-pattern "/anthropic*"
+```
+
+**Why it fails:** OneCLI's `anthropic` secret type injects the key as the `x-api-key` HTTP header (Anthropic's format). But Moonshot requires the key as `Authorization: Bearer <token>`, which is what the Anthropic SDK uses when `ANTHROPIC_AUTH_TOKEN` is set — not `ANTHROPIC_API_KEY`. The result is HTTP 401 on every request.
+
+Evidence from OneCLI proxy logs:
+```
+MITM method=POST url=https://api.moonshot.ai:443/anthropic/v1/messages status=401 injections_applied=0
+```
+
+---
+
+### Attempt 3: Hardcode env vars in `container-runner.ts`
+
+```typescript
+args.push('-e', 'ANTHROPIC_BASE_URL=https://api.moonshot.ai/anthropic');
+args.push('-e', 'ANTHROPIC_MODEL=kimi-k2.5');
+```
+
+**Why it partially works but auth still fails:** The env vars do reach the container (verified with `docker exec <container> env`). But the SDK still uses `ANTHROPIC_API_KEY` to set `x-api-key`, which Moonshot rejects. The `system/api_retry` messages in container logs indicate auth failures being retried.
+
+---
+
+## Root Cause
+
+There are two distinct problems:
+
+### Problem 1: `ANTHROPIC_BASE_URL` never reaches the container
+
+NanoClaw's setup scripts and `data/env/env` mechanism only pass auth credentials to containers, not endpoint configuration. The container-runner must explicitly pass `ANTHROPIC_BASE_URL` as a `-e` flag.
+
+### Problem 2: Wrong auth header format for Moonshot
+
+The Anthropic SDK uses two different auth mechanisms:
+- `ANTHROPIC_API_KEY` → sends `x-api-key: <value>` header
+- `ANTHROPIC_AUTH_TOKEN` → sends `Authorization: Bearer <value>` header
+
+Moonshot's Anthropic-compatible API requires `Authorization: Bearer`, meaning you must set `ANTHROPIC_AUTH_TOKEN`, not `ANTHROPIC_API_KEY`.
+
+From Moonshot's official documentation:
+```bash
+export ANTHROPIC_BASE_URL=https://api.moonshot.ai/anthropic
+export ANTHROPIC_AUTH_TOKEN=${YOUR_MOONSHOT_API_KEY}
+```
+
+---
+
+## The Working Solution
+
+### Step 1: Update `src/container-runner.ts`
+
+Import `readEnvFile` and dynamically read Anthropic-related env vars from `.env`, passing them directly to the container as `-e` flags. This bypasses the `data/env/env` mechanism entirely.
+
+```typescript
+// In imports:
+import { readEnvFile } from './env.js';
+
+// In buildContainerArgs(), after TZ is pushed:
+const anthropicEnv = readEnvFile([
+  'ANTHROPIC_BASE_URL',
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_AUTH_TOKEN',
+  'ANTHROPIC_MODEL',
+]);
+for (const [key, value] of Object.entries(anthropicEnv)) {
+  args.push('-e', `${key}=${value}`);
+}
+```
+
+This reads values fresh from `.env` on every container spawn — no rebuild required when you change credentials.
+
+### Step 2: Set the correct variables in `.env`
+
+```bash
+ANTHROPIC_BASE_URL=https://api.moonshot.ai/anthropic
+ANTHROPIC_AUTH_TOKEN=sk-your-moonshot-key   # NOT ANTHROPIC_API_KEY
+ANTHROPIC_MODEL=kimi-k2.5
+```
+
+**Critical:** Use `ANTHROPIC_AUTH_TOKEN`, not `ANTHROPIC_API_KEY`. This triggers Bearer token auth in the Anthropic SDK, which is what Moonshot expects.
+
+### Step 3: Configure OneCLI to match the new host
+
+OneCLI still intercepts HTTPS traffic via its proxy. Even though `ANTHROPIC_AUTH_TOKEN` is set directly, OneCLI must know about `api.moonshot.ai` to allow the connection through (or it blocks/misroutes it).
+
+```bash
+onecli secrets create \
+  --name "Kimi" \
+  --type anthropic \
+  --value "sk-your-moonshot-key" \
+  --host-pattern "api.moonshot.ai" \
+  --path-pattern "/anthropic*"
+```
+
+Remove any old `api.anthropic.com` secret if you want to force all calls through Moonshot:
+
+```bash
+onecli secrets delete --id <old-anthropic-secret-id>
+```
+
+### Step 4: Rebuild and restart
+
+```bash
+npm run build
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw  # macOS
+# or: systemctl --user restart nanoclaw            # Linux
+```
+
+---
+
+## Verification
+
+### 1. Confirm env vars reach the container
+
+```bash
+docker ps | grep sales   # get container name
+docker exec <container-name> env | grep ANTHROPIC
+```
+
+Expected output:
+```
+ANTHROPIC_API_KEY=placeholder        # set by OneCLI (harmless)
+ANTHROPIC_AUTH_TOKEN=sk-your-key     # set by our fix ✓
+ANTHROPIC_BASE_URL=https://api.moonshot.ai/anthropic  ✓
+ANTHROPIC_MODEL=kimi-k2.5            ✓
+```
+
+### 2. Confirm API calls go to Moonshot
+
+```bash
+docker logs onecli 2>&1 | grep "moonshot\|anthropic" | tail -10
+```
+
+A successful call looks like:
+```
+MITM method=POST url=https://api.moonshot.ai:443/anthropic/v1/messages?beta=true status=200
+```
+
+`status=200` on `api.moonshot.ai` confirms Kimi K2.5 is handling requests.
+
+---
+
+## How it Works End-to-End
+
+```
+.env (ANTHROPIC_AUTH_TOKEN, ANTHROPIC_BASE_URL, ANTHROPIC_MODEL)
+  ↓
+container-runner.ts reads via readEnvFile() on each container spawn
+  ↓
+Docker container receives -e ANTHROPIC_AUTH_TOKEN=sk-... -e ANTHROPIC_BASE_URL=...
+  ↓
+Claude Agent SDK inside container reads these env vars
+  ↓
+SDK sends POST to https://api.moonshot.ai/anthropic/v1/messages
+  with header: Authorization: Bearer sk-your-moonshot-key
+  ↓
+OneCLI proxy intercepts (HTTPS_PROXY), sees api.moonshot.ai, passes through
+  ↓
+Moonshot API responds with Kimi K2.5 completion ✓
+```
+
+---
+
+## Reverting to Claude (Anthropic)
+
+To switch back to Anthropic Claude:
+
+1. In `.env`:
+   ```bash
+   # Remove or comment out:
+   # ANTHROPIC_BASE_URL=https://api.moonshot.ai/anthropic
+   # ANTHROPIC_AUTH_TOKEN=sk-moonshot-key
+   # ANTHROPIC_MODEL=kimi-k2.5
+
+   # Add back:
+   ANTHROPIC_API_KEY=sk-ant-your-anthropic-key
+   ```
+
+2. In OneCLI, restore the Anthropic secret:
+   ```bash
+   onecli secrets create --name Anthropic --type anthropic \
+     --value "sk-ant-your-key" \
+     --host-pattern "api.anthropic.com"
+   ```
+
+3. Rebuild and restart NanoClaw.
+
+---
+
+## Key Takeaways
+
+| Env Var | Purpose | When to Use |
+|---------|---------|-------------|
+| `ANTHROPIC_API_KEY` | Sets `x-api-key` header | Standard Anthropic API |
+| `ANTHROPIC_AUTH_TOKEN` | Sets `Authorization: Bearer` header | Moonshot and other compatible providers |
+| `ANTHROPIC_BASE_URL` | Redirects API endpoint | Any non-Anthropic provider |
+| `ANTHROPIC_MODEL` | Sets default model | Override the default claude model name |
+
+The critical insight: **the header format matters**. Moonshot uses Bearer auth, Anthropic uses x-api-key. Using the wrong env var causes silent 401 failures that look like retries in the logs.

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -17,6 +17,7 @@ import {
   TIMEZONE,
 } from './config.js';
 import { resolveGroupFolderPath, resolveGroupIpcPath } from './group-folder.js';
+import { readEnvFile } from './env.js';
 import { logger } from './logger.js';
 import {
   CONTAINER_RUNTIME_BIN,
@@ -251,6 +252,18 @@ async function buildContainerArgs(
 
   // Pass host timezone so container's local time matches the user's
   args.push('-e', `TZ=${TIMEZONE}`);
+
+  // Pass Anthropic API configuration from .env (supports custom endpoints like Moonshot).
+  // Read directly so changes to .env take effect without rebuilding.
+  const anthropicEnv = readEnvFile([
+    'ANTHROPIC_BASE_URL',
+    'ANTHROPIC_API_KEY',
+    'ANTHROPIC_AUTH_TOKEN',
+    'ANTHROPIC_MODEL',
+  ]);
+  for (const [key, value] of Object.entries(anthropicEnv)) {
+    args.push('-e', `${key}=${value}`);
+  }
 
   // OneCLI gateway handles credential injection — containers never see real secrets.
   // The gateway intercepts HTTPS traffic and injects API keys or OAuth tokens.


### PR DESCRIPTION
The README documents ANTHROPIC_BASE_URL as a supported way to use non-Anthropic providers, but the variable never reached containers. Only ANTHROPIC_API_KEY and CLAUDE_CODE_OAUTH_TOKEN were forwarded via the data/env/env mechanism.

This fix reads ANTHROPIC_BASE_URL, ANTHROPIC_API_KEY, ANTHROPIC_AUTH_TOKEN, and ANTHROPIC_MODEL directly from .env at container spawn time and passes them as -e flags to the docker run command.

Also adds:
- docs/kimi-k2-integration.md: explains root causes and working solution for Moonshot Kimi K2.5 (confirmed working)
- .claude/skills/use-custom-model/: operational skill that guides users through configuring any Anthropic-compatible provider

Key insight: Moonshot requires Authorization: Bearer (ANTHROPIC_AUTH_TOKEN), not x-api-key (ANTHROPIC_API_KEY). Using the wrong variable causes silent 401 failures that appear as api_retry loops in container logs.

<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description


## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
