### PR TITLE
feat: MS Graph MCP bridge for container access

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -469,6 +469,7 @@ async function runQuery(
         'Skill',
         'NotebookEdit',
         'mcp__nanoclaw__*',
+        'mcp__microsoft_graph__*',
       ],
       env: sdkEnv,
       permissionMode: 'bypassPermissions',
@@ -484,6 +485,15 @@ async function runQuery(
             NANOCLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
           },
         },
+        // MS Graph MCP exposed by mcp-proxy on the host
+        ...(process.env.MS_GRAPH_MCP_URL
+          ? {
+              microsoft_graph: {
+                type: 'http' as const,
+                url: process.env.MS_GRAPH_MCP_URL,
+              },
+            }
+          : {}),
       },
       hooks: {
         PreCompact: [

--- a/scripts/start-mcp-proxy.sh
+++ b/scripts/start-mcp-proxy.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Start MS Graph MCP server behind mcp-proxy for container access.
+# Containers reach it via http://host.docker.internal:8080/mcp
+#
+# Usage: ./scripts/start-mcp-proxy.sh
+# Stop:  kill $(cat mcp-proxy.pid)
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+PORT="${MCP_PROXY_PORT:-8080}"
+PID_FILE="mcp-proxy.pid"
+LOG_FILE="logs/mcp-proxy.log"
+
+mkdir -p logs
+
+# Stop existing instance
+if [ -f "$PID_FILE" ]; then
+  OLD_PID=$(cat "$PID_FILE" 2>/dev/null || echo "")
+  if [ -n "$OLD_PID" ] && kill -0 "$OLD_PID" 2>/dev/null; then
+    echo "Stopping existing mcp-proxy (PID $OLD_PID)..."
+    kill "$OLD_PID" 2>/dev/null || true
+    sleep 1
+  fi
+  rm -f "$PID_FILE"
+fi
+
+echo "Starting mcp-proxy on port $PORT..."
+nohup mcp-proxy --port "$PORT" -- npx -y @softeria/ms-365-mcp-server \
+  >> "$LOG_FILE" 2>&1 &
+
+echo $! > "$PID_FILE"
+echo "mcp-proxy started (PID $!) on port $PORT"
+echo "Logs: tail -f $LOG_FILE"
+
+# Health check
+sleep 3
+if kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+  echo "✓ mcp-proxy is running"
+else
+  echo "✗ mcp-proxy failed to start — check $LOG_FILE"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Adds `scripts/start-mcp-proxy.sh` — launcher that runs MS Graph MCP server behind mcp-proxy, exposing it as HTTP on port 8080
- Modifies `container/agent-runner/src/index.ts` to conditionally add `microsoft_graph` MCP server when `MS_GRAPH_MCP_URL` env var is set
- Adds `mcp__microsoft_graph__*` to agent allowedTools

## Setup

1. Install mcp-proxy: `npm install -g mcp-proxy`
2. Start the bridge: `./scripts/start-mcp-proxy.sh`
3. Add to `.env`: `MS_GRAPH_MCP_URL=http://host.docker.internal:8080/mcp`
4. Complete MS Graph OAuth via the MCP server's auth flow

## Test plan

- [ ] Start mcp-proxy, verify health check passes
- [ ] Complete MS Graph OAuth on host
- [ ] Spawn container, confirm `mcp__microsoft_graph__GetEvents` works
- [ ] Confirm OAuth tokens stay on host (never in container)
- [ ] Verify existing groups without MS Graph still work (env var unset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)