### PR TITLE
fix: make mount path errors point users to the parent directory

### DIFF
--- a/src/mount-security.test.ts
+++ b/src/mount-security.test.ts
@@ -1,0 +1,112 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockLog = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+vi.mock('./log.js', () => ({
+  log: mockLog,
+}));
+
+let allowlistPath: string;
+
+vi.mock('./config.js', () => ({
+  get MOUNT_ALLOWLIST_PATH() {
+    return allowlistPath;
+  },
+}));
+
+describe('validateMount', () => {
+  let tempDir: string;
+  let validateMount: typeof import('./mount-security.js').validateMount;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-mounts-'));
+    allowlistPath = path.join(tempDir, 'mount-allowlist.json');
+    ({ validateMount } = await import('./mount-security.js'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it('rejects file mounts outside allowed roots and explains that only parent directories are supported', () => {
+    const privateDir = path.join(tempDir, 'private-files');
+    fs.mkdirSync(privateDir, { recursive: true });
+    const tokenFile = path.join(privateDir, 'pomoclaw-token');
+    fs.writeFileSync(tokenFile, 'secret');
+
+    const safeDir = path.join(tempDir, 'shared');
+    fs.mkdirSync(safeDir, { recursive: true });
+
+    fs.writeFileSync(
+      allowlistPath,
+      JSON.stringify(
+        {
+          allowedRoots: [
+            {
+              path: safeDir,
+              allowReadWrite: false,
+              description: 'Shared files',
+            },
+          ],
+          blockedPatterns: [],
+        },
+        null,
+        2,
+      ),
+    );
+
+    const result = validateMount({
+      hostPath: tokenFile,
+      containerPath: 'pomoclaw-token',
+      readonly: true,
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain('not under any allowed root');
+    expect(result.reason).toContain('Only parent directories can be allowlisted');
+    expect(result.reason).toContain(`Parent directory: "${privateDir}"`);
+  });
+
+  it('accepts directories under allowed roots', () => {
+    const sharedDir = path.join(tempDir, 'shared');
+    fs.mkdirSync(sharedDir, { recursive: true });
+
+    fs.writeFileSync(
+      allowlistPath,
+      JSON.stringify(
+        {
+          allowedRoots: [
+            {
+              path: sharedDir,
+              allowReadWrite: false,
+              description: 'Shared files',
+            },
+          ],
+          blockedPatterns: [],
+        },
+        null,
+        2,
+      ),
+    );
+
+    const result = validateMount({
+      hostPath: sharedDir,
+      containerPath: 'shared',
+      readonly: true,
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(result.realHostPath).toBe(fs.realpathSync(sharedDir));
+    expect(result.effectiveReadonly).toBe(true);
+  });
+});

--- a/src/mount-security.ts
+++ b/src/mount-security.ts
@@ -272,11 +272,17 @@ export function validateMount(mount: AdditionalMount): MountValidationResult {
   // Check if under an allowed root
   const allowedRoot = findAllowedRoot(realPath, allowlist.allowedRoots);
   if (allowedRoot === null) {
+    const parentDirectory = path.dirname(realPath);
+    const fileHint =
+      fs.statSync(realPath).isFile() && parentDirectory !== realPath
+        ? ` Only parent directories can be allowlisted, not individual files. Parent directory: "${parentDirectory}".`
+        : '';
+
     return {
       allowed: false,
       reason: `Path "${realPath}" is not under any allowed root. Allowed roots: ${allowlist.allowedRoots
         .map((r) => expandPath(r.path))
-        .join(', ')}`,
+        .join(', ')}.${fileHint}`,
     };
   }
 


### PR DESCRIPTION
Closes #1790

This tightens the mount-path error so `/setup` stops making people guess.

Right now if someone pastes a file path, NanoClaw just tells them the path is not under an allowed root. That is technically true, but it still leaves them doing trial and error. The real issue is simpler: the allowlist works at the parent-directory level, not the individual-file level.

What changed:
- when a rejected mount path resolves to a file, the error now says only parent directories can be allowlisted
- the message also shows the exact parent directory to use instead
- added a focused test covering the file-path case, plus a sanity check that allowed directories still pass

Why this helps:
- reduces setup friction
- makes the mount model obvious at the moment of failure
- gives the operator the next correct step immediately instead of forcing guesswork

Verification:
- `npx vitest run src/mount-security.test.ts`
- `npx tsc --noEmit`
