### PR TITLE
fix: thread ONECLI_API_KEY to host-side OneCLI clients

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
   GROUPS_DIR,
   IDLE_TIMEOUT,
   MAX_MESSAGES_PER_PROMPT,
+  ONECLI_API_KEY,
   ONECLI_URL,
   POLL_INTERVAL,
   TIMEZONE,
@@ -78,7 +79,7 @@ let messageLoopRunning = false;
 const channels: Channel[] = [];
 const queue = new GroupQueue();
 
-const onecli = new OneCLI({ url: ONECLI_URL });
+const onecli = new OneCLI({ url: ONECLI_URL, apiKey: ONECLI_API_KEY });
 
 function ensureOneCLIAgent(jid: string, group: RegisteredGroup): void {
   if (group.isMain) return;


### PR DESCRIPTION
## Summary
- read ONECLI_API_KEY from .env/config alongside ONECLI_URL
- pass the API key into host-side OneCLI clients used for container setup and approval handling
- keep host-side requests authenticated when the OneCLI server is protected

Closes #1818
