### PR TITLE
feat(providers): add codex provider via app-server JSON-RPC

### DIFF
--- a/.claude/skills/add-codex/SKILL.md
+++ b/.claude/skills/add-codex/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: add-codex
+description: Use Codex (CLI + AppServer) as the full agent provider — planning, tool orchestration, native compaction, MCP tools, session resume — in place of the Claude Agent SDK. ChatGPT subscription or OPENAI_API_KEY. Per-group via agent_provider. Distinct from using OpenAI as an MCP tool (where Claude remains the planner).
+---
+
+# Codex agent provider
+
+NanoClaw runs agents in a long-lived **poll loop** inside the container. The backend is selected with **`AGENT_PROVIDER`** (`claude` | `opencode` | `codex` | `mock`).
+
+Trunk ships with only the `claude` provider baked in. This skill copies the Codex provider files in from the `providers` branch, wires them into the host and container barrels, updates the Dockerfile to install the Codex CLI, and rebuilds the image.
+
+The Codex provider runs `codex app-server` as a child process and speaks JSON-RPC over stdio. That gives it native session resume, streaming events, MCP tool access, and `thread/compact/start` compaction — same feature bar as the Claude Agent SDK, without the Anthropic-only lock-in.
+
+## Install
+
+### Pre-flight
+
+If all of the following are already present, skip to **Configuration**:
+
+- `src/providers/codex.ts`
+- `container/agent-runner/src/providers/codex.ts`
+- `container/agent-runner/src/providers/codex-app-server.ts`
+- `container/agent-runner/src/providers/codex.factory.test.ts`
+- `import './codex.js';` line in `src/providers/index.ts`
+- `import './codex.js';` line in `container/agent-runner/src/providers/index.ts`
+- `ARG CODEX_VERSION` and `"@openai/codex@${CODEX_VERSION}"` in the pnpm global-install block in `container/Dockerfile`
+
+Missing pieces — continue below. All steps are idempotent; re-running is safe.
+
+### 1. Fetch the providers branch
+
+```bash
+git fetch origin providers
+```
+
+### 2. Copy the Codex source files
+
+Wholesale copies (owned entirely by this skill — user edits to these files won't survive a re-run, as designed):
+
+```bash
+git show origin/providers:src/providers/codex.ts                                      > src/providers/codex.ts
+git show origin/providers:container/agent-runner/src/providers/codex.ts               > container/agent-runner/src/providers/codex.ts
+git show origin/providers:container/agent-runner/src/providers/codex-app-server.ts    > container/agent-runner/src/providers/codex-app-server.ts
+git show origin/providers:container/agent-runner/src/providers/codex.factory.test.ts  > container/agent-runner/src/providers/codex.factory.test.ts
+```
+
+### 3. Append the self-registration imports
+
+Each barrel gets one line — alphabetical placement keeps diffs small.
+
+`src/providers/index.ts`:
+
+```typescript
+import './codex.js';
+```
+
+`container/agent-runner/src/providers/index.ts`:
+
+```typescript
+import './codex.js';
+```
+
+### 4. Add the Codex CLI to the container Dockerfile
+
+Two edits to `container/Dockerfile`, both idempotent (skip if already present):
+
+**(a)** In the "Pin CLI versions" ARG block (around line 18), add after `ARG CLAUDE_CODE_VERSION=...`:
+
+```dockerfile
+ARG CODEX_VERSION=0.121.0
+```
+
+**(b)** In the `pnpm install -g` block (around line 80), append `"@openai/codex@${CODEX_VERSION}"` to the list:
+
+```dockerfile
+    pnpm install -g \
+        "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+        "@openai/codex@${CODEX_VERSION}" \
+        "agent-browser@${AGENT_BROWSER_VERSION}" \
+        "vercel@${VERCEL_VERSION}"
+```
+
+Note: **no agent-runner package dependency** — Codex is a CLI binary, not a library. Unlike OpenCode, there's nothing to add to `container/agent-runner/package.json`.
+
+### 5. Build
+
+```bash
+pnpm run build                                         # host
+pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit   # container typecheck
+./container/build.sh                                   # agent image
+```
+
+## Configuration
+
+Codex supports two primary auth paths and one experimental BYO-endpoint path. Pick the one that matches your setup.
+
+### Option A — ChatGPT subscription (recommended for individuals)
+
+On the host (not inside the container), run Codex's OAuth login:
+
+```bash
+codex login
+```
+
+This writes `~/.codex/auth.json` with a subscription token. The host-side Codex provider ([src/providers/codex.ts](../../../src/providers/codex.ts)) copies `auth.json` into a per-session `~/.codex` directory mounted into the container — your host's own Codex CLI is never touched.
+
+No `.env` variables required for this mode.
+
+### Option B — API key (recommended for CI or API billing)
+
+```env
+OPENAI_API_KEY=sk-...
+CODEX_MODEL=gpt-5.4-mini
+```
+
+The host forwards both variables into the container. If both subscription (`auth.json`) and `OPENAI_API_KEY` are present, Codex prefers the subscription.
+
+### Option C — BYO OpenAI-compatible endpoint (experimental)
+
+Codex's built-in `openai` provider honors the `OPENAI_BASE_URL` env var directly. Point it at any OpenAI-compatible endpoint — Groq, Together, self-hosted vLLM, an OpenAI proxy, etc.
+
+```env
+OPENAI_API_KEY=...
+OPENAI_BASE_URL=https://api.groq.com/openai/v1
+CODEX_MODEL=llama-3.3-70b-versatile
+```
+
+Codex also ships first-class local-runner flags — `codex --oss --local-provider ollama` or `--local-provider lmstudio` — that auto-detect a local server. To use those inside NanoClaw, set `CODEX_MODEL` to a model your local runner serves and add the corresponding base URL; see the Codex CLI docs for the full `model_provider = oss` configuration.
+
+**Experimental caveat:** tool-calling quality depends on the model and endpoint. Not every OpenAI-compat provider implements the full function-calling spec, and smaller models (< 30B) often struggle with multi-step tool orchestration. Test before committing.
+
+### Per group / per session
+
+Schema: **`agent_groups.agent_provider`** and **`sessions.agent_provider`**. Set to `codex` for groups or sessions that should use Codex. The container receives `AGENT_PROVIDER` from the resolved value (session overrides group).
+
+`CODEX_MODEL` applies process-wide via `.env`; if you need different models for different groups, set them via `container_config.env` on the group.
+
+Extra MCP servers still come from **`NANOCLAW_MCP_SERVERS`** / `container_config.mcpServers` on the host. The runner merges them into the same `mcpServers` object passed to all providers.
+
+## Operational notes
+
+- **Spawn-per-query:** Codex's app-server is spawned fresh per query invocation, matching the OpenCode pattern. No long-lived daemon to keep healthy across sessions.
+- **Per-session `~/.codex` isolation:** each group gets its own copy of the host's `auth.json`. The container can rewrite `config.toml` freely on every wake without touching the host's Codex config.
+- **Native compaction:** kicks in automatically at 40K cumulative input tokens between turns, via `thread/compact/start`. If compaction fails, the provider logs and continues uncompacted — no fatal error.
+- **Approvals:** auto-accepted inside the container (the container is the sandbox; same posture as Claude/OpenCode).
+- **Mid-turn input:** Codex turns don't accept mid-turn messages. Follow-up `push()` calls queue and drain between turns, matching the OpenCode pattern. The poll-loop only pushes between turns anyway, so no messages are dropped.
+- **Stale thread recovery:** `isSessionInvalid` matches on stale-thread-ID errors (`thread not found`, `unknown thread`, etc.) so a cold-started app-server can recover cleanly when it sees a stored continuation it no longer has.
+
+## Verify
+
+```bash
+grep -q "./codex.js" container/agent-runner/src/providers/index.ts && echo "container barrel: OK"
+grep -q "./codex.js" src/providers/index.ts && echo "host barrel: OK"
+grep -q "@openai/codex@" container/Dockerfile && echo "Dockerfile install: OK"
+cd container/agent-runner && bun test src/providers/codex.factory.test.ts && cd -
+```
+
+After the image rebuild, set `agent_provider = 'codex'` on a test group and send a message. Successful round-trip looks like:
+
+- `init` event with a stable thread ID as continuation
+- One or more `activity` / `progress` events during the turn
+- `result` event with the model's reply
+
+If the agent hangs or errors, check `~/.codex/auth.json` exists on the host (Option A) or that `OPENAI_API_KEY` is forwarding correctly (Option B) — `docker exec` into a running container and `env | grep -i openai` to confirm.

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -16,6 +16,7 @@ ARG INSTALL_CJK_FONTS=false
 # mean every rebuild silently picks up the latest and can break in lockstep
 # across all users.
 ARG CLAUDE_CODE_VERSION=2.1.112
+ARG CODEX_VERSION=0.121.0
 ARG AGENT_BROWSER_VERSION=latest
 ARG VERCEL_VERSION=latest
 ARG BUN_VERSION=1.3.12
@@ -78,6 +79,7 @@ RUN --mount=type=cache,target=/root/.cache/pnpm \
     echo "only-built-dependencies[]=agent-browser" > /root/.npmrc && \
     pnpm install -g \
         "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+        "@openai/codex@${CODEX_VERSION}" \
         "agent-browser@${AGENT_BROWSER_VERSION}" \
         "vercel@${VERCEL_VERSION}"
 

--- a/container/agent-runner/src/providers/codex-app-server.test.ts
+++ b/container/agent-runner/src/providers/codex-app-server.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'bun:test';
+
+import { STALE_THREAD_RE, tomlBasicString } from './codex-app-server.js';
+
+describe('tomlBasicString', () => {
+  it('leaves safe strings unchanged inside quotes', () => {
+    expect(tomlBasicString('hello')).toBe('"hello"');
+    expect(tomlBasicString('bun')).toBe('"bun"');
+    expect(tomlBasicString('/usr/local/bin/node')).toBe('"/usr/local/bin/node"');
+  });
+
+  it('escapes double-quotes', () => {
+    expect(tomlBasicString('a"b')).toBe('"a\\"b"');
+    expect(tomlBasicString('"quoted"')).toBe('"\\"quoted\\""');
+  });
+
+  it('escapes backslashes', () => {
+    expect(tomlBasicString('a\\b')).toBe('"a\\\\b"');
+    expect(tomlBasicString('C:\\path\\to\\bin')).toBe('"C:\\\\path\\\\to\\\\bin"');
+  });
+
+  it('escapes backslash before quote (order matters)', () => {
+    expect(tomlBasicString('\\"')).toBe('"\\\\\\""');
+  });
+
+  it('rejects strings containing newlines', () => {
+    expect(() => tomlBasicString('line1\nline2')).toThrow(/newline/);
+    expect(() => tomlBasicString('trailing\n')).toThrow(/newline/);
+    expect(() => tomlBasicString('crlf\r\nhere')).toThrow(/newline/);
+  });
+});
+
+describe('STALE_THREAD_RE', () => {
+  it('matches stale-thread error messages', () => {
+    expect(STALE_THREAD_RE.test('thread not found')).toBe(true);
+    expect(STALE_THREAD_RE.test('unknown thread xyz')).toBe(true);
+    expect(STALE_THREAD_RE.test('No such thread: abc')).toBe(true);
+    expect(STALE_THREAD_RE.test('invalid thread_id')).toBe(true);
+  });
+
+  it('does not match transient or unrelated errors', () => {
+    expect(STALE_THREAD_RE.test('rate limit exceeded')).toBe(false);
+    expect(STALE_THREAD_RE.test('authentication failed')).toBe(false);
+    expect(STALE_THREAD_RE.test('connection reset by peer')).toBe(false);
+    expect(STALE_THREAD_RE.test('internal server error')).toBe(false);
+  });
+});

--- a/container/agent-runner/src/providers/codex-app-server.ts
+++ b/container/agent-runner/src/providers/codex-app-server.ts
@@ -21,6 +21,34 @@ function log(msg: string): void {
 
 const INIT_TIMEOUT_MS = 30_000;
 
+/**
+ * Errors from `thread/resume` that indicate the thread ID is unusable —
+ * typically because the app-server has no memory of it (thread transcript
+ * was deleted, server was wiped, ID is from a different codex version).
+ * Only errors matching this pattern trigger silent fallback to a fresh
+ * thread; everything else bubbles up so the caller can decide what to do.
+ *
+ * Shared with `codex.ts`'s `isSessionInvalid` to keep the two detection
+ * paths in sync.
+ */
+export const STALE_THREAD_RE = /thread\s+not\s+found|unknown\s+thread|thread[_\s]id|no such thread/i;
+
+/**
+ * Escape a string for emission inside a TOML basic string (double-quoted).
+ * Handles `"` and `\`. Rejects newlines: basic strings can't contain raw
+ * newlines, and silently converting them to `\n` would mask misconfiguration
+ * (e.g. a secret pasted with a trailing newline). Multiline strings are
+ * unsupported for `config.toml` use here.
+ */
+export function tomlBasicString(value: string): string {
+  if (value.includes('\n') || value.includes('\r')) {
+    throw new Error(
+      `MCP config value contains newline (not supported in config.toml): ${JSON.stringify(value.slice(0, 40))}${value.length > 40 ? '…' : ''}`,
+    );
+  }
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
 // ── JSON-RPC types ──────────────────────────────────────────────────────────
 
 let nextRequestId = 1;
@@ -283,7 +311,13 @@ export async function startOrResumeCodexThread(
       log(`Thread resumed: ${threadId}`);
       return threadId;
     }
-    log(`Resume failed: ${resp.error.message}. Starting fresh thread.`);
+    // Only fall through to fresh-thread on recognized stale-thread errors.
+    // Auth, version, or transient failures would otherwise silently discard
+    // session state — fail loud instead so the caller can retry or surface.
+    if (!STALE_THREAD_RE.test(resp.error.message)) {
+      throw new Error(`thread/resume failed: ${resp.error.message}`);
+    }
+    log(`Stale thread ${threadId}; starting fresh thread.`);
   }
 
   log('Starting new thread…');
@@ -336,15 +370,15 @@ export function writeCodexMcpConfigToml(servers: Record<string, CodexMcpServer>)
   for (const [name, config] of Object.entries(servers)) {
     lines.push(`[mcp_servers.${name}]`);
     lines.push('type = "stdio"');
-    lines.push(`command = "${config.command}"`);
+    lines.push(`command = ${tomlBasicString(config.command)}`);
     if (config.args && config.args.length > 0) {
-      const argsStr = config.args.map((a) => `"${a}"`).join(', ');
+      const argsStr = config.args.map(tomlBasicString).join(', ');
       lines.push(`args = [${argsStr}]`);
     }
     if (config.env && Object.keys(config.env).length > 0) {
       lines.push(`[mcp_servers.${name}.env]`);
       for (const [key, value] of Object.entries(config.env)) {
-        lines.push(`${key} = "${value}"`);
+        lines.push(`${key} = ${tomlBasicString(value)}`);
       }
     }
     lines.push('');

--- a/container/agent-runner/src/providers/codex-app-server.ts
+++ b/container/agent-runner/src/providers/codex-app-server.ts
@@ -1,0 +1,361 @@
+/**
+ * Codex app-server JSON-RPC transport primitives.
+ *
+ * Communicates with `codex app-server` over stdio. This module is just the
+ * plumbing — spawn the process, send requests, dispatch responses and
+ * notifications. Higher-level semantics (threads, turns, event translation)
+ * live in codex.ts.
+ *
+ * Kept separate so the transport can be unit-tested without pulling in the
+ * full provider and so any future Codex tooling (e.g. a CLI for manual
+ * debugging) can reuse the same primitives.
+ */
+import fs from 'fs';
+import path from 'path';
+import { spawn, type ChildProcess } from 'child_process';
+import { createInterface, type Interface as ReadlineInterface } from 'readline';
+
+function log(msg: string): void {
+  console.error(`[codex-app-server] ${msg}`);
+}
+
+const INIT_TIMEOUT_MS = 30_000;
+
+// ── JSON-RPC types ──────────────────────────────────────────────────────────
+
+let nextRequestId = 1;
+
+interface JsonRpcRequest {
+  id: number;
+  method: string;
+  params: Record<string, unknown>;
+}
+
+export interface JsonRpcResponse {
+  id: number;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+export interface JsonRpcNotification {
+  method: string;
+  params: Record<string, unknown>;
+}
+
+export interface JsonRpcServerRequest {
+  id: number;
+  method: string;
+  params: Record<string, unknown>;
+}
+
+type JsonRpcMessage = JsonRpcResponse | JsonRpcNotification | JsonRpcServerRequest;
+
+function makeRequest(method: string, params: Record<string, unknown>): JsonRpcRequest {
+  return { id: nextRequestId++, method, params };
+}
+
+function isResponse(msg: JsonRpcMessage): msg is JsonRpcResponse {
+  return 'id' in msg && ('result' in msg || 'error' in msg) && !('method' in msg);
+}
+
+function isServerRequest(msg: JsonRpcMessage): msg is JsonRpcServerRequest {
+  return 'id' in msg && 'method' in msg;
+}
+
+// ── App-server handle ───────────────────────────────────────────────────────
+
+export interface AppServer {
+  process: ChildProcess;
+  readline: ReadlineInterface;
+  pending: Map<number, { resolve: (r: JsonRpcResponse) => void; reject: (e: Error) => void }>;
+  notificationHandlers: ((n: JsonRpcNotification) => void)[];
+  serverRequestHandlers: ((r: JsonRpcServerRequest) => void)[];
+}
+
+export function spawnCodexAppServer(configOverrides: string[] = []): AppServer {
+  const args = ['app-server', '--listen', 'stdio://'];
+  for (const override of configOverrides) args.push('-c', override);
+
+  log(`Spawning: codex ${args.join(' ')}`);
+  const proc = spawn('codex', args, {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env },
+  });
+
+  const rl = createInterface({ input: proc.stdout! });
+
+  const server: AppServer = {
+    process: proc,
+    readline: rl,
+    pending: new Map(),
+    notificationHandlers: [],
+    serverRequestHandlers: [],
+  };
+
+  proc.stderr?.on('data', (chunk: Buffer) => {
+    const text = chunk.toString().trim();
+    if (text) log(`[stderr] ${text}`);
+  });
+
+  rl.on('line', (line: string) => {
+    if (!line.trim()) return;
+    let msg: JsonRpcMessage;
+    try {
+      msg = JSON.parse(line);
+    } catch {
+      log(`[parse-error] ${line.slice(0, 200)}`);
+      return;
+    }
+
+    if (isResponse(msg)) {
+      const handler = server.pending.get(msg.id);
+      if (handler) {
+        server.pending.delete(msg.id);
+        handler.resolve(msg);
+      }
+    } else if (isServerRequest(msg)) {
+      for (const h of server.serverRequestHandlers) h(msg);
+    } else if ('method' in msg) {
+      for (const h of server.notificationHandlers) h(msg as JsonRpcNotification);
+    }
+  });
+
+  proc.on('error', (err) => {
+    log(`[process-error] ${err.message}`);
+    for (const [, handler] of server.pending) handler.reject(err);
+    server.pending.clear();
+  });
+
+  proc.on('exit', (code, signal) => {
+    log(`[exit] code=${code} signal=${signal}`);
+    const err = new Error(`Codex app-server exited: code=${code} signal=${signal}`);
+    for (const [, handler] of server.pending) handler.reject(err);
+    server.pending.clear();
+  });
+
+  return server;
+}
+
+export function sendCodexRequest(
+  server: AppServer,
+  method: string,
+  params: Record<string, unknown>,
+  timeoutMs = 60_000,
+): Promise<JsonRpcResponse> {
+  const req = makeRequest(method, params);
+  const line = JSON.stringify(req) + '\n';
+
+  return new Promise<JsonRpcResponse>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      server.pending.delete(req.id);
+      reject(new Error(`Timeout waiting for ${method} response (${timeoutMs}ms)`));
+    }, timeoutMs);
+
+    server.pending.set(req.id, {
+      resolve: (r) => {
+        clearTimeout(timer);
+        resolve(r);
+      },
+      reject: (e) => {
+        clearTimeout(timer);
+        reject(e);
+      },
+    });
+
+    try {
+      server.process.stdin!.write(line);
+    } catch (err) {
+      clearTimeout(timer);
+      server.pending.delete(req.id);
+      reject(err instanceof Error ? err : new Error(String(err)));
+    }
+  });
+}
+
+export function sendCodexResponse(server: AppServer, id: number, result: unknown): void {
+  const line = JSON.stringify({ id, result }) + '\n';
+  try {
+    server.process.stdin!.write(line);
+  } catch (err) {
+    log(`[send-error] Failed to send response for id=${id}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+export function killCodexAppServer(server: AppServer): void {
+  try {
+    server.readline.close();
+    server.process.kill('SIGTERM');
+  } catch {
+    /* ignore */
+  }
+}
+
+// ── Auto-approval ───────────────────────────────────────────────────────────
+// The container sandbox is already the security boundary; inside it, Codex's
+// own approval prompts would just block every tool call on a user that isn't
+// watching. Accept everything and let sandbox limits do the enforcement.
+
+export function attachCodexAutoApproval(server: AppServer): void {
+  server.serverRequestHandlers.push((req) => {
+    const method = req.method;
+    log(`[approval] ${method}`);
+
+    switch (method) {
+      case 'item/commandExecution/requestApproval':
+      case 'item/fileChange/requestApproval':
+        sendCodexResponse(server, req.id, { decision: 'accept' });
+        break;
+      case 'item/permissions/requestApproval':
+        sendCodexResponse(server, req.id, {
+          permissions: { fileSystem: { read: ['/'], write: ['/'] }, network: { enabled: true } },
+          scope: 'session',
+        });
+        break;
+      case 'applyPatchApproval':
+      case 'execCommandApproval':
+        sendCodexResponse(server, req.id, { decision: 'approved' });
+        break;
+      case 'item/tool/call': {
+        const toolName = (req.params as { tool?: string }).tool || 'unknown';
+        log(`[approval] Unexpected dynamic tool call: ${toolName}`);
+        sendCodexResponse(server, req.id, {
+          success: false,
+          contentItems: [{ type: 'inputText', text: `Tool "${toolName}" is not available. Use MCP tools instead.` }],
+        });
+        break;
+      }
+      case 'item/tool/requestUserInput':
+      case 'mcpServer/elicitation/request':
+        sendCodexResponse(server, req.id, { input: null });
+        break;
+      default:
+        log(`[approval] Unknown method ${method}, generic accept`);
+        sendCodexResponse(server, req.id, { decision: 'accept' });
+        break;
+    }
+  });
+}
+
+// ── High-level helpers ──────────────────────────────────────────────────────
+
+export async function initializeCodexAppServer(server: AppServer): Promise<void> {
+  log('Sending initialize…');
+  const resp = await sendCodexRequest(
+    server,
+    'initialize',
+    {
+      clientInfo: { name: 'nanoclaw', version: '1.0.0' },
+      capabilities: { experimentalApi: false },
+    },
+    INIT_TIMEOUT_MS,
+  );
+  if (resp.error) throw new Error(`Initialize failed: ${resp.error.message}`);
+  log('Initialize successful');
+}
+
+export interface ThreadParams {
+  model: string;
+  cwd: string;
+  sandbox?: string;
+  approvalPolicy?: string;
+  personality?: string;
+  baseInstructions?: string;
+}
+
+/**
+ * Start or resume a Codex thread. If `threadId` is provided, attempts
+ * `thread/resume` first and falls back to a fresh `thread/start` on failure
+ * (stale thread IDs commonly outlive containers). Returns the active thread
+ * ID either way.
+ */
+export async function startOrResumeCodexThread(
+  server: AppServer,
+  threadId: string | undefined,
+  params: ThreadParams,
+): Promise<string> {
+  if (threadId) {
+    log(`Resuming thread: ${threadId}`);
+    const resp = await sendCodexRequest(server, 'thread/resume', {
+      threadId,
+      ...(params as unknown as Record<string, unknown>),
+    });
+    if (!resp.error) {
+      log(`Thread resumed: ${threadId}`);
+      return threadId;
+    }
+    log(`Resume failed: ${resp.error.message}. Starting fresh thread.`);
+  }
+
+  log('Starting new thread…');
+  const resp = await sendCodexRequest(server, 'thread/start', {
+    ...(params as unknown as Record<string, unknown>),
+  });
+  if (resp.error) throw new Error(`thread/start failed: ${resp.error.message}`);
+
+  const result = resp.result as { thread?: { id?: string } } | undefined;
+  const newThreadId = result?.thread?.id;
+  if (!newThreadId) throw new Error('thread/start response missing thread ID');
+  log(`New thread: ${newThreadId}`);
+  return newThreadId;
+}
+
+export interface TurnParams {
+  threadId: string;
+  inputText: string;
+  model?: string;
+  cwd?: string;
+}
+
+export async function startCodexTurn(server: AppServer, params: TurnParams): Promise<void> {
+  const resp = await sendCodexRequest(server, 'turn/start', {
+    threadId: params.threadId,
+    input: [{ type: 'text', text: params.inputText }],
+    model: params.model,
+    cwd: params.cwd,
+  });
+  if (resp.error) throw new Error(`turn/start failed: ${resp.error.message}`);
+}
+
+// ── MCP config.toml ─────────────────────────────────────────────────────────
+// Codex discovers MCP servers by reading ~/.codex/config.toml at startup.
+// We rewrite it on every spawn from whatever mcpServers the agent-runner
+// passes in, so the container's config reflects the current host wiring.
+
+export interface CodexMcpServer {
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+export function writeCodexMcpConfigToml(servers: Record<string, CodexMcpServer>): void {
+  const codexConfigDir = path.join(process.env.HOME || '/home/node', '.codex');
+  fs.mkdirSync(codexConfigDir, { recursive: true });
+  const configTomlPath = path.join(codexConfigDir, 'config.toml');
+
+  const lines: string[] = [];
+  for (const [name, config] of Object.entries(servers)) {
+    lines.push(`[mcp_servers.${name}]`);
+    lines.push('type = "stdio"');
+    lines.push(`command = "${config.command}"`);
+    if (config.args && config.args.length > 0) {
+      const argsStr = config.args.map((a) => `"${a}"`).join(', ');
+      lines.push(`args = [${argsStr}]`);
+    }
+    if (config.env && Object.keys(config.env).length > 0) {
+      lines.push(`[mcp_servers.${name}.env]`);
+      for (const [key, value] of Object.entries(config.env)) {
+        lines.push(`${key} = "${value}"`);
+      }
+    }
+    lines.push('');
+  }
+
+  fs.writeFileSync(configTomlPath, lines.join('\n'));
+  log(`Wrote MCP config.toml (${Object.keys(servers).length} server(s))`);
+}
+
+export function createCodexConfigOverrides(baseUrl?: string | null): string[] {
+  const overrides = ['features.use_linux_sandbox_bwrap=false'];
+  if (baseUrl) overrides.push(`model_provider_base_url="${baseUrl}"`);
+  return overrides;
+}

--- a/container/agent-runner/src/providers/codex-app-server.ts
+++ b/container/agent-runner/src/providers/codex-app-server.ts
@@ -354,8 +354,6 @@ export function writeCodexMcpConfigToml(servers: Record<string, CodexMcpServer>)
   log(`Wrote MCP config.toml (${Object.keys(servers).length} server(s))`);
 }
 
-export function createCodexConfigOverrides(baseUrl?: string | null): string[] {
-  const overrides = ['features.use_linux_sandbox_bwrap=false'];
-  if (baseUrl) overrides.push(`model_provider_base_url="${baseUrl}"`);
-  return overrides;
+export function createCodexConfigOverrides(): string[] {
+  return ['features.use_linux_sandbox_bwrap=false'];
 }

--- a/container/agent-runner/src/providers/codex.factory.test.ts
+++ b/container/agent-runner/src/providers/codex.factory.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'bun:test';
+
+import { createProvider } from './factory.js';
+import { CodexProvider } from './codex.js';
+
+describe('createProvider (codex)', () => {
+  it('returns CodexProvider for codex', () => {
+    expect(createProvider('codex')).toBeInstanceOf(CodexProvider);
+  });
+
+  it('flags stale thread errors as session-invalid', () => {
+    const p = new CodexProvider();
+    expect(p.isSessionInvalid(new Error('thread not found'))).toBe(true);
+    expect(p.isSessionInvalid(new Error('unknown thread 123'))).toBe(true);
+    expect(p.isSessionInvalid(new Error('No such thread: abc'))).toBe(true);
+  });
+
+  it('does not flag unrelated errors as session-invalid', () => {
+    const p = new CodexProvider();
+    expect(p.isSessionInvalid(new Error('rate limit exceeded'))).toBe(false);
+    expect(p.isSessionInvalid(new Error('connection reset'))).toBe(false);
+    expect(p.isSessionInvalid(new Error('codex app-server exited: code=1'))).toBe(false);
+  });
+
+  it('declares no native slash command support', () => {
+    const p = new CodexProvider();
+    expect(p.supportsNativeSlashCommands).toBe(false);
+  });
+});

--- a/container/agent-runner/src/providers/codex.ts
+++ b/container/agent-runner/src/providers/codex.ts
@@ -1,0 +1,332 @@
+/**
+ * OpenAI Codex provider — wraps `codex app-server` via JSON-RPC.
+ *
+ * Unlike the (deprecated) @openai/codex-sdk approach, the app-server
+ * protocol exposes proper session/stream semantics, native compaction, and
+ * stable MCP config via ~/.codex/config.toml — which is the same mechanism
+ * the standalone codex CLI uses, so the container and host share one
+ * provider-integration story.
+ *
+ * Codex turns don't accept mid-turn input. Follow-up `push()` messages are
+ * queued and drained after the current turn completes (same pattern as the
+ * opencode provider — see poll-loop for why that's correct: the poll-loop
+ * only pushes once it has new pending messages, and we only drain between
+ * turns, so no message is dropped).
+ */
+import fs from 'fs';
+
+import { registerProvider } from './provider-registry.js';
+import type { AgentProvider, AgentQuery, ProviderEvent, ProviderOptions, QueryInput } from './types.js';
+import {
+  type AppServer,
+  type JsonRpcNotification,
+  attachCodexAutoApproval,
+  createCodexConfigOverrides,
+  initializeCodexAppServer,
+  killCodexAppServer,
+  sendCodexRequest,
+  spawnCodexAppServer,
+  startCodexTurn,
+  startOrResumeCodexThread,
+  writeCodexMcpConfigToml,
+} from './codex-app-server.js';
+
+function log(msg: string): void {
+  console.error(`[codex-provider] ${msg}`);
+}
+
+/** Cumulative input tokens before triggering native compaction. */
+const COMPACT_THRESHOLD = 40_000;
+
+/** Hard ceiling for a single turn. Guards against app-server wedging. */
+const TURN_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * Errors that indicate the stored thread ID is unusable — typically
+ * because the app-server has no memory of it (thread transcript was
+ * deleted, server was wiped, ID is from a different codex version).
+ */
+const STALE_THREAD_RE = /thread\s+not\s+found|unknown\s+thread|thread[_\s]id|no such thread/i;
+
+// ── System-prompt assembly ──────────────────────────────────────────────────
+// Codex's app-server doesn't read CLAUDE.md/AGENT.md from cwd the way Claude
+// Code does. We have to load it and pass it in as `baseInstructions`. The
+// addendum from the poll-loop (destinations syntax, etc.) is appended.
+
+function loadAgentBaseInstructions(): string | undefined {
+  const candidates = ['/workspace/agent/CLAUDE.md', '/workspace/agent/AGENT.md'];
+  const parts: string[] = [];
+  for (const p of candidates) {
+    if (fs.existsSync(p)) {
+      parts.push(fs.readFileSync(p, 'utf-8'));
+      break;
+    }
+  }
+  return parts.length > 0 ? parts.join('\n\n') : undefined;
+}
+
+function composeBaseInstructions(promptAddendum: string | undefined): string | undefined {
+  const agentMd = loadAgentBaseInstructions();
+  const pieces = [agentMd, promptAddendum].filter((s): s is string => Boolean(s));
+  return pieces.length > 0 ? pieces.join('\n\n---\n\n') : undefined;
+}
+
+// ── Provider ────────────────────────────────────────────────────────────────
+
+export class CodexProvider implements AgentProvider {
+  readonly supportsNativeSlashCommands = false;
+
+  private readonly mcpServers: Record<string, { command: string; args: string[]; env: Record<string, string> }>;
+  private readonly model: string;
+  private readonly baseUrl?: string;
+
+  constructor(options: ProviderOptions = {}) {
+    this.mcpServers = options.mcpServers ?? {};
+    this.model = (options.env?.CODEX_MODEL as string | undefined) ?? 'gpt-5.4-mini';
+    this.baseUrl = options.env?.OPENAI_BASE_URL as string | undefined;
+  }
+
+  isSessionInvalid(err: unknown): boolean {
+    const msg = err instanceof Error ? err.message : String(err);
+    return STALE_THREAD_RE.test(msg);
+  }
+
+  query(input: QueryInput): AgentQuery {
+    const pending: string[] = [];
+    let waiting: (() => void) | null = null;
+    let ended = false;
+    let aborted = false;
+    const kick = (): void => {
+      waiting?.();
+    };
+
+    pending.push(input.prompt);
+
+    const self = this;
+
+    async function* gen(): AsyncGenerator<ProviderEvent> {
+      // One app-server per query invocation. The poll-loop keeps a single
+      // query active per batch of pending messages and ends it on idle, so
+      // spawn-per-query matches that cadence naturally.
+      writeCodexMcpConfigToml(self.mcpServers);
+      const server = spawnCodexAppServer(createCodexConfigOverrides(self.baseUrl));
+      attachCodexAutoApproval(server);
+
+      let threadId: string | undefined = input.continuation;
+      let initYielded = false;
+      let cumulativeInputTokens = 0;
+
+      try {
+        await initializeCodexAppServer(server);
+
+        const threadParams = {
+          model: self.model,
+          cwd: input.cwd,
+          sandbox: 'danger-full-access',
+          approvalPolicy: 'never',
+          personality: 'friendly',
+          baseInstructions: composeBaseInstructions(input.systemContext?.instructions),
+        };
+
+        threadId = await startOrResumeCodexThread(server, threadId, threadParams);
+
+        while (!aborted) {
+          while (pending.length === 0 && !ended && !aborted) {
+            await new Promise<void>((resolve) => {
+              waiting = resolve;
+            });
+            waiting = null;
+          }
+          if (aborted) return;
+          if (pending.length === 0 && ended) return;
+
+          const text = pending.shift()!;
+
+          // One turn = one channel of streaming events. Each notification
+          // from the app-server yields an `activity` first (so the
+          // poll-loop's idle timer stays honest) and then, where relevant,
+          // an init / result / progress event.
+          yield* runOneTurn(
+            server,
+            threadId!,
+            text,
+            self.model,
+            input.cwd,
+            () => initYielded,
+            () => {
+              initYielded = true;
+            },
+            (tokens) => {
+              cumulativeInputTokens = tokens;
+            },
+          );
+
+          // Trigger native compaction between turns if we've crossed the
+          // threshold. Codex's compaction is deterministic enough to do
+          // inline — if it fails, we log and carry on uncompacted.
+          if (cumulativeInputTokens >= COMPACT_THRESHOLD && threadId) {
+            log(`Compacting thread (${cumulativeInputTokens} tokens)`);
+            const compactResp = await sendCodexRequest(server, 'thread/compact/start', { threadId });
+            if (compactResp.error) {
+              log(`Compaction failed: ${compactResp.error.message} — continuing uncompacted`);
+            } else {
+              log('Native compaction completed');
+            }
+          }
+        }
+      } finally {
+        killCodexAppServer(server);
+      }
+    }
+
+    return {
+      push: (message: string) => {
+        pending.push(message);
+        kick();
+      },
+      end: () => {
+        ended = true;
+        kick();
+      },
+      abort: () => {
+        aborted = true;
+        kick();
+      },
+      events: gen(),
+    };
+  }
+}
+
+// ── Per-turn event pump ─────────────────────────────────────────────────────
+// Pulled out because the gen() loop above reads cleaner with it extracted,
+// and because it's a natural seam for future unit tests that drive it with
+// a fake notification stream.
+
+async function* runOneTurn(
+  server: AppServer,
+  threadId: string,
+  inputText: string,
+  model: string,
+  cwd: string,
+  hasInit: () => boolean,
+  markInit: () => void,
+  setInputTokens: (n: number) => void,
+): AsyncGenerator<ProviderEvent> {
+  // Mutable refs via object properties — TS can't track closure assignments
+  // for narrowing, but property access keeps the declared type visible.
+  const turnState: { error: Error | null } = { error: null };
+  let resultText = '';
+  let turnDone = false;
+
+  // Buffered event queue so we can `yield` across the async notification
+  // callback. Each notification pushes zero or more ProviderEvents; the
+  // generator drains the buffer.
+  const buffer: ProviderEvent[] = [];
+  let waker: (() => void) | null = null;
+  const kick = (): void => {
+    waker?.();
+    waker = null;
+  };
+
+  const handler = (n: JsonRpcNotification): void => {
+    const method = n.method;
+    const params = n.params;
+
+    // Every inbound notification counts as activity for the poll-loop's
+    // idle timer — yield before any event-specific translation so even
+    // long tool executions keep the loop awake.
+    buffer.push({ type: 'activity' });
+
+    switch (method) {
+      case 'thread/started': {
+        const thread = params.thread as { id?: string } | undefined;
+        if (thread?.id && !hasInit()) {
+          markInit();
+          buffer.push({ type: 'init', continuation: thread.id });
+        }
+        break;
+      }
+      case 'item/agentMessage/delta': {
+        const delta = params.delta as string;
+        if (delta) resultText += delta;
+        break;
+      }
+      case 'item/completed': {
+        const item = params.item as { type?: string; text?: string } | undefined;
+        if (item?.type === 'agentMessage' && item.text) resultText = item.text;
+        break;
+      }
+      case 'thread/tokenUsage/updated': {
+        const usage = params.tokenUsage as { total?: { inputTokens?: number } } | undefined;
+        if (usage?.total?.inputTokens !== undefined) setInputTokens(usage.total.inputTokens);
+        break;
+      }
+      case 'turn/completed':
+        turnDone = true;
+        break;
+      case 'turn/failed': {
+        const e = params.error as { message?: string } | undefined;
+        turnState.error = new Error(e?.message || 'Turn failed');
+        turnDone = true;
+        break;
+      }
+      case 'thread/status/changed': {
+        const status = params.status as string | undefined;
+        if (status) buffer.push({ type: 'progress', message: `status: ${status}` });
+        break;
+      }
+      default:
+        // Silently handle the many item/* notifications — they already
+        // contributed an activity event above.
+        break;
+    }
+
+    kick();
+  };
+
+  server.notificationHandlers.push(handler);
+
+  const timer = setTimeout(() => {
+    turnState.error = new Error(`Turn timed out after ${TURN_TIMEOUT_MS}ms`);
+    turnDone = true;
+    kick();
+  }, TURN_TIMEOUT_MS);
+
+  try {
+    // If we yield init before turn/start, the poll-loop stores
+    // continuation early and survives a mid-turn crash.
+    if (!hasInit()) {
+      markInit();
+      buffer.push({ type: 'init', continuation: threadId });
+    }
+
+    await startCodexTurn(server, { threadId, inputText, model, cwd });
+
+    while (true) {
+      while (buffer.length > 0) {
+        const ev = buffer.shift()!;
+        yield ev;
+      }
+      if (turnDone) break;
+      await new Promise<void>((resolve) => {
+        waker = resolve;
+      });
+      waker = null;
+    }
+
+    while (buffer.length > 0) yield buffer.shift()!;
+
+    if (turnState.error) {
+      yield { type: 'error', message: turnState.error.message, retryable: false };
+      return;
+    }
+
+    yield { type: 'result', text: resultText || null };
+  } finally {
+    clearTimeout(timer);
+    const idx = server.notificationHandlers.indexOf(handler);
+    if (idx >= 0) server.notificationHandlers.splice(idx, 1);
+  }
+}
+
+registerProvider('codex', (opts) => new CodexProvider(opts));

--- a/container/agent-runner/src/providers/codex.ts
+++ b/container/agent-runner/src/providers/codex.ts
@@ -20,6 +20,7 @@ import type { AgentProvider, AgentQuery, ProviderEvent, ProviderOptions, QueryIn
 import {
   type AppServer,
   type JsonRpcNotification,
+  STALE_THREAD_RE,
   attachCodexAutoApproval,
   createCodexConfigOverrides,
   initializeCodexAppServer,
@@ -40,13 +41,6 @@ const COMPACT_THRESHOLD = 40_000;
 
 /** Hard ceiling for a single turn. Guards against app-server wedging. */
 const TURN_TIMEOUT_MS = 5 * 60 * 1000;
-
-/**
- * Errors that indicate the stored thread ID is unusable — typically
- * because the app-server has no memory of it (thread transcript was
- * deleted, server was wiped, ID is from a different codex version).
- */
-const STALE_THREAD_RE = /thread\s+not\s+found|unknown\s+thread|thread[_\s]id|no such thread/i;
 
 // ── System-prompt assembly ──────────────────────────────────────────────────
 // Codex's app-server doesn't expand Claude Code's `@-import` syntax in

--- a/container/agent-runner/src/providers/codex.ts
+++ b/container/agent-runner/src/providers/codex.ts
@@ -25,19 +25,11 @@ import {
   createCodexConfigOverrides,
   initializeCodexAppServer,
   killCodexAppServer,
-  sendCodexRequest,
   spawnCodexAppServer,
   startCodexTurn,
   startOrResumeCodexThread,
   writeCodexMcpConfigToml,
 } from './codex-app-server.js';
-
-function log(msg: string): void {
-  console.error(`[codex-provider] ${msg}`);
-}
-
-/** Cumulative input tokens before triggering native compaction. */
-const COMPACT_THRESHOLD = 40_000;
 
 /** Hard ceiling for a single turn. Guards against app-server wedging. */
 const TURN_TIMEOUT_MS = 5 * 60 * 1000;
@@ -112,7 +104,6 @@ export class CodexProvider implements AgentProvider {
 
       let threadId: string | undefined = input.continuation;
       let initYielded = false;
-      let cumulativeInputTokens = 0;
 
       try {
         await initializeCodexAppServer(server);
@@ -154,23 +145,7 @@ export class CodexProvider implements AgentProvider {
             () => {
               initYielded = true;
             },
-            (tokens) => {
-              cumulativeInputTokens = tokens;
-            },
           );
-
-          // Trigger native compaction between turns if we've crossed the
-          // threshold. Codex's compaction is deterministic enough to do
-          // inline — if it fails, we log and carry on uncompacted.
-          if (cumulativeInputTokens >= COMPACT_THRESHOLD && threadId) {
-            log(`Compacting thread (${cumulativeInputTokens} tokens)`);
-            const compactResp = await sendCodexRequest(server, 'thread/compact/start', { threadId });
-            if (compactResp.error) {
-              log(`Compaction failed: ${compactResp.error.message} — continuing uncompacted`);
-            } else {
-              log('Native compaction completed');
-            }
-          }
         }
       } finally {
         killCodexAppServer(server);
@@ -208,7 +183,6 @@ async function* runOneTurn(
   cwd: string,
   hasInit: () => boolean,
   markInit: () => void,
-  setInputTokens: (n: number) => void,
 ): AsyncGenerator<ProviderEvent> {
   // Mutable refs via object properties — TS can't track closure assignments
   // for narrowing, but property access keeps the declared type visible.
@@ -252,11 +226,6 @@ async function* runOneTurn(
       case 'item/completed': {
         const item = params.item as { type?: string; text?: string } | undefined;
         if (item?.type === 'agentMessage' && item.text) resultText = item.text;
-        break;
-      }
-      case 'thread/tokenUsage/updated': {
-        const usage = params.tokenUsage as { total?: { inputTokens?: number } } | undefined;
-        if (usage?.total?.inputTokens !== undefined) setInputTokens(usage.total.inputTokens);
         break;
       }
       case 'turn/completed':

--- a/container/agent-runner/src/providers/codex.ts
+++ b/container/agent-runner/src/providers/codex.ts
@@ -78,12 +78,10 @@ export class CodexProvider implements AgentProvider {
 
   private readonly mcpServers: Record<string, { command: string; args: string[]; env: Record<string, string> }>;
   private readonly model: string;
-  private readonly baseUrl?: string;
 
   constructor(options: ProviderOptions = {}) {
     this.mcpServers = options.mcpServers ?? {};
     this.model = (options.env?.CODEX_MODEL as string | undefined) ?? 'gpt-5.4-mini';
-    this.baseUrl = options.env?.OPENAI_BASE_URL as string | undefined;
   }
 
   isSessionInvalid(err: unknown): boolean {
@@ -109,7 +107,7 @@ export class CodexProvider implements AgentProvider {
       // query active per batch of pending messages and ends it on idle, so
       // spawn-per-query matches that cadence naturally.
       writeCodexMcpConfigToml(self.mcpServers);
-      const server = spawnCodexAppServer(createCodexConfigOverrides(self.baseUrl));
+      const server = spawnCodexAppServer(createCodexConfigOverrides());
       attachCodexAutoApproval(server);
 
       let threadId: string | undefined = input.continuation;

--- a/container/agent-runner/src/providers/codex.ts
+++ b/container/agent-runner/src/providers/codex.ts
@@ -49,25 +49,31 @@ const TURN_TIMEOUT_MS = 5 * 60 * 1000;
 const STALE_THREAD_RE = /thread\s+not\s+found|unknown\s+thread|thread[_\s]id|no such thread/i;
 
 // ── System-prompt assembly ──────────────────────────────────────────────────
-// Codex's app-server doesn't read CLAUDE.md/AGENT.md from cwd the way Claude
-// Code does. We have to load it and pass it in as `baseInstructions`. The
-// addendum from the poll-loop (destinations syntax, etc.) is appended.
+// Codex's app-server doesn't expand Claude Code's `@-import` syntax in
+// CLAUDE.md, so we load group + global explicitly and pass the combined text
+// as `baseInstructions`. Mirrors the OpenCode provider's readClaudeMdForPrompt
+// so non-Claude providers behave the same way. The literal `@./.claude-global.md`
+// line in group CLAUDE.md is left in place — it's harmless context for the
+// model and strips on an agent-side convention upstream may change.
 
-function loadAgentBaseInstructions(): string | undefined {
-  const candidates = ['/workspace/agent/CLAUDE.md', '/workspace/agent/AGENT.md'];
-  const parts: string[] = [];
-  for (const p of candidates) {
-    if (fs.existsSync(p)) {
-      parts.push(fs.readFileSync(p, 'utf-8'));
-      break;
-    }
+function readAgentAndGlobalClaudeMd(): string | undefined {
+  const groupPath = '/workspace/agent/CLAUDE.md';
+  const globalPath = '/workspace/global/CLAUDE.md';
+  let content = '';
+  if (fs.existsSync(groupPath)) {
+    content += fs.readFileSync(groupPath, 'utf-8');
   }
-  return parts.length > 0 ? parts.join('\n\n') : undefined;
+  const isMain = process.env.NANOCLAW_IS_MAIN === '1';
+  if (!isMain && fs.existsSync(globalPath)) {
+    if (content) content += '\n\n---\n\n';
+    content += fs.readFileSync(globalPath, 'utf-8');
+  }
+  return content || undefined;
 }
 
 function composeBaseInstructions(promptAddendum: string | undefined): string | undefined {
-  const agentMd = loadAgentBaseInstructions();
-  const pieces = [agentMd, promptAddendum].filter((s): s is string => Boolean(s));
+  const claudeMd = readAgentAndGlobalClaudeMd();
+  const pieces = [claudeMd, promptAddendum].filter((s): s is string => Boolean(s));
   return pieces.length > 0 ? pieces.join('\n\n---\n\n') : undefined;
 }
 

--- a/container/agent-runner/src/providers/factory.test.ts
+++ b/container/agent-runner/src/providers/factory.test.ts
@@ -2,11 +2,16 @@ import { describe, it, expect } from 'bun:test';
 
 import { createProvider, type ProviderName } from './factory.js';
 import { ClaudeProvider } from './claude.js';
+import { CodexProvider } from './codex.js';
 import { MockProvider } from './mock.js';
 
 describe('createProvider', () => {
   it('returns ClaudeProvider for claude', () => {
     expect(createProvider('claude')).toBeInstanceOf(ClaudeProvider);
+  });
+
+  it('returns CodexProvider for codex', () => {
+    expect(createProvider('codex')).toBeInstanceOf(CodexProvider);
   });
 
   it('returns MockProvider for mock', () => {

--- a/container/agent-runner/src/providers/index.ts
+++ b/container/agent-runner/src/providers/index.ts
@@ -3,5 +3,6 @@
 // level. Skills add a new provider by appending one import line below.
 
 import './claude.js';
+import './codex.js';
 import './mock.js';
 import './opencode.js';

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -1,0 +1,49 @@
+/**
+ * Host-side container config for the `codex` provider.
+ *
+ * Codex reads auth and MCP config from ~/.codex. We give each session its
+ * own private copy of that directory so:
+ *
+ * - The user's host ~/.codex/auth.json reaches the container without us
+ *   touching their host config.toml (which the host's own `codex` CLI
+ *   might be using).
+ * - The in-container provider can rewrite config.toml freely on every
+ *   wake with container-appropriate MCP server paths, without racing
+ *   other sessions or leaking per-session paths back to the host.
+ *
+ * Env passthrough covers the two knobs that are read at runtime:
+ *   OPENAI_API_KEY  — fallback auth when auth.json isn't a subscription token
+ *   CODEX_MODEL     — model override if the user wants something other than the default
+ *   OPENAI_BASE_URL — rare, but supports API-compatible alternates
+ */
+import fs from 'fs';
+import path from 'path';
+
+import { registerProviderContainerConfig } from './provider-container-registry.js';
+
+registerProviderContainerConfig('codex', (ctx) => {
+  const codexDir = path.join(ctx.sessionDir, 'codex');
+  fs.mkdirSync(codexDir, { recursive: true });
+
+  // Copy the host's auth.json into the per-session dir if it exists.
+  // We only copy auth.json, not the full ~/.codex — config.toml would
+  // get clobbered by the container on every wake anyway.
+  const hostHome = ctx.hostEnv.HOME;
+  if (hostHome) {
+    const hostAuth = path.join(hostHome, '.codex', 'auth.json');
+    if (fs.existsSync(hostAuth)) {
+      fs.copyFileSync(hostAuth, path.join(codexDir, 'auth.json'));
+    }
+  }
+
+  const env: Record<string, string> = {};
+  for (const key of ['OPENAI_API_KEY', 'CODEX_MODEL', 'OPENAI_BASE_URL'] as const) {
+    const value = ctx.hostEnv[key];
+    if (value) env[key] = value;
+  }
+
+  return {
+    mounts: [{ hostPath: codexDir, containerPath: '/home/node/.codex', readonly: false }],
+    env,
+  };
+});

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -5,4 +5,5 @@
 //
 // Skills add a new provider by appending one import line below.
 
+import './codex.js';
 import './opencode.js';


### PR DESCRIPTION
## TL;DR

Adds `codex` as an AgentProvider: **a full agent loop with Claude-SDK feature parity, where the planner is not Claude.** Session resume, streaming, MCP, native compaction, approvals — all via `codex app-server` over JSON-RPC.

Why app-server, not `@openai/codex-sdk`: app-server is a strict superset for nanoclaw's needs. Ran SDK in production on a downstream fork first — migrated away because hand-rolling compaction and skill discovery was *more* code, not less.

Side benefit — better support for alternate models. Codex CLI honors `OPENAI_BASE_URL` natively, opening a direct path to any OpenAI-compatible endpoint. Distinct from OpenCode's reach-the-same-endpoints path in two ways that matter: Codex uses **OpenAI function-calling** (the tool-use schema open models widely emit — Llama, Qwen, Mistral, DeepSeek...), and endpoint redirection is just one env var (versus OpenCode's provider-registry config, currently wired toward Anthropic-via-proxy). See §Overlap below.

## Why app-server over `@openai/codex-sdk`

App-server is a strict superset for nanoclaw's needs. **Session persistence and compaction are the load-bearing differences:**

| | Codex SDK | Codex app-server |
|---|---|---|
| **Session persistence** | Client gets a thread ID; must archive transcripts, track compaction state, re-inject skills every turn | Server owns transcript, token accounting, skill discovery — client just holds the ID |
| **Native compaction** | None — roll your own summary-and-restart loop | `thread/compact/start` between turns |
| **Mid-turn input** | Not supported | Queue + drain between turns (matches opencode) |
| **Approval hooks** | Limited | Structured server requests |
| **Multi-turn subagents** | Not supported | `spawnAgent` |

Ran SDK in production on a downstream fork before switching to app-server. The migration **removed code** — the transcript archive, the compact-state sidecar, and the skill pre-injection pass all disappeared because the server now owns that state. Net complexity went *down*.

Re: shipping both — `@openai/codex-sdk` is a thin Node wrapper that spawns the same `codex` binary underneath, so "simpler install" isn't real. Shipping both doubles maintenance for no user-visible win. Happy to add Codex SDK support (I still have the code), but I don't see the benefit to users over the app-server solution.

## Overlap with the OpenCode provider

Both providers can reach OpenAI-compatible endpoints. The distinctions:

- **Tool-use protocol.** OpenCode uses its own tool registry; Codex uses OpenAI function-calling — the schema open models (Llama, Qwen, Mistral, DeepSeek...) are trained to emit. Tool reliability on open models should favor Codex as a result.
- **Config path.** OpenCode's v2 wiring biases toward Anthropic-via-proxy (`baseURL: ANTHROPIC_BASE_URL`, `apiKey: 'placeholder'`); local-LLM works but requires working around the provider registry. Codex reads `OPENAI_BASE_URL` directly.
- **Use case.** nanoclaw today covers "Claude as planner, local model as MCP tool" well. It has no path for "non-Claude model as planner" — that's what this PR enables.

Same pattern as OpenCode alongside Claude: partial overlap, distinct user intents.

## What's in the rebase

Rebased cleanly onto `upstream/providers` HEAD (zero conflicts). Re-validation pass (including an adversarial review of the full diff) surfaced five correctness / hygiene issues; five commits follow the rebased original:

1. **`fix(codex): remove no-op model_provider_base_url override`** — broken `-c` override (wrong config key) that was also redundant: Codex's built-in `openai` provider honors `OPENAI_BASE_URL` natively. Removed the dead branch; host-side env-var forwarding preserved.

2. **`fix(codex): load /workspace/global/CLAUDE.md for non-main groups`** — original provider only read `/workspace/agent/CLAUDE.md`, so global persona content never reached Codex (which doesn't expand Claude Code's `@-import` syntax). Mirrored OpenCode's `readClaudeMdForPrompt` pattern: load both files, skip global when `NANOCLAW_IS_MAIN=1`.

3. **`feat(skills): /add-codex — install Codex as the agent provider`** — modeled on `/add-opencode`. Documents three auth paths: `codex login` subscription, `OPENAI_API_KEY`, experimental BYO endpoint via `OPENAI_BASE_URL`. No agent-runner package dep — Codex is a CLI binary.

4. **`fix(codex): harden resume fallback and MCP config.toml escaping`** — two tightenings surfaced by adversarial review: `thread/resume` now only falls back to a fresh thread on recognized stale-thread errors (previously silently discarded session state on any resume failure, including transient/auth/version issues), and `writeCodexMcpConfigToml` routes all `command`/`args`/env values through a `tomlBasicString` helper that escapes quotes and backslashes and rejects newlines (previously raw string interpolation could produce invalid TOML on legitimate user env values).

5. **`fix(codex): remove client-driven compaction threshold`** — the 40 000-token threshold and its supporting plumbing (`cumulativeInputTokens` counter, `thread/tokenUsage/updated` handler, `setInputTokens` callback) was SDK-era residue. Made sense when driving custom summarize-and-restart at a conservative fraction of the context window; didn't get removed when the mechanism switched to app-server's native `thread/compact/start`. On 128k-context models it over-compacted by ~3×. Trusts app-server to handle its own compaction (same posture as the Claude provider trusts Claude Code's auto-compact). If turns fail at the context wall in practice, revisit with a server-notification-driven trigger, not a client-side threshold.

## Files

Container-side: `codex-app-server.ts` (JSON-RPC transport) + `codex.ts` (`CodexProvider` implementation) + `codex.factory.test.ts` + `codex-app-server.test.ts`. Host-side: `src/providers/codex.ts` (per-session `~/.codex` isolation, auth + env forwarding). Dockerfile pins `CODEX_VERSION=0.121.0`. Skill: `.claude/skills/add-codex/SKILL.md`.

## Validation

- **Rebase:** clean onto `upstream/providers` (`eb0055a`), zero conflicts.
- **Host tests:** `pnpm test` — 137 passing.
- **Container tests:** `bun test` — 33 passing (26 pre-existing + 7 new for `tomlBasicString` and `STALE_THREAD_RE`).
- **Typecheck:** both sides clean.
- **Container build:** `./container/build.sh` produces a working image with `codex-cli 0.121.0` installed.
- **End-to-end smoke test:** real `codex app-server` against OpenAI — event sequence `init → progress → progress → result("hello")` with stable thread ID. Re-confirmed after the compaction removal.
- **Persona read validation:** container-side test with fixture mounts confirms non-main groups receive `group + global` CLAUDE.md; main groups (`NANOCLAW_IS_MAIN=1`) receive group only.

## Known shortcomings

*Tractable follow-ups, not blocking this PR:*

1. **No native file tools.** Claude SDK ships `Read`, `Write`, `Edit`, `Glob`, `Grep`, `WebFetch`, `WebSearch`; Codex leaves the agent to shell out via bash. Works — just slower + noisier. **Follow-up PR** will add these as MCP tools on the `nanoclaw` MCP server, benefiting OpenCode (and Claude-via-`--allowed-tools`) too.

2. **Additional latency vs Claude.** The agent loop is comparable, but several layers add significant overhead relative to Claude SDK's in-process dispatch:

   | Source | Cost | Mitigation |
   |---|---|---|
   | Tool-call JSON-RPC over stdio | ~10–50ms per hop | Batch MCP calls, pipeline commands |
   | File ops going through bash (shell spawn + `cat`/`sed`/etc.) | highly variable, often seconds | File-tools MCP follow-up (see #1) |
   | TypeScript recompilation on container cold start | ~5–10s | Pre-compile TS at image build (ported from downstream fork) |
   | MCP servers invoked via `npx` shims | ~3–5s per invocation | Direct binary paths (ported from downstream fork) |

   Together these add substantial startup + first-turn latency on a cold container. Each mitigation landed in production on the downstream fork; all port cleanly to this provider. See §What's next.

3. **Local-LLM preset UX.** The skill documents `OPENAI_BASE_URL` but doesn't ship curated Ollama/LM Studio/Groq/etc. presets. Clean follow-up work if/when file-tools land.

4. **Compaction behavior.** Commit #5 trusts app-server to handle compaction without a client-side trigger, matching how the Claude provider trusts Claude Code's auto-compact. Verified via host-side smoke test — a 3-turn context-wall probe with ~52k-token filler per turn (cumulative ~157k input tokens, exceeding the 128k window by turn 3) completed all three turns cleanly in ~10s with no client-driven trigger and no context-limit errors. If real-world usage ever shows turns failing near context limit, the fix path is a server-notification-driven trigger on `thread/tokenUsage/updated` — not a return to the hard-coded threshold.

## What's next after this merges

- **File-tools MCP server** — native `Read`/`Write`/`Edit`/`Glob`/`Grep` exposed to all providers.
- **Latency polish** — pre-compile TS at container build, direct MCP server paths, `baseInstructions` hygiene (details in §Known shortcomings above). Ported from the downstream fork; mostly additive, no architectural change.
- **Local-LLM quickstart** — opinionated presets in the `/add-codex` skill.
- **Gemini ADK provider** — same AgentProvider interface, same skill shape. Working on the downstream fork; can upstream if this pattern is accepted.


