### PR TITLE
fix: make setup sandbox-safe by using project-local npm cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Dependencies
 node_modules/
 .npm-cache/
+.pnpm-store/
 # Build output
 dist/
 

--- a/setup.sh
+++ b/setup.sh
@@ -120,6 +120,10 @@ check_build_tools() {
 
 log "=== Bootstrap started ==="
 
+# Keep all caches project-local so setup works inside sandboxed environments
+# (e.g. Claude Code sandbox) without needing write access to ~/.npm or global stores.
+export npm_config_cache="$PROJECT_ROOT/.npm-cache"
+
 detect_platform
 
 check_node


### PR DESCRIPTION
## Summary
- Set `npm_config_cache` to `.npm-cache` in `setup.sh` so `npm ci` keeps all writes within the project directory
- Add `.pnpm-store/` to `.gitignore` (pnpm creates this fallback when the global store is unreachable)

This lets `bash setup.sh` run inside Claude Code sandbox without needing `dangerouslyDisableSandbox: true`. Verified: bootstrap completes with all-green status under default sandbox restrictions.

## Test plan
- [ ] `bash setup.sh` succeeds under Claude Code sandbox (no permission errors)
- [ ] `node -e "require('better-sqlite3')"` loads successfully
- [ ] `.npm-cache/` created in project root (not `~/.npm`)