### PR TITLE
chore: upgrade container base to node:24-trixie-slim

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,7 +1,7 @@
 # NanoClaw Agent Container
 # Runs Claude Agent SDK in isolated Linux VM with browser automation
 
-FROM node:22-slim
+FROM node:24-trixie-slim
 
 # Install system dependencies for Chromium
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
## Summary

- Upgrades the container base image from `node:22-slim` (Debian Bookworm) to `node:24-trixie-slim` (Debian Trixie)
- Fixes `gws` calendar breakage caused by `gws 0.22.5` requiring `GLIBC_2.39`, which Bookworm (GLIBC 2.36) didn't satisfy
- Trixie ships GLIBC 2.41; also upgrades Node from 22 to 24 LTS

## Test plan

- [ ] Rebuild container with `./container/build.sh`
- [ ] Verify `gws` calendar operations work without GLIBC errors
- [ ] Verify agent container starts and responds normally