### PR TITLE
fix(credential-proxy): prepend upstream URL path to forwarded requests

### DIFF
--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -79,11 +79,16 @@ export function startCredentialProxy(
           }
         }
 
+        // Prepend upstream URL path so providers with a base path
+        // (e.g., https://api.z.ai/api/anthropic) work correctly.
+        const basePath = upstreamUrl.pathname.replace(/\/+$/, '');
+        const fullPath = basePath + req.url;
+
         const upstream = makeRequest(
           {
             hostname: upstreamUrl.hostname,
             port: upstreamUrl.port || (isHttps ? 443 : 80),
-            path: req.url,
+            path: fullPath,
             method: req.method,
             headers,
           } as RequestOptions,


### PR DESCRIPTION
## Summary

Fixes a bug where the credential proxy drops the path component from the upstream base URL when forwarding requests.

## Problem

The proxy uses `req.url` directly as the `path` in the upstream HTTP request. For providers with a non-root base URL (e.g., `https://api.z.ai/api/anthropic`), this means:

- Container sends: `POST /v1/messages`
- Proxy forwards to: `https://api.z.ai/v1/messages` (WRONG — 404)
- Should forward to: `https://api.z.ai/api/anthropic/v1/messages`

## Fix

Prepend `upstreamUrl.pathname` (stripped of trailing slashes) before `req.url`:

```typescript
const basePath = upstreamUrl.pathname.replace(/\/+$/, '');
const fullPath = basePath + req.url;
```

For providers with root base URLs (e.g., `https://api.anthropic.com`), `basePath` is empty and behavior is unchanged.

## Testing

- Tested with z.ai (`ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic`) — requests now correctly reach `/api/anthropic/v1/messages`
- No-op for standard Anthropic API (root base URL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>