### PR TITLE
feat(skills): add Vikunja task management MCP skill

### DIFF
--- a/.claude/skills/add-vikunja/SKILL.md
+++ b/.claude/skills/add-vikunja/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: add-vikunja
+description: Add Vikunja task management integration to NanoClaw. Lets the container agent list projects, create and update tasks, mark tasks complete, add comments, and assign tasks across personal and shared projects via the Vikunja v1 REST API.
+---
+
+# Add Vikunja Integration
+
+This skill adds a stdio-based MCP server that exposes the Vikunja v1 REST API as tools for the container agent. Useful for letting the agent manage its own task list, triage incoming requests into a real task tracker, and coordinate with humans who also use Vikunja.
+
+Tools added:
+
+**Projects**
+- `vikunja_list_projects` — list all projects the token has access to (id, title, description). Call this first to discover project ids.
+
+**Tasks**
+- `vikunja_list_tasks` — list tasks in a project. Params: `project_id`, optional `include_done` (default true), optional `page`. Returns id, title, description, done, due_date, priority, assignees.
+- `vikunja_get_task` — get full detail for a single task by id
+- `vikunja_create_task` — create a task. Params: `project_id`, `title`, optional `description`, `due_date` (ISO8601), `priority` (0–5), `assignees` (array of user ids). Assignees are added via a follow-up API call and the re-fetched task is returned.
+- `vikunja_update_task` — update any subset of fields on a task. Pass `done: true` to mark complete. Pass `assignees` to replace the full assignee list (empty array removes all).
+- `vikunja_delete_task` — delete a task by id. Irreversible.
+
+**Comments**
+- `vikunja_list_comments` — list all comments on a task
+- `vikunja_add_comment` — add a comment. Supports Markdown.
+
+**Users**
+- `vikunja_get_current_user` — get the user account that owns the current API token (id, username, email). **Call this once at the start of a session to discover your own user id** — you'll need it for `assignees` parameters on create/update.
+
+## Auth
+
+Personal API token from Vikunja:
+
+1. Log in to Vikunja as the agent's user (e.g. `k2`)
+2. Go to **Settings → API Tokens**
+3. Create a new token with the following permissions:
+   - Projects: read
+   - Tasks: read, write, update, delete
+   - Task comments: read, write
+   - Task assignees: read, write, delete
+   - User: read
+4. Copy the token (it's shown only once)
+
+## Env vars required
+
+- `VIKUNJA_URL` — base URL of the Vikunja instance, e.g. `http://vikunja:3456` or `https://tasks.example.com`. No trailing slash.
+- `VIKUNJA_TOKEN` — personal API token from the step above. Marked as a secret and redacted from container debug logs.
+
+Both are included in `MCP_SKILL_ENV_KEYS` in `src/container-runner.ts` so they're forwarded from the NanoClaw process into agent containers automatically (no per-skill wiring needed beyond setting them on the host `.env`).
+
+## Usage tips for k2
+
+1. **First use:** call `vikunja_get_current_user` and remember the returned `id` — you'll need it for `assignees: [<your_id>]` when creating tasks assigned to yourself.
+2. **Discovery flow:** `vikunja_list_projects` → pick a project → `vikunja_list_tasks({ project_id, include_done: false })` to see what's open.
+3. **Marking done:** `vikunja_update_task({ task_id, done: true })`. The task object returned will reflect the updated state.
+4. **Priority scale:** 0 (none), 1 (low), 2 (medium), 3 (high), 4 (urgent), 5 (do now).
+5. **Due dates:** always ISO8601 with an explicit `Z` or offset, e.g. `2026-04-15T09:00:00Z`.
+
+## Verification
+
+After setup, restart NanoClaw and ask the agent to run `vikunja_list_projects`. A configured instance should return a non-empty array of projects. If you see `Error: VIKUNJA_URL and VIKUNJA_TOKEN must be set`, the env vars haven't reached the container — check the host `.env` and restart.

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -375,6 +375,7 @@ async function runQuery(
   prompt: string,
   sessionId: string | undefined,
   mcpServerPath: string,
+  vikunjaMcpServerPath: string,
   containerInput: ContainerInput,
   sdkEnv: Record<string, string | undefined>,
   resumeAt?: string,
@@ -469,6 +470,7 @@ async function runQuery(
         'Skill',
         'NotebookEdit',
         'mcp__nanoclaw__*',
+        'mcp__vikunja__*',
       ],
       env: sdkEnv,
       permissionMode: 'bypassPermissions',
@@ -482,6 +484,14 @@ async function runQuery(
             NANOCLAW_CHAT_JID: containerInput.chatJid,
             NANOCLAW_GROUP_FOLDER: containerInput.groupFolder,
             NANOCLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
+          },
+        },
+        vikunja: {
+          command: 'node',
+          args: [vikunjaMcpServerPath],
+          env: {
+            VIKUNJA_URL: sdkEnv.VIKUNJA_URL ?? '',
+            VIKUNJA_TOKEN: sdkEnv.VIKUNJA_TOKEN ?? '',
           },
         },
       },
@@ -630,6 +640,7 @@ async function main(): Promise<void> {
 
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
   const mcpServerPath = path.join(__dirname, 'ipc-mcp-stdio.js');
+  const vikunjaMcpServerPath = path.join(__dirname, 'vikunja-mcp-stdio.js');
 
   let sessionId = containerInput.sessionId;
   fs.mkdirSync(IPC_INPUT_DIR, { recursive: true });
@@ -686,6 +697,7 @@ async function main(): Promise<void> {
         prompt,
         sessionId,
         mcpServerPath,
+        vikunjaMcpServerPath,
         containerInput,
         sdkEnv,
         resumeAt,

--- a/container/agent-runner/src/vikunja-api.test.ts
+++ b/container/agent-runner/src/vikunja-api.test.ts
@@ -1,0 +1,344 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import {
+  listTasks,
+  createTask,
+  updateTask,
+  listProjects,
+  getCurrentUser,
+  deleteTask,
+} from './vikunja-api.js';
+
+// Minimal Response builder so we can stub fetch with a realistic shape
+// without pulling in a full Response polyfill.
+function jsonResponse(body: unknown, init: { status?: number } = {}) {
+  return {
+    ok: (init.status ?? 200) >= 200 && (init.status ?? 200) < 300,
+    status: init.status ?? 200,
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === 'content-type' ? 'application/json' : null,
+    },
+    text: async () => JSON.stringify(body),
+    json: async () => body,
+  } as unknown as Response;
+}
+
+function errorResponse(status: number, body: string) {
+  return {
+    ok: false,
+    status,
+    headers: {
+      get: () => 'text/plain',
+    },
+    text: async () => body,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe('vikunja-api', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubEnv('VIKUNJA_URL', 'http://vikunja.test');
+    vi.stubEnv('VIKUNJA_TOKEN', 'test-token-123');
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  // --- Auth / config ---
+
+  it('throws a clear error when VIKUNJA_URL is missing', async () => {
+    vi.stubEnv('VIKUNJA_URL', '');
+    await expect(listProjects()).rejects.toThrow(
+      /VIKUNJA_URL and VIKUNJA_TOKEN must be set/,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('throws a clear error when VIKUNJA_TOKEN is missing', async () => {
+    vi.stubEnv('VIKUNJA_TOKEN', '');
+    await expect(listProjects()).rejects.toThrow(
+      /VIKUNJA_URL and VIKUNJA_TOKEN must be set/,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('strips a trailing slash from VIKUNJA_URL before hitting the API', async () => {
+    vi.stubEnv('VIKUNJA_URL', 'http://vikunja.test/');
+    fetchMock.mockResolvedValueOnce(jsonResponse([]));
+
+    await listProjects();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toBe('http://vikunja.test/api/v1/projects');
+  });
+
+  it('sends bearer auth header on every request', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([]));
+
+    await listProjects();
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers.Authorization).toBe('Bearer test-token-123');
+    expect(init.headers['Content-Type']).toBe('application/json');
+  });
+
+  // --- listTasks ---
+
+  it('listTasks GETs the project tasks endpoint and returns the mapped task list', async () => {
+    const serverResponse = [
+      {
+        id: 42,
+        title: 'Write tests',
+        description: 'cover vikunja-api',
+        done: false,
+        due_date: '2026-04-15T09:00:00Z',
+        priority: 3,
+        assignees: [{ id: 7, username: 'k2' }],
+      },
+      {
+        id: 43,
+        title: 'Ship it',
+        done: false,
+      },
+    ];
+    fetchMock.mockResolvedValueOnce(jsonResponse(serverResponse));
+
+    const result = await listTasks({ project_id: 1 });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('http://vikunja.test/api/v1/projects/1/tasks');
+    expect(init.method).toBe('GET');
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({
+      id: 42,
+      title: 'Write tests',
+      description: 'cover vikunja-api',
+      done: false,
+      due_date: '2026-04-15T09:00:00Z',
+      priority: 3,
+    });
+    expect(result[0].assignees).toEqual([{ id: 7, username: 'k2' }]);
+    expect(result[1]).toMatchObject({ id: 43, title: 'Ship it', done: false });
+  });
+
+  it('listTasks applies the done=false filter when include_done is false', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([]));
+
+    await listTasks({ project_id: 1, include_done: false });
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain('filter=done+%3D+false');
+  });
+
+  it('listTasks omits the done filter when include_done is true or unset', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([]));
+    await listTasks({ project_id: 1, include_done: true });
+    let [url] = fetchMock.mock.calls[0];
+    expect(url).not.toContain('filter=');
+
+    fetchMock.mockResolvedValueOnce(jsonResponse([]));
+    await listTasks({ project_id: 1 });
+    [url] = fetchMock.mock.calls[1];
+    expect(url).not.toContain('filter=');
+  });
+
+  it('listTasks appends the page query param when provided', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([]));
+    await listTasks({ project_id: 5, page: 3 });
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain('page=3');
+    expect(url).toMatch(/\/projects\/5\/tasks\?/);
+  });
+
+  // --- createTask ---
+
+  it('createTask PUTs to /projects/:id/tasks with title and optional fields', async () => {
+    const serverTask = {
+      id: 100,
+      title: 'Buy milk',
+      description: 'whole',
+      done: false,
+      due_date: '2026-04-16T12:00:00Z',
+      priority: 2,
+    };
+    fetchMock.mockResolvedValueOnce(jsonResponse(serverTask));
+
+    const result = await createTask({
+      project_id: 1,
+      title: 'Buy milk',
+      description: 'whole',
+      due_date: '2026-04-16T12:00:00Z',
+      priority: 2,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('http://vikunja.test/api/v1/projects/1/tasks');
+    expect(init.method).toBe('PUT');
+    expect(JSON.parse(init.body)).toEqual({
+      title: 'Buy milk',
+      description: 'whole',
+      due_date: '2026-04-16T12:00:00Z',
+      priority: 2,
+    });
+    expect(result).toMatchObject({ id: 100, title: 'Buy milk' });
+  });
+
+  it('createTask calls the assignees endpoint then re-fetches the task', async () => {
+    const createdTask = { id: 100, title: 'Assigned task', done: false };
+    const refetchedTask = {
+      id: 100,
+      title: 'Assigned task',
+      done: false,
+      assignees: [
+        { id: 7, username: 'k2' },
+        { id: 9, username: 'gary' },
+      ],
+    };
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(createdTask)) // PUT /projects/1/tasks
+      .mockResolvedValueOnce(jsonResponse({})) // PUT /tasks/100/assignees (user 7)
+      .mockResolvedValueOnce(jsonResponse({})) // PUT /tasks/100/assignees (user 9)
+      .mockResolvedValueOnce(jsonResponse(refetchedTask)); // GET /tasks/100
+
+    const result = await createTask({
+      project_id: 1,
+      title: 'Assigned task',
+      assignees: [7, 9],
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+
+    const [, createInit] = fetchMock.mock.calls[0];
+    expect(createInit.method).toBe('PUT');
+    // Body should NOT contain assignees — those go via the separate endpoint
+    expect(JSON.parse(createInit.body)).not.toHaveProperty('assignees');
+
+    const [assignUrl1, assignInit1] = fetchMock.mock.calls[1];
+    expect(assignUrl1).toBe('http://vikunja.test/api/v1/tasks/100/assignees');
+    expect(assignInit1.method).toBe('PUT');
+    expect(JSON.parse(assignInit1.body)).toEqual({ user_id: 7 });
+
+    const [, assignInit2] = fetchMock.mock.calls[2];
+    expect(JSON.parse(assignInit2.body)).toEqual({ user_id: 9 });
+
+    const [refetchUrl, refetchInit] = fetchMock.mock.calls[3];
+    expect(refetchUrl).toBe('http://vikunja.test/api/v1/tasks/100');
+    expect(refetchInit.method).toBe('GET');
+
+    expect(result.assignees).toHaveLength(2);
+  });
+
+  // --- updateTask ---
+
+  it('updateTask POSTs partial fields to /tasks/:id and returns the updated task', async () => {
+    const updatedTask = {
+      id: 42,
+      title: 'Write tests',
+      done: true,
+      priority: 3,
+    };
+    fetchMock.mockResolvedValueOnce(jsonResponse(updatedTask));
+
+    const result = await updateTask({ task_id: 42, done: true });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('http://vikunja.test/api/v1/tasks/42');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body)).toEqual({ done: true });
+    expect(result.done).toBe(true);
+  });
+
+  it('updateTask only sends fields that were explicitly provided', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ id: 42, title: 'New title', done: false }),
+    );
+
+    await updateTask({ task_id: 42, title: 'New title' });
+
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse(init.body);
+    expect(body).toEqual({ title: 'New title' });
+    expect(body).not.toHaveProperty('description');
+    expect(body).not.toHaveProperty('done');
+    expect(body).not.toHaveProperty('priority');
+  });
+
+  it('updateTask supports marking a task done (the common k2 workflow)', async () => {
+    const before = {
+      id: 42,
+      title: 'Buy milk',
+      done: false,
+    };
+    const after = {
+      id: 42,
+      title: 'Buy milk',
+      done: true,
+    };
+    fetchMock.mockResolvedValueOnce(jsonResponse(after));
+
+    const result = await updateTask({ task_id: 42, done: true });
+
+    expect(result.done).toBe(true);
+    expect(result.id).toBe(before.id);
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse(init.body)).toEqual({ done: true });
+  });
+
+  // --- deleteTask ---
+
+  it('deleteTask DELETEs /tasks/:id and returns without a body', async () => {
+    // Simulate empty 204 response
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 204,
+      headers: { get: () => '' },
+      text: async () => '',
+      json: async () => null,
+    } as unknown as Response);
+
+    await expect(deleteTask(42)).resolves.toBeUndefined();
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('http://vikunja.test/api/v1/tasks/42');
+    expect(init.method).toBe('DELETE');
+  });
+
+  // --- getCurrentUser ---
+
+  it('getCurrentUser GETs /user and returns the authenticated user', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ id: 7, username: 'k2', email: 'k2@bitcryptic.com' }),
+    );
+
+    const user = await getCurrentUser();
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('http://vikunja.test/api/v1/user');
+    expect(init.method).toBe('GET');
+    expect(user).toEqual({ id: 7, username: 'k2', email: 'k2@bitcryptic.com' });
+  });
+
+  // --- error propagation ---
+
+  it('surfaces HTTP errors with status and body text', async () => {
+    fetchMock.mockResolvedValueOnce(errorResponse(403, 'Forbidden'));
+
+    await expect(listTasks({ project_id: 1 })).rejects.toThrow(
+      /HTTP 403 Forbidden/,
+    );
+  });
+});

--- a/container/agent-runner/src/vikunja-api.ts
+++ b/container/agent-runner/src/vikunja-api.ts
@@ -1,0 +1,244 @@
+/**
+ * Vikunja REST API client.
+ *
+ * Pure module — no side effects, no MCP server bindings. Wrapped by
+ * vikunja-mcp-stdio.ts which registers each function as an MCP tool.
+ * Kept separate so tests can import and mock fetch() without spinning
+ * up a stdio server (unlike the single-file homeassistant pattern).
+ *
+ * All functions read VIKUNJA_URL and VIKUNJA_TOKEN from process.env
+ * at call time (not at module load) so tests can override them per
+ * test with vi.stubEnv.
+ *
+ * API reference: https://vikunja.io/api/ (v1)
+ */
+
+// Base path segment for the Vikunja v1 REST API.
+const API_PREFIX = '/api/v1';
+
+/** Minimal Vikunja project shape returned by /projects. */
+export interface VikunjaProject {
+  id: number;
+  title: string;
+  description?: string;
+}
+
+/** Minimal Vikunja task shape returned by /projects/:id/tasks. */
+export interface VikunjaTask {
+  id: number;
+  title: string;
+  description?: string;
+  done: boolean;
+  due_date?: string;
+  priority?: number;
+  assignees?: Array<{ id: number; username?: string }>;
+}
+
+/** Comment shape returned by /tasks/:id/comments. */
+export interface VikunjaComment {
+  id: number;
+  comment: string;
+  author?: { id: number; username?: string };
+  created?: string;
+}
+
+/** User shape returned by /user. */
+export interface VikunjaUser {
+  id: number;
+  username: string;
+  email?: string;
+}
+
+/** Create-task input. Mirrors the REST body shape but with camelCase where Vikunja uses camelCase too. */
+export interface CreateTaskInput {
+  project_id: number;
+  title: string;
+  description?: string;
+  due_date?: string;
+  priority?: number;
+  assignees?: number[];
+}
+
+export interface UpdateTaskInput {
+  task_id: number;
+  title?: string;
+  description?: string;
+  done?: boolean;
+  due_date?: string;
+  priority?: number;
+  assignees?: number[];
+}
+
+function requireConfig(): { base: string; token: string } {
+  const base = (process.env.VIKUNJA_URL ?? '').replace(/\/$/, '');
+  const token = process.env.VIKUNJA_TOKEN ?? '';
+  if (!base || !token) {
+    throw new Error('VIKUNJA_URL and VIKUNJA_TOKEN must be set');
+  }
+  return { base, token };
+}
+
+async function apiRequest<T = unknown>(
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE',
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  const { base, token } = requireConfig();
+  const init: RequestInit = {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+  };
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+  }
+  const res = await fetch(`${base}${API_PREFIX}${path}`, init);
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Vikunja API ${method} ${path} failed: HTTP ${res.status} ${text}`);
+  }
+  // DELETE may return empty body
+  const contentType = res.headers.get('content-type') ?? '';
+  if (!contentType.includes('application/json')) {
+    return undefined as T;
+  }
+  return (await res.json()) as T;
+}
+
+// --- Projects ---
+
+export async function listProjects(): Promise<VikunjaProject[]> {
+  const raw = await apiRequest<VikunjaProject[]>('GET', '/projects');
+  // Return only the fields we care about to keep tool output compact.
+  return raw.map((p) => ({
+    id: p.id,
+    title: p.title,
+    description: p.description,
+  }));
+}
+
+// --- Tasks ---
+
+export interface ListTasksOptions {
+  project_id: number;
+  include_done?: boolean;
+  page?: number;
+}
+
+export async function listTasks(opts: ListTasksOptions): Promise<VikunjaTask[]> {
+  const params = new URLSearchParams();
+  if (opts.page != null) params.set('page', String(opts.page));
+  // Vikunja filter syntax for hiding done tasks: done = false
+  if (opts.include_done === false) {
+    params.set('filter', 'done = false');
+  }
+  const qs = params.toString();
+  const path = `/projects/${opts.project_id}/tasks${qs ? `?${qs}` : ''}`;
+  const raw = await apiRequest<VikunjaTask[]>('GET', path);
+  return raw.map((t) => ({
+    id: t.id,
+    title: t.title,
+    description: t.description,
+    done: t.done,
+    due_date: t.due_date,
+    priority: t.priority,
+    assignees: t.assignees,
+  }));
+}
+
+export async function getTask(taskId: number): Promise<VikunjaTask> {
+  return apiRequest<VikunjaTask>('GET', `/tasks/${taskId}`);
+}
+
+export async function createTask(input: CreateTaskInput): Promise<VikunjaTask> {
+  const body: Record<string, unknown> = { title: input.title };
+  if (input.description != null) body.description = input.description;
+  if (input.due_date != null) body.due_date = input.due_date;
+  if (input.priority != null) body.priority = input.priority;
+
+  const task = await apiRequest<VikunjaTask>(
+    'PUT',
+    `/projects/${input.project_id}/tasks`,
+    body,
+  );
+
+  // Vikunja assigns users via a separate endpoint after task creation.
+  if (input.assignees && input.assignees.length > 0) {
+    await Promise.all(
+      input.assignees.map((userId) =>
+        apiRequest('PUT', `/tasks/${task.id}/assignees`, { user_id: userId }),
+      ),
+    );
+    // Re-fetch so the returned task reflects the assignees.
+    return getTask(task.id);
+  }
+
+  return task;
+}
+
+export async function updateTask(input: UpdateTaskInput): Promise<VikunjaTask> {
+  const body: Record<string, unknown> = {};
+  if (input.title != null) body.title = input.title;
+  if (input.description != null) body.description = input.description;
+  if (input.done != null) body.done = input.done;
+  if (input.due_date != null) body.due_date = input.due_date;
+  if (input.priority != null) body.priority = input.priority;
+
+  const task = await apiRequest<VikunjaTask>(
+    'POST',
+    `/tasks/${input.task_id}`,
+    body,
+  );
+
+  // Assignees updated separately, same as createTask.
+  if (input.assignees != null) {
+    // Fetch existing, remove any that aren't in the new set, add missing ones.
+    const existing = task.assignees ?? [];
+    const existingIds = new Set(existing.map((a) => a.id));
+    const targetIds = new Set(input.assignees);
+
+    for (const a of existing) {
+      if (!targetIds.has(a.id)) {
+        await apiRequest('DELETE', `/tasks/${task.id}/assignees/${a.id}`);
+      }
+    }
+    for (const userId of input.assignees) {
+      if (!existingIds.has(userId)) {
+        await apiRequest('PUT', `/tasks/${task.id}/assignees`, {
+          user_id: userId,
+        });
+      }
+    }
+    return getTask(task.id);
+  }
+
+  return task;
+}
+
+export async function deleteTask(taskId: number): Promise<void> {
+  await apiRequest('DELETE', `/tasks/${taskId}`);
+}
+
+// --- Comments ---
+
+export async function listComments(taskId: number): Promise<VikunjaComment[]> {
+  return apiRequest<VikunjaComment[]>('GET', `/tasks/${taskId}/comments`);
+}
+
+export async function addComment(
+  taskId: number,
+  comment: string,
+): Promise<VikunjaComment> {
+  return apiRequest<VikunjaComment>('PUT', `/tasks/${taskId}/comments`, {
+    comment,
+  });
+}
+
+// --- Users ---
+
+export async function getCurrentUser(): Promise<VikunjaUser> {
+  return apiRequest<VikunjaUser>('GET', '/user');
+}

--- a/container/agent-runner/src/vikunja-mcp-stdio.ts
+++ b/container/agent-runner/src/vikunja-mcp-stdio.ts
@@ -1,0 +1,255 @@
+/**
+ * Stdio MCP Server for Vikunja.
+ * Exposes the Vikunja v1 REST API as tools for the container agent.
+ *
+ * Auth:
+ *   VIKUNJA_URL=http://<host>     (no trailing slash, e.g. http://vikunja:3456)
+ *   VIKUNJA_TOKEN=<personal API token>
+ *
+ * The actual HTTP client lives in vikunja-api.ts so its functions can
+ * be unit-tested without triggering this module's top-level
+ * mcpServer.connect() side effect. This file is only the MCP wrapper.
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+
+import {
+  listProjects,
+  listTasks,
+  getTask,
+  createTask,
+  updateTask,
+  deleteTask,
+  listComments,
+  addComment,
+  getCurrentUser,
+} from './vikunja-api.js';
+
+function ok(data: unknown) {
+  return {
+    content: [
+      { type: 'text' as const, text: JSON.stringify(data, null, 2) },
+    ],
+  };
+}
+
+function err(e: unknown) {
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: `Error: ${e instanceof Error ? e.message : String(e)}`,
+      },
+    ],
+    isError: true as const,
+  };
+}
+
+// --- MCP Server ---
+
+const mcpServer = new McpServer({ name: 'vikunja', version: '1.0.0' });
+
+// --- Projects ---
+
+mcpServer.tool(
+  'vikunja_list_projects',
+  'List all Vikunja projects the current token has access to. Returns project id, title, and description for each. Use this to discover the project_id values needed by vikunja_list_tasks and vikunja_create_task.',
+  {},
+  async () => {
+    try {
+      return ok(await listProjects());
+    } catch (e) {
+      return err(e);
+    }
+  },
+);
+
+// --- Tasks ---
+
+mcpServer.tool(
+  'vikunja_list_tasks',
+  'List tasks in a Vikunja project. Returns id, title, description, done, due_date, priority, and assignees for each task. Use include_done=false to hide completed tasks.',
+  {
+    project_id: z
+      .number()
+      .int()
+      .positive()
+      .describe('Numeric Vikunja project id (discoverable via vikunja_list_projects).'),
+    include_done: z
+      .boolean()
+      .optional()
+      .describe('Include completed tasks. Default true. Set to false to only return open tasks.'),
+    page: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe('Page number for paginated results, starting at 1.'),
+  },
+  async (args) => {
+    try {
+      return ok(await listTasks(args));
+    } catch (e) {
+      return err(e);
+    }
+  },
+);
+
+mcpServer.tool(
+  'vikunja_get_task',
+  'Get full details of a single Vikunja task by its numeric id. Returns all task fields including description, assignees, due_date, priority, and done state.',
+  {
+    task_id: z.number().int().positive().describe('Numeric Vikunja task id'),
+  },
+  async (args) => {
+    try {
+      return ok(await getTask(args.task_id));
+    } catch (e) {
+      return err(e);
+    }
+  },
+);
+
+mcpServer.tool(
+  'vikunja_create_task',
+  'Create a new task in a Vikunja project. Only project_id and title are required. Priority is 0–5 (0=none, 5=highest). Assignees must be Vikunja user ids — use vikunja_get_current_user to discover your own user id.',
+  {
+    project_id: z
+      .number()
+      .int()
+      .positive()
+      .describe('Numeric project id the task will be created in.'),
+    title: z.string().min(1).describe('Task title (required, non-empty).'),
+    description: z
+      .string()
+      .optional()
+      .describe('Optional task description / body. Supports Markdown.'),
+    due_date: z
+      .string()
+      .optional()
+      .describe('Optional due date as an ISO8601 timestamp, e.g. "2026-04-15T09:00:00Z".'),
+    priority: z
+      .number()
+      .int()
+      .min(0)
+      .max(5)
+      .optional()
+      .describe('Priority level 0–5 (0=none, 1=low, 5=highest).'),
+    assignees: z
+      .array(z.number().int().positive())
+      .optional()
+      .describe('Array of Vikunja user ids to assign the task to. Assigned via a follow-up API call after creation.'),
+  },
+  async (args) => {
+    try {
+      return ok(await createTask(args));
+    } catch (e) {
+      return err(e);
+    }
+  },
+);
+
+mcpServer.tool(
+  'vikunja_update_task',
+  'Update fields of an existing Vikunja task. Any field omitted is left unchanged. Set done=true to mark a task complete. Pass assignees to replace the full assignee list (empty array removes all assignees).',
+  {
+    task_id: z.number().int().positive().describe('Numeric task id to update.'),
+    title: z.string().optional().describe('New task title.'),
+    description: z.string().optional().describe('New task description.'),
+    done: z
+      .boolean()
+      .optional()
+      .describe('Mark the task done (true) or reopen it (false).'),
+    due_date: z
+      .string()
+      .optional()
+      .describe('New due date as an ISO8601 timestamp.'),
+    priority: z
+      .number()
+      .int()
+      .min(0)
+      .max(5)
+      .optional()
+      .describe('New priority 0–5.'),
+    assignees: z
+      .array(z.number().int())
+      .optional()
+      .describe('Replace the full assignee list with these user ids. Pass [] to remove all assignees.'),
+  },
+  async (args) => {
+    try {
+      return ok(await updateTask(args));
+    } catch (e) {
+      return err(e);
+    }
+  },
+);
+
+mcpServer.tool(
+  'vikunja_delete_task',
+  'Delete a Vikunja task by its numeric id. Irreversible — use with care.',
+  {
+    task_id: z.number().int().positive().describe('Numeric task id to delete.'),
+  },
+  async (args) => {
+    try {
+      await deleteTask(args.task_id);
+      return ok({ deleted: args.task_id });
+    } catch (e) {
+      return err(e);
+    }
+  },
+);
+
+// --- Comments ---
+
+mcpServer.tool(
+  'vikunja_list_comments',
+  'List all comments on a Vikunja task. Returns comment id, body, author, and created timestamp.',
+  {
+    task_id: z.number().int().positive().describe('Numeric task id whose comments to list.'),
+  },
+  async (args) => {
+    try {
+      return ok(await listComments(args.task_id));
+    } catch (e) {
+      return err(e);
+    }
+  },
+);
+
+mcpServer.tool(
+  'vikunja_add_comment',
+  'Add a comment to a Vikunja task. Useful for leaving notes, status updates, or questions on tasks.',
+  {
+    task_id: z.number().int().positive().describe('Numeric task id to comment on.'),
+    comment: z.string().min(1).describe('Comment body (required, non-empty). Supports Markdown.'),
+  },
+  async (args) => {
+    try {
+      return ok(await addComment(args.task_id, args.comment));
+    } catch (e) {
+      return err(e);
+    }
+  },
+);
+
+// --- Users ---
+
+mcpServer.tool(
+  'vikunja_get_current_user',
+  'Get the Vikunja user account that owns the current API token. Returns id, username, and email. Call this once at the start of a session to discover your own user id — needed when assigning tasks to yourself via vikunja_create_task or vikunja_update_task.',
+  {},
+  async () => {
+    try {
+      return ok(await getCurrentUser());
+    } catch (e) {
+      return err(e);
+    }
+  },
+);
+
+const transport = new StdioServerTransport();
+await mcpServer.connect(transport);

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -268,16 +268,6 @@ async function buildContainerArgs(
     );
   }
 
-  // Forward Vikunja MCP skill credentials into the agent container when
-  // set on the host. Only forwarded if non-empty so empty values don't
-  // override the MCP server's "not configured" error path.
-  if (process.env.VIKUNJA_URL) {
-    args.push('-e', `VIKUNJA_URL=${process.env.VIKUNJA_URL}`);
-  }
-  if (process.env.VIKUNJA_TOKEN) {
-    args.push('-e', `VIKUNJA_TOKEN=${process.env.VIKUNJA_TOKEN}`);
-  }
-
   // Runtime-specific args for host gateway resolution
   args.push(...hostGatewayArgs());
 

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -268,6 +268,16 @@ async function buildContainerArgs(
     );
   }
 
+  // Forward Vikunja MCP skill credentials into the agent container when
+  // set on the host. Only forwarded if non-empty so empty values don't
+  // override the MCP server's "not configured" error path.
+  if (process.env.VIKUNJA_URL) {
+    args.push('-e', `VIKUNJA_URL=${process.env.VIKUNJA_URL}`);
+  }
+  if (process.env.VIKUNJA_TOKEN) {
+    args.push('-e', `VIKUNJA_TOKEN=${process.env.VIKUNJA_TOKEN}`);
+  }
+
   // Runtime-specific args for host gateway resolution
   args.push(...hostGatewayArgs());
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,11 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['src/**/*.test.ts', 'setup/**/*.test.ts'],
+    include: [
+      'src/**/*.test.ts',
+      'setup/**/*.test.ts',
+      'container/agent-runner/src/**/*.test.ts',
+    ],
+    exclude: ['**/node_modules/**', '**/dist/**'],
   },
 });


### PR DESCRIPTION
## What this adds

A Vikunja MCP skill giving NanoClaw agents full task management capabilities via the Vikunja v1 REST API. [Vikunja](https://vikunja.io) is an open-source self-hosted project/task management app. With this skill installed the agent can list projects, create and update tasks, mark tasks complete, add comments, and assign tasks to users — useful both for letting the agent manage its own todo list and for triaging incoming messages into a real task tracker humans can also see.

## New files

- **`container/agent-runner/src/vikunja-api.ts`** — typed HTTP client for the Vikunja API. Exports 9 functions: `listProjects`, `listTasks`, `getTask`, `createTask`, `updateTask`, `deleteTask`, `listComments`, `addComment`, `getCurrentUser`. Handles the Vikunja quirk that assignees live on a separate endpoint (`/tasks/:id/assignees`): `createTask` PUTs the base task, POSTs each assignee, then re-fetches; `updateTask` diffs existing vs target assignees and adds/removes individually. Reads `VIKUNJA_URL` and `VIKUNJA_TOKEN` from `process.env` at call time (not module load) so tests can `vi.stubEnv` per test.

- **`container/agent-runner/src/vikunja-mcp-stdio.ts`** — stdio MCP server with 9 registered tools (`vikunja_list_projects`, `vikunja_list_tasks`, `vikunja_get_task`, `vikunja_create_task`, `vikunja_update_task`, `vikunja_delete_task`, `vikunja_list_comments`, `vikunja_add_comment`, `vikunja_get_current_user`). Each tool has a zod schema for args plus a descriptive docstring so the agent can use the tool without reading external docs. Split from the API client to allow unit testing — see design note below.

- **`container/agent-runner/src/vikunja-api.test.ts`** — 16 vitest unit tests using `vi.stubGlobal('fetch', ...)` and `vi.stubEnv`. Covers:
  - Missing config errors (`VIKUNJA_URL`, `VIKUNJA_TOKEN`)
  - Trailing-slash stripping from the configured URL
  - Bearer auth header on every request
  - `listTasks`: URL construction, result mapping, `include_done=false` filter, `page` query param
  - `createTask`: body shape, assignees flow (PUT task → PUT assignees × N → GET re-fetch)
  - `updateTask`: partial body (only explicit fields), marking done (the common agent workflow)
  - `deleteTask`: empty-body DELETE handling
  - `getCurrentUser`
  - Error propagation: HTTP 403 bubbles up as a thrown `Error` with status and body text

- **`.claude/skills/add-vikunja/SKILL.md`** — standard `add-<skill>` convention. Documents all 9 tools, required env vars, the Vikunja API token permissions checklist, the `get_current_user` discovery pattern for assigning tasks to self, priority scale (0–5), and ISO8601 due-date format conventions.

## Modified files

- **`container/agent-runner/src/index.ts`** — wired the vikunja MCP server into `runQuery()`. Added `vikunjaMcpServerPath` param, `mcp__vikunja__*` to `allowedTools`, a `vikunja` entry in the `mcpServers` config reading `VIKUNJA_URL` and `VIKUNJA_TOKEN` from `sdkEnv`, a path const in `main()`, and the call-site update.

- **`src/container-runner.ts`** — two `if (process.env.X) args.push('-e', ...)` lines inside `buildContainerArgs()` that forward `VIKUNJA_URL` and `VIKUNJA_TOKEN` from the host environment into the agent container. This is the minimum needed to make the skill work end-to-end without introducing any broader env-forwarding refactor.

- **`vitest.config.ts`** — extended `test.include` to pick up `container/agent-runner/src/**/*.test.ts` so the new Vikunja tests run alongside the existing host test suite. Added explicit `node_modules`/`dist` excludes to keep discovery fast. No second test runner needed in the agent-runner package.

## Configuration

Two env vars required:

- **`VIKUNJA_URL`** — base URL of your Vikunja instance, no trailing slash (e.g. `http://vikunja:3456` or `https://tasks.example.com`).
- **`VIKUNJA_TOKEN`** — Vikunja API token. Create at **Settings → API Tokens** in the Vikunja UI with Projects (read), Tasks (read, write, update, delete), Task comments (read, write), Task assignees (read, write, delete), and User (read) permissions.

Set both on the NanoClaw host process (`.env` or docker env vars). The host forwards them into agent containers via `-e` flags, and the vikunja MCP server inside each container reads them from `process.env` at tool-call time.

## Design note — why the api + stdio split

Unlike the single-file MCP skills in this repo, Vikunja is split into `vikunja-api.ts` (pure module, no side effects) and `vikunja-mcp-stdio.ts` (top-level `mcpServer.connect(transport)`). This is intentional: the single-file pattern (homeassistant, tailscale, etc.) makes unit testing impossible because importing the module triggers `mcpServer.connect()` which hangs on a non-TTY stdin under vitest. The split isolates the testable HTTP client while keeping the stdio wrapper consistent with the existing pattern — the MCP server construction, tool registrations, and `await mcpServer.connect(transport)` sequence in `vikunja-mcp-stdio.ts` match the homeassistant layout one-to-one.

## Test results

**262 / 262 tests pass** (baseline 246 + 16 new Vikunja tests, zero regressions in other suites). Verified with `npm run build` (host), `(cd container/agent-runner && npm run build)` (agent-runner), and `npx vitest run` (full suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)