### PR TITLE
feat: surface agent API errors to users with friendly messages

### DIFF
--- a/container/agent-runner/package-lock.json
+++ b/container/agent-runner/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.92",
+        "@anthropic-ai/sdk": "^0.88.0",
         "@modelcontextprotocol/sdk": "^1.12.1",
         "cron-parser": "^5.0.0",
         "zod": "^4.0.0"
@@ -45,10 +46,30 @@
         "zod": "^4.0.0"
       }
     },
-    "node_modules/@anthropic-ai/sdk": {
+    "node_modules/@anthropic-ai/claude-agent-sdk/node_modules/@anthropic-ai/sdk": {
       "version": "0.80.0",
       "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.80.0.tgz",
       "integrity": "sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.88.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.88.0.tgz",
+      "integrity": "sha512-QQOtB5U9ZBJQj6y1ICmDZl14LWa4JCiJRoihI+0yuZ4OjbONrakP0yLwPv4DJFb3VYCtQM31bTOpCBMs2zghPw==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"

--- a/container/agent-runner/package.json
+++ b/container/agent-runner/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.92",
+    "@anthropic-ai/sdk": "^0.88.0",
     "@modelcontextprotocol/sdk": "^1.12.1",
     "cron-parser": "^5.0.0",
     "zod": "^4.0.0"

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -22,7 +22,55 @@ import {
   HookCallback,
   PreCompactHookInput,
 } from '@anthropic-ai/claude-agent-sdk';
+import Anthropic from '@anthropic-ai/sdk';
 import { fileURLToPath } from 'url';
+
+/**
+ * Classify an error thrown during query() iteration and return a
+ * user-facing message. Errors from the Claude Agent SDK's transport
+ * layer propagate as @anthropic-ai/sdk error instances, which we can
+ * discriminate by class. Everything else falls through to a generic
+ * message so unexpected errors never leak stack traces to chat.
+ *
+ * Note: there is no APIStatusError class in @anthropic-ai/sdk. The
+ * actual base class is Anthropic.APIError, which carries a .status
+ * field we check for 529 (Overloaded, Anthropic-specific) and 5xx.
+ */
+function classifyApiError(err: unknown): string {
+  if (err instanceof Anthropic.RateLimitError) {
+    return 'Anthropic rate limit reached. Please try again in a moment.';
+  }
+  if (err instanceof Anthropic.AuthenticationError) {
+    return 'Anthropic API key is invalid or missing.';
+  }
+  if (err instanceof Anthropic.PermissionDeniedError) {
+    return 'Anthropic API access denied.';
+  }
+  if (err instanceof Anthropic.NotFoundError) {
+    return 'Anthropic model not found.';
+  }
+  if (err instanceof Anthropic.APIConnectionTimeoutError) {
+    return 'Could not reach Anthropic. Check your network connection.';
+  }
+  if (err instanceof Anthropic.APIConnectionError) {
+    return 'Could not reach Anthropic. Check your network connection.';
+  }
+  if (err instanceof Anthropic.APIError) {
+    if (err.status === 529) {
+      return 'Anthropic is currently overloaded. Please try again shortly.';
+    }
+    if (
+      err.status === 500 ||
+      err.status === 502 ||
+      err.status === 503 ||
+      err.status === 504
+    ) {
+      return 'Anthropic is experiencing server issues. Please try again shortly.';
+    }
+    return `Anthropic API error (HTTP ${err.status}).`;
+  }
+  return 'An unexpected error occurred.';
+}
 
 interface ContainerInput {
   prompt: string;
@@ -40,6 +88,8 @@ interface ContainerOutput {
   result: string | null;
   newSessionId?: string;
   error?: string;
+  /** Friendly user-facing message for error statuses (no stack trace, no PII). */
+  userMessage?: string;
 }
 
 interface SessionEntry {
@@ -435,106 +485,127 @@ async function runQuery(
     log(`Additional directories: ${extraDirs.join(', ')}`);
   }
 
-  for await (const message of query({
-    prompt: stream,
-    options: {
-      cwd: '/workspace/group',
-      additionalDirectories: extraDirs.length > 0 ? extraDirs : undefined,
-      resume: sessionId,
-      resumeSessionAt: resumeAt,
-      systemPrompt: globalClaudeMd
-        ? {
-            type: 'preset' as const,
-            preset: 'claude_code' as const,
-            append: globalClaudeMd,
-          }
-        : undefined,
-      allowedTools: [
-        'Bash',
-        'Read',
-        'Write',
-        'Edit',
-        'Glob',
-        'Grep',
-        'WebSearch',
-        'WebFetch',
-        'Task',
-        'TaskOutput',
-        'TaskStop',
-        'TeamCreate',
-        'TeamDelete',
-        'SendMessage',
-        'TodoWrite',
-        'ToolSearch',
-        'Skill',
-        'NotebookEdit',
-        'mcp__nanoclaw__*',
-      ],
-      env: sdkEnv,
-      permissionMode: 'bypassPermissions',
-      allowDangerouslySkipPermissions: true,
-      settingSources: ['project', 'user'],
-      mcpServers: {
-        nanoclaw: {
-          command: 'node',
-          args: [mcpServerPath],
-          env: {
-            NANOCLAW_CHAT_JID: containerInput.chatJid,
-            NANOCLAW_GROUP_FOLDER: containerInput.groupFolder,
-            NANOCLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
+  try {
+    for await (const message of query({
+      prompt: stream,
+      options: {
+        cwd: '/workspace/group',
+        additionalDirectories: extraDirs.length > 0 ? extraDirs : undefined,
+        resume: sessionId,
+        resumeSessionAt: resumeAt,
+        systemPrompt: globalClaudeMd
+          ? {
+              type: 'preset' as const,
+              preset: 'claude_code' as const,
+              append: globalClaudeMd,
+            }
+          : undefined,
+        allowedTools: [
+          'Bash',
+          'Read',
+          'Write',
+          'Edit',
+          'Glob',
+          'Grep',
+          'WebSearch',
+          'WebFetch',
+          'Task',
+          'TaskOutput',
+          'TaskStop',
+          'TeamCreate',
+          'TeamDelete',
+          'SendMessage',
+          'TodoWrite',
+          'ToolSearch',
+          'Skill',
+          'NotebookEdit',
+          'mcp__nanoclaw__*',
+        ],
+        env: sdkEnv,
+        permissionMode: 'bypassPermissions',
+        allowDangerouslySkipPermissions: true,
+        settingSources: ['project', 'user'],
+        mcpServers: {
+          nanoclaw: {
+            command: 'node',
+            args: [mcpServerPath],
+            env: {
+              NANOCLAW_CHAT_JID: containerInput.chatJid,
+              NANOCLAW_GROUP_FOLDER: containerInput.groupFolder,
+              NANOCLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
+            },
           },
         },
+        hooks: {
+          PreCompact: [
+            { hooks: [createPreCompactHook(containerInput.assistantName)] },
+          ],
+        },
       },
-      hooks: {
-        PreCompact: [
-          { hooks: [createPreCompactHook(containerInput.assistantName)] },
-        ],
-      },
-    },
-  })) {
-    messageCount++;
-    const msgType =
-      message.type === 'system'
-        ? `system/${(message as { subtype?: string }).subtype}`
-        : message.type;
-    log(`[msg #${messageCount}] type=${msgType}`);
+    })) {
+      messageCount++;
+      const msgType =
+        message.type === 'system'
+          ? `system/${(message as { subtype?: string }).subtype}`
+          : message.type;
+      log(`[msg #${messageCount}] type=${msgType}`);
 
-    if (message.type === 'assistant' && 'uuid' in message) {
-      lastAssistantUuid = (message as { uuid: string }).uuid;
-    }
+      if (message.type === 'assistant' && 'uuid' in message) {
+        lastAssistantUuid = (message as { uuid: string }).uuid;
+      }
 
-    if (message.type === 'system' && message.subtype === 'init') {
-      newSessionId = message.session_id;
-      log(`Session initialized: ${newSessionId}`);
-    }
+      if (message.type === 'system' && message.subtype === 'init') {
+        newSessionId = message.session_id;
+        log(`Session initialized: ${newSessionId}`);
+      }
 
-    if (
-      message.type === 'system' &&
-      (message as { subtype?: string }).subtype === 'task_notification'
-    ) {
-      const tn = message as {
-        task_id: string;
-        status: string;
-        summary: string;
-      };
-      log(
-        `Task notification: task=${tn.task_id} status=${tn.status} summary=${tn.summary}`,
-      );
-    }
+      if (
+        message.type === 'system' &&
+        (message as { subtype?: string }).subtype === 'task_notification'
+      ) {
+        const tn = message as {
+          task_id: string;
+          status: string;
+          summary: string;
+        };
+        log(
+          `Task notification: task=${tn.task_id} status=${tn.status} summary=${tn.summary}`,
+        );
+      }
 
-    if (message.type === 'result') {
-      resultCount++;
-      const textResult =
-        'result' in message ? (message as { result?: string }).result : null;
-      log(
-        `Result #${resultCount}: subtype=${message.subtype}${textResult ? ` text=${textResult.slice(0, 200)}` : ''}`,
-      );
-      writeOutput({
-        status: 'success',
-        result: textResult || null,
-        newSessionId,
-      });
+      if (message.type === 'result') {
+        resultCount++;
+        const textResult =
+          'result' in message ? (message as { result?: string }).result : null;
+        log(
+          `Result #${resultCount}: subtype=${message.subtype}${textResult ? ` text=${textResult.slice(0, 200)}` : ''}`,
+        );
+        writeOutput({
+          status: 'success',
+          result: textResult || null,
+          newSessionId,
+        });
+      }
     }
+  } catch (err) {
+    ipcPolling = false;
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    const userMessage = classifyApiError(err);
+    log(`Agent error: ${errorMessage}`);
+    writeOutput({
+      status: 'error',
+      result: null,
+      newSessionId,
+      error: errorMessage,
+      userMessage,
+    });
+    // Re-throw a sentinel so the outer main() catch knows the error has
+    // already been reported to the user and doesn't write a second,
+    // unclassified error output.
+    const reported = new Error(errorMessage);
+    (reported as Error & { __nanoclawReported?: boolean }).__nanoclawReported =
+      true;
+    throw reported;
   }
 
   ipcPolling = false;
@@ -722,13 +793,23 @@ async function main(): Promise<void> {
     }
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : String(err);
-    log(`Agent error: ${errorMessage}`);
-    writeOutput({
-      status: 'error',
-      result: null,
-      newSessionId: sessionId,
-      error: errorMessage,
-    });
+    // If runQuery's inner catch already classified and reported this
+    // error to the host (with userMessage), don't overwrite it with an
+    // unclassified second error output — just log and exit.
+    const alreadyReported =
+      err instanceof Error &&
+      (err as Error & { __nanoclawReported?: boolean }).__nanoclawReported ===
+        true;
+    if (!alreadyReported) {
+      log(`Agent error: ${errorMessage}`);
+      writeOutput({
+        status: 'error',
+        result: null,
+        newSessionId: sessionId,
+        error: errorMessage,
+        userMessage: classifyApiError(err),
+      });
+    }
     process.exit(1);
   }
 }

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -50,6 +50,13 @@ export interface ContainerOutput {
   result: string | null;
   newSessionId?: string;
   error?: string;
+  /**
+   * Friendly user-facing message for error statuses. Set by the agent-runner's
+   * classifyApiError() for Anthropic SDK errors; contains no stack trace or
+   * PII. The orchestrator forwards this verbatim to the chat channel when
+   * status === 'error'.
+   */
+  userMessage?: string;
 }
 
 interface VolumeMount {

--- a/src/index.ts
+++ b/src/index.ts
@@ -307,6 +307,25 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
 
     if (result.status === 'error') {
       hadError = true;
+      // Surface a friendly error to the user so failures aren't silent.
+      // The agent-runner's classifyApiError() produces userMessage for
+      // Anthropic SDK errors; fall back to a generic message for anything
+      // that slipped through unclassified.
+      //
+      // Intentionally does NOT set outputSentToUser = true: that flag
+      // controls cursor-rollback for retry, and we want the existing
+      // retry logic to run unchanged. Each retry attempt will surface
+      // its own error message if it also fails.
+      const userMessage =
+        result.userMessage ?? 'Something went wrong. Please try again.';
+      try {
+        await channel.sendMessage(chatJid, `⚠️ ${userMessage}`);
+      } catch (sendErr) {
+        logger.warn(
+          { chatJid, err: sendErr },
+          'Failed to deliver user-facing error message to channel',
+        );
+      }
     }
   });
 


### PR DESCRIPTION
## Problem

When the Anthropic API returns errors (429 rate limit, 529 overloaded, 5xx server errors, network failures), NanoClaw silently sets a `hadError` flag in the `onOutput` callback and says nothing to the user. After `MAX_RETRIES` (5) attempts the messages are dropped entirely with no chat-visible feedback — the user sees the typing indicator stop and then silence, and has no way to know whether their request was processed, is being retried, or was dropped.

Trace of the current flow:
1. Claude Agent SDK throws an `@anthropic-ai/sdk` error during the `for await (const message of query(...))` loop in `container/agent-runner/src/index.ts`
2. The generic outer `catch` stringifies `err.message` and writes a `ContainerOutput` with `status: 'error'`
3. The host's `onOutput` callback in `src/index.ts` sets `hadError = true` — no `channel.sendMessage` call
4. `GroupQueue.scheduleRetry` fires exponential backoff silently (5s → 10s → 20s → 40s → 80s), logging only to `logger.error`
5. After 5 retries, `logger.error('Max retries exceeded, dropping messages')` — still nothing to chat

## Solution

Three-layer fix, with graceful degradation between them.

### 1. `container/agent-runner/src/index.ts` — classify errors by SDK type

Added `@anthropic-ai/sdk` as a new dep (the Claude Agent SDK has no transitive deps, so the error types are not already reachable).

New `classifyApiError(err)` helper maps thrown errors to user-facing strings via `instanceof` checks on the SDK's exported error classes:

| Error class | User message |
|---|---|
| `Anthropic.RateLimitError` (429) | `Anthropic rate limit reached. Please try again in a moment.` |
| `Anthropic.APIError` with `status === 529` | `Anthropic is currently overloaded. Please try again shortly.` |
| `Anthropic.APIError` with `status ∈ {500, 502, 503, 504}` | `Anthropic is experiencing server issues. Please try again shortly.` |
| `Anthropic.AuthenticationError` (401) | `Anthropic API key is invalid or missing.` |
| `Anthropic.PermissionDeniedError` (403) | `Anthropic API access denied.` |
| `Anthropic.NotFoundError` (404) | `Anthropic model not found.` |
| `Anthropic.APIConnectionTimeoutError` | `Could not reach Anthropic. Check your network connection.` |
| `Anthropic.APIConnectionError` | `Could not reach Anthropic. Check your network connection.` |
| Any other `Anthropic.APIError` | `Anthropic API error (HTTP ${err.status}).` |
| Anything else | `An unexpected error occurred.` |

Wrapped the `for await (const message of query({...}))` loop in `runQuery()` with an inner `try/catch` that:
1. Calls `classifyApiError(err)` to produce a `userMessage`
2. Writes a `ContainerOutput` with both the raw `error: errorMessage` (preserved for logs) and the new `userMessage` field
3. Re-throws a sentinel error flagged with `__nanoclawReported = true` so the outer `main()` catch doesn't write a duplicate, unclassified error output

The outer `main()` catch was updated to check the sentinel flag and skip the duplicate `writeOutput`, and to use `classifyApiError` as a fallback for errors that escape the inner try (e.g. thrown from script setup before `query()`).

Added `userMessage?: string` to the agent-runner's local `ContainerOutput` interface.

The existing ``log(`Agent error: ${errorMessage}`)`` call is preserved verbatim so host-side logs still get the raw error for debugging.

**Note:** the spec'd `Anthropic.APIStatusError` doesn't exist in `@anthropic-ai/sdk`. The actual base class is `Anthropic.APIError`, which carries a `.status` field. This PR uses `err.status === 529` for Overloaded and `[500, 502, 503, 504]` for generic server issues — same semantics.

### 2. `src/container-runner.ts` — propagate `userMessage` through `ContainerOutput`

Added `userMessage?: string` to the exported `ContainerOutput` interface with a JSDoc comment documenting the contract (no stack trace, no PII, forwarded verbatim to the chat channel).

### 3. `src/index.ts` — send the error message to chat

In `processGroupMessages`'s `onOutput` callback, the `if (result.status === 'error')` branch now calls:

```ts
const userMessage = result.userMessage ?? 'Something went wrong. Please try again.';
try {
  await channel.sendMessage(chatJid, `⚠️ ${userMessage}`);
} catch (sendErr) {
  logger.warn({ chatJid, err: sendErr }, 'Failed to deliver user-facing error message to channel');
}
```

The `channel.sendMessage` call is wrapped in its own `try/catch` so a channel delivery failure (e.g. transient homeserver blip) doesn't crash the `onOutput` chain.

**Critical non-change:** this branch deliberately does NOT set `outputSentToUser = true`. That flag controls cursor-rollback for retries — flipping it would short-circuit the retry entirely. Each retry attempt now surfaces its own error message if it also fails.

## Graceful degradation

The host-side changes (items 2 + 3) take effect immediately on the next NanoClaw process restart. The agent-side change (item 1) only takes effect after the container image is rebuilt via `./container/build.sh` — until then, existing agent containers still use the old agent-runner and will not populate `userMessage`. When that happens, the host's fallback `'Something went wrong. Please try again.'` fires, so users still see an error message — just less specific. Strictly better than silence either way.

## Not changed

- `MAX_RETRIES` (5) and `BASE_RETRY_MS` (5000) — unchanged
- Exponential backoff schedule 5s → 10s → 20s → 40s → 80s — unchanged
- Cursor rollback logic in `processGroupMessages` — unchanged
- `GroupQueue.scheduleRetry` — unchanged (has no `channel` reference and threading one through would require restructuring the class)

## Per-retry UX

On a sustained outage, the user will see up to 5 `⚠️` messages spaced by the backoff delays before the retry counter exhausts and messages are dropped. That's a trade-off (vs. one message at the start and one at the end) but strictly better than the current silent failure, and avoids adding dedup/suppression logic that would conflict with the "no retry logic changes" constraint.

## Test plan

- [x] Host-side build clean (`npm run build`)
- [x] Agent-runner build clean (`cd container/agent-runner && npm run build`)
- [x] Existing test suite passes (246/246)
- [ ] Verify against a real rate-limit response (429): user should see `⚠️ Anthropic rate limit reached. Please try again in a moment.`
- [ ] Verify against a real overloaded response (529): user should see `⚠️ Anthropic is currently overloaded. Please try again shortly.`
- [ ] Verify against a network disconnect: user should see `⚠️ Could not reach Anthropic. Check your network connection.`
- [ ] Verify with a deliberately-invalid API key: user should see `⚠️ Anthropic API key is invalid or missing.`
- [ ] Verify graceful degradation: run host-side changes against an old agent-runner image and confirm the generic fallback fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)