### PR TITLE
fix(db): normalize auto-generated timestamps to ISO 8601

### DIFF
--- a/container/agent-runner/src/db/messages-in.ts
+++ b/container/agent-runner/src/db/messages-in.ts
@@ -59,7 +59,7 @@ export function markProcessing(ids: string[]): void {
   if (ids.length === 0) return;
   const db = getOutboundDb();
   const stmt = db.prepare(
-    "INSERT OR REPLACE INTO processing_ack (message_id, status, status_changed) VALUES (?, 'processing', datetime('now'))",
+    "INSERT OR REPLACE INTO processing_ack (message_id, status, status_changed) VALUES (?, 'processing', strftime('%Y-%m-%dT%H:%M:%fZ','now'))",
   );
   db.transaction(() => {
     for (const id of ids) stmt.run(id);
@@ -71,7 +71,7 @@ export function markCompleted(ids: string[]): void {
   if (ids.length === 0) return;
   const db = getOutboundDb();
   const stmt = db.prepare(
-    "INSERT OR REPLACE INTO processing_ack (message_id, status, status_changed) VALUES (?, 'completed', datetime('now'))",
+    "INSERT OR REPLACE INTO processing_ack (message_id, status, status_changed) VALUES (?, 'completed', strftime('%Y-%m-%dT%H:%M:%fZ','now'))",
   );
   db.transaction(() => {
     for (const id of ids) stmt.run(id);
@@ -82,7 +82,7 @@ export function markCompleted(ids: string[]): void {
 export function markFailed(id: string): void {
   getOutboundDb()
     .prepare(
-      "INSERT OR REPLACE INTO processing_ack (message_id, status, status_changed) VALUES (?, 'failed', datetime('now'))",
+      "INSERT OR REPLACE INTO processing_ack (message_id, status, status_changed) VALUES (?, 'failed', strftime('%Y-%m-%dT%H:%M:%fZ','now'))",
     )
     .run(id);
 }

--- a/container/agent-runner/src/db/messages-out.ts
+++ b/container/agent-runner/src/db/messages-out.ts
@@ -58,7 +58,7 @@ export function writeMessageOut(msg: WriteMessageOut): number {
   outbound
     .prepare(
       `INSERT INTO messages_out (id, seq, in_reply_to, timestamp, deliver_after, recurrence, kind, platform_id, channel_type, thread_id, content)
-     VALUES ($id, $seq, $in_reply_to, datetime('now'), $deliver_after, $recurrence, $kind, $platform_id, $channel_type, $thread_id, $content)`,
+     VALUES ($id, $seq, $in_reply_to, strftime('%Y-%m-%dT%H:%M:%fZ','now'), $deliver_after, $recurrence, $kind, $platform_id, $channel_type, $thread_id, $content)`,
     )
     .run({
       $id: msg.id,

--- a/my-docs/01-vue-ensemble.md
+++ b/my-docs/01-vue-ensemble.md
@@ -1,0 +1,99 @@
+# Vue d'ensemble de NanoClaw
+
+## Philosophie
+
+NanoClaw est un assistant Claude personnel. Le host est un unique processus Node qui orchestre des containers agent Docker par session. Les messages arrivent via des adaptateurs de canaux, transitent par un modèle d'entités, et déclenchent un container qui exécute Claude via le Claude Agent SDK.
+
+**Principe fondamental : tout est message.** Il n'y a pas d'IPC, pas de file watcher, pas de stdin entre host et container. Les deux DBs de session sont l'unique surface d'IO.
+
+---
+
+## Schéma général
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                        PLATEFORMES EXTERNES                         │
+│   Telegram  Discord  Slack  WhatsApp  GitHub  Linear  ...           │
+└──────────┬──────────────────────────────────────────────────────────┘
+           │ événements
+           ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                         HOST NODE PROCESS                           │
+│                                                                     │
+│  ┌──────────────┐   ┌──────────────┐   ┌─────────────────────────┐ │
+│  │ Channel      │   │   Router     │   │  Session Manager        │ │
+│  │ Adapters     │──▶│ (router.ts)  │──▶│  (session-manager.ts)   │ │
+│  │ (channels/)  │   │              │   │  inbound.db write       │ │
+│  └──────────────┘   └──────────────┘   └──────────┬──────────────┘ │
+│                                                   │ wake            │
+│  ┌──────────────┐                      ┌──────────▼──────────────┐ │
+│  │  Delivery    │◀─────────────────────│ Container Runner        │ │
+│  │ (delivery.ts)│   outbound.db read   │ (container-runner.ts)   │ │
+│  │  1s poll     │                      │  docker run ...         │ │
+│  └──────┬───────┘                      └─────────────────────────┘ │
+│         │                                                           │
+│  ┌──────▼───────┐   ┌──────────────────────────────────────────┐   │
+│  │ Host Sweep   │   │           data/v2.db (SQLite)            │   │
+│  │ (60s)        │   │  users, sessions, agent_groups,          │   │
+│  └──────────────┘   │  messaging_groups, pending_*, ...        │   │
+│                      └──────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────────┘
+           │ docker mounts
+           ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                    CONTAINER AGENT (Docker / Bun)                   │
+│                                                                     │
+│  ┌──────────────┐   ┌──────────────┐   ┌─────────────────────────┐ │
+│  │  Poll Loop   │──▶│  Provider    │──▶│   Claude Agent SDK      │ │
+│  │ (poll-loop)  │   │  (claude.ts) │   │   @anthropic-ai/        │ │
+│  │ inbound read │   └──────────────┘   │   claude-agent-sdk      │ │
+│  └──────┬───────┘                      └─────────────────────────┘ │
+│         │                                          │ MCP tools      │
+│  ┌──────▼───────┐                      ┌──────────▼──────────────┐ │
+│  │ outbound.db  │◀─────────────────────│  MCP Tool Server        │ │
+│  │   write      │                      │  send_message, ask_user │ │
+│  └──────────────┘                      │  schedule_task, ...     │ │
+│                                        └─────────────────────────┘ │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Composants principaux
+
+### Host (Node + pnpm)
+
+| Fichier | Rôle |
+|---------|------|
+| `src/index.ts` | Point d'entrée : init DB, migrations, adapters, polls, shutdown |
+| `src/router.ts` | Routing entrant : messaging group → agent group → session → inbound.db |
+| `src/delivery.ts` | Poll outbound.db, livraison via adapter, approbations |
+| `src/host-sweep.ts` | Sweep 60s : stale detection, recurrence, retries |
+| `src/session-manager.ts` | Résolution de session, création des DBs, projections |
+| `src/container-runner.ts` | Spawn des containers Docker par session |
+| `src/channels/` | Registre des adaptateurs de canaux |
+| `src/db/` | Couche DB centrale (CRUD par entité) |
+
+### Container (Bun)
+
+| Fichier | Rôle |
+|---------|------|
+| `container/agent-runner/src/index.ts` | Point d'entrée container, config provider, MCP |
+| `container/agent-runner/src/poll-loop.ts` | Boucle principale : poll inbound, invoke provider |
+| `container/agent-runner/src/formatter.ts` | Formatage des messages pour le prompt |
+| `container/agent-runner/src/providers/` | Wrappers SDK (claude, codex, opencode) |
+| `container/agent-runner/src/mcp-tools/` | Outils MCP (send, schedule, ask, agents, self-mod) |
+
+---
+
+## Intervalles clés
+
+| Composant | Intervalle | But |
+|-----------|-----------|-----|
+| Active delivery poll | 1s | Sessions actives, réponse rapide |
+| Sweep delivery poll | 60s | Toutes les sessions, messages schedulés |
+| Host sweep | 60s | Stale detection, récurrence, retries |
+| Agent poll loop (idle) | 1s | Pickup de nouveaux messages |
+| Agent poll loop (query) | 500ms | Follow-ups continus pendant traitement |
+| Idle timeout container | 30 min | Tuer le container chaud après inactivité |
+| Stale threshold | 10 min | Détecter container crashé via heartbeat |

--- a/my-docs/02-modele-entites.md
+++ b/my-docs/02-modele-entites.md
@@ -1,0 +1,121 @@
+# Modèle d'entités
+
+## DB centrale (`data/v2.db`)
+
+Tout ce qui n'est pas per-session vit ici. Géré exclusivement par le host.
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                           data/v2.db                                    │
+│                                                                         │
+│  users                          agent_groups                            │
+│  ┌──────────────────────┐       ┌──────────────────────────────────┐   │
+│  │ id  (telegram:123)   │       │ id                               │   │
+│  │ kind (human/bot)     │       │ folder  (unique)                 │   │
+│  │ display_name         │       │ agent_provider (claude/opencode) │   │
+│  └──────┬───────────────┘       │ workspace / memory / personality │   │
+│         │                       │ container_config (JSON)          │   │
+│         │ user_roles            └──────────────┬───────────────────┘   │
+│  ┌──────▼───────────────┐                      │                       │
+│  │ user_id              │   messaging_groups    │ messaging_group_agents│
+│  │ role (owner/admin)   │  ┌────────────────┐  │ ┌──────────────────┐  │
+│  │ agent_group_id (NULL │  │ id             │  │ │ mg_id            │  │
+│  │  = global)           │  │ channel_type   │  │ │ ag_id            │  │
+│  └──────────────────────┘  │ platform_id    │◀─┘ │ session_mode     │  │
+│                             │ unknown_sender │    │ trigger_rules    │  │
+│  agent_group_members        │  _policy       │    │ priority         │  │
+│  ┌──────────────────────┐   └────────────────┘    └──────────────────┘  │
+│  │ user_id              │                                               │
+│  │ agent_group_id       │   sessions                                    │
+│  └──────────────────────┘   ┌────────────────────────────────────────┐  │
+│                              │ id                                     │  │
+│  user_dms (cache DM froid)   │ agent_group_id                        │  │
+│  ┌──────────────────────┐    │ messaging_group_id                    │  │
+│  │ user_id              │    │ thread_id                             │  │
+│  │ channel_type         │    │ status / container_status             │  │
+│  │ messaging_group_id   │    │ agent_provider (override)             │  │
+│  └──────────────────────┘    └────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Hiérarchie de droits
+
+```
+owner (global)
+  └── peut tout faire sur tous les agent groups
+
+admin (global ou scoped à un agent_group_id)
+  └── peut gérer le(s) agent group(s) concerné(s)
+
+member (agent_group_members)
+  └── accès non-privilégié à un agent group
+
+inconnu
+  └── géré par unknown_sender_policy du messaging_group :
+        strict           → drop silencieux
+        request_approval → demande approbation à l'admin
+        public           → autorisé
+```
+
+---
+
+## Session — résolution et modes
+
+La table `sessions` est le registre de toutes les conversations actives ou passées.
+
+```
+session_mode :
+
+  shared      → 1 session par messaging_group (ignore threadId)
+               ┌──────────────────────────────┐
+               │  #general (discord)          │──▶ session A
+               └──────────────────────────────┘
+
+  per-thread  → 1 session par (messaging_group, threadId)
+               ┌──────────────────────────────┐
+               │  #general / thread-123       │──▶ session A
+               │  #general / thread-456       │──▶ session B
+               └──────────────────────────────┘
+
+  agent-shared → 1 session par agent_group (toutes plateformes)
+               ┌──────────────────────────────┐
+               │  telegram + discord + slack  │──▶ session unique
+               └──────────────────────────────┘
+```
+
+---
+
+## Structure de fichiers par session
+
+```
+data/v2-sessions/
+  <agent_group_id>/
+    .claude-shared/          ← données SDK Claude partagées par toutes les sessions du groupe
+    agent-runner-src/        ← overlay agent-runner per-group (customisations)
+    <session_id>/
+      inbound.db             ← host écrit, container lit
+      outbound.db            ← container écrit, host lit
+      .heartbeat             ← container touche (mtime = liveness)
+      inbox/<msg_id>/        ← pièces jointes décodées (inbound)
+      outbox/<msg_id>/       ← fichiers produits par l'agent (outbound)
+
+groups/
+  <folder>/
+    CLAUDE.md                ← system prompt du groupe
+    skills/                  ← skills container du groupe
+    agent-runner-src/        ← overlay agent-runner (optionnel)
+```
+
+---
+
+## Tables annexes
+
+| Table | But |
+|-------|-----|
+| `agent_destinations` | ACL + noms pour `send_message(to="...")` ; projetée dans `inbound.db` au wake |
+| `pending_questions` | Questions interactives en attente de réponse utilisateur |
+| `pending_approvals` | Approbations admin (install_packages, rebuild, add_mcp_server) |
+| `schema_version` | Suivi des migrations |
+| `chat_sdk_*` | Tables de bridge Chat SDK (conversations, threads, messages) |

--- a/my-docs/03-flux-message.md
+++ b/my-docs/03-flux-message.md
@@ -1,0 +1,200 @@
+# Flux complet d'un message
+
+## Vue chronologique
+
+```
+PLATEFORME          HOST (Node)                    CONTAINER (Bun)
+    │                    │                               │
+    │── événement ──────▶│                               │
+    │                    │ 1. routeInbound()             │
+    │                    │    - résolution messaging_group│
+    │                    │    - upsert user              │
+    │                    │    - vérif accès              │
+    │                    │    - résolution session        │
+    │                    │                               │
+    │                    │ 2. writeSessionMessage()       │
+    │                    │    - écrit messages_in         │
+    │                    │      seq PAIR                 │
+    │                    │                               │
+    │                    │ 3. wakeContainer()             │
+    │                    │    - spawn docker run          │
+    │                    │      (si pas actif)           │
+    │                    │                               │
+    │                    │ ........ typing .............. │
+    │◀── typing ─────────│ 4. setTyping() 3s refresh     │
+    │                    │    (gated sur heartbeat)       │
+    │                    │                               │
+    │                    │                               │◀── .heartbeat touch
+    │                    │                               │
+    │                    │                               │ 5. poll messages_in
+    │                    │                               │    status=pending
+    │                    │                               │
+    │                    │                               │ 6. formatMessages()
+    │                    │                               │    XML delimiters
+    │                    │                               │
+    │                    │                               │ 7. provider.query()
+    │                    │                               │    Claude Agent SDK
+    │                    │                               │
+    │                    │                               │ 8. MCP tool: send_message
+    │                    │                               │    écrit messages_out
+    │                    │                               │    seq IMPAIR
+    │                    │                               │
+    │                    │ 9. active poll 1s             │
+    │                    │    lit messages_out            │
+    │                    │                               │
+    │                    │ 10. deliverSessionMessages()   │
+    │                    │     adapter.deliver()          │
+    │                    │     markDelivered()            │
+    │                    │                               │
+    │◀── message ────────│                               │
+```
+
+---
+
+## 1. Routage entrant (`src/router.ts`)
+
+```
+onInbound(platformId, threadId, message)
+         │
+         ▼
+   extractAndUpsertUser()
+   → users table (id = "telegram:123")
+         │
+         ▼
+   findOrCreateMessagingGroup()
+   → messaging_groups (channel_type + platform_id, unique pair)
+         │
+         ▼
+   enforceAccess()
+   → owner/admin/member → OK
+   → inconnu → drop | request_approval | public
+         │
+         ▼
+   pickAgent()
+   → messaging_group_agents : prend l'agent de plus haute priorité
+     dont les trigger_rules correspondent au message
+         │
+         ▼
+   resolveSession()
+   → session_mode : shared | per-thread | agent-shared
+   → crée si absente (inbound.db + outbound.db créés vides)
+         │
+         ▼
+   writeSessionMessage()    writeDestinations()    writeSessionRouting()
+   → inbound.db             → inbound.db           → inbound.db
+     messages_in              destinations           session_routing
+     seq=nextEvenSeq()
+```
+
+---
+
+## 2. Wake du container (`src/container-runner.ts`)
+
+```
+wakeContainer(sessionId, agentGroupId)
+         │
+         ├── déjà en cours ? → join le wakePromise existant (déduplication)
+         │
+         ├── activeContainers.has() ? → return (déjà running)
+         │
+         ▼
+   refreshProjections()
+   writeDestinations() + writeSessionRouting()
+         │
+         ▼
+   buildMounts()
+   ┌──────────────────────────────────────────────────────┐
+   │ /workspace/inbound.db    ← data/v2-sessions/…/inbound.db  │
+   │ /workspace/outbound.db   ← data/v2-sessions/…/outbound.db │
+   │ /workspace/.heartbeat    ← data/v2-sessions/…/.heartbeat  │
+   │ /workspace/outbox/       ← data/v2-sessions/…/outbox/     │
+   │ /workspace/agent/        ← groups/<folder>/               │
+   │ /workspace/.claude/      ← data/v2-sessions/<agId>/.claude-shared/ │
+   └──────────────────────────────────────────────────────┘
+         │
+         ▼
+   spawn(CONTAINER_RUNTIME_BIN, ["run", ...args])
+   markContainerRunning()
+   startIdleTimer(30min)
+```
+
+---
+
+## 3. Poll loop container (`container/agent-runner/src/poll-loop.ts`)
+
+```
+loop:
+  messages = getPendingMessages()   ← messages_in WHERE status='pending'
+                                       AND process_after <= now()
+
+  si vide → sleep 1s → continue
+
+  markProcessing(messages)           ← status='processing', status_changed=now
+
+  routing = extractRouting(messages[0])   ← channelType, platformId, threadId
+
+  categorize(messages) :
+    admin commands  → /clear, /remote-control
+    filtered        → /help
+    passthrough     → autres /commandes
+    normal          → tout le reste
+
+  formatted = formatMessages(messages)
+  ┌────────────────────────────────────────────────┐
+  │ <message sender="Alice" time="10:00">          │
+  │   Regarde ce bug                               │
+  │ </message>                                     │
+  │ <message sender="Bob" time="10:01">            │
+  │   +1, c'est urgent                             │
+  │ </message>                                     │
+  └────────────────────────────────────────────────┘
+
+  sessionId = getStoredSessionId()   ← outbound.db session_state
+
+  events = provider.query({ prompt, sessionId, cwd, mcpServers, ... })
+
+  pour chaque événement :
+    'init'     → setStoredSessionId(newSessionId)
+    'progress' → log
+    'result'   → log texte final
+    'error'    → retry ou fail avec backoff
+```
+
+---
+
+## 4. Livraison (`src/delivery.ts`)
+
+```
+startActiveDeliveryPoll() ← toutes les 1s, sessions running
+
+  pour chaque session active :
+    si déjà in-flight → skip (guard double-delivery)
+    
+    rows = messages_out WHERE delivered=0 
+                          AND deliver_after <= now()
+    
+    pour chaque row :
+      inflightDeliveries.add(sessionId)
+      
+      adapter.deliver(channelType, platformId, threadId, kind, content, files)
+      → retourne platform_message_id (si disponible)
+      
+      markDelivered(seq, platform_message_id)
+      → inbound.db delivered table
+      
+      resetIdleTimer()   ← garde le container chaud
+      
+      inflightDeliveries.delete(sessionId)
+```
+
+---
+
+## Formatage des messages par kind
+
+| Kind | Formatage |
+|------|-----------|
+| `chat` | `<message sender="..." time="...">contenu</message>` |
+| `chat-sdk` | idem, avec métadonnées Chat SDK |
+| `task` | `<task id="..." scheduled="...">prompt</task>` |
+| `webhook` | `<webhook source="...">payload JSON</webhook>` |
+| `system` | `<system type="question_response" ...>...</system>` |

--- a/my-docs/04-session-db.md
+++ b/my-docs/04-session-db.md
@@ -1,0 +1,169 @@
+# Les deux DBs de session
+
+## Principe fondamental : un seul écrivain par fichier
+
+```
+HOST (Node)                          CONTAINER (Bun)
+     │                                      │
+     │ ÉCRIT                                │ LIT (read-only)
+     ▼                                      ▼
+┌──────────────┐                   ┌──────────────┐
+│  inbound.db  │                   │  inbound.db  │
+│              │                   │              │
+│ messages_in  │                   │ messages_in  │
+│ delivered    │                   │ delivered    │
+│ destinations │                   │ destinations │
+│ session_     │                   │ session_     │
+│  routing     │                   │  routing     │
+└──────────────┘                   └──────────────┘
+
+┌──────────────┐                   ┌──────────────┐
+│  outbound.db │                   │  outbound.db │
+│              │                   │              │
+│ LIT          │◀──────────────────│ ÉCRIT        │
+│ (read-only)  │                   │              │
+│              │                   │ messages_out │
+│ messages_out │                   │ processing_  │
+│ processing_  │                   │  ack         │
+│  ack         │                   │ session_     │
+│ session_     │                   │  state       │
+│  state       │                   └──────────────┘
+└──────────────┘
+```
+
+**Pourquoi pas WAL ?** Le WAL de SQLite utilise mmap, qui ne fonctionne pas de façon fiable à travers les mounts Docker. Toutes les session DBs utilisent `journal_mode=DELETE`. Le host doit fermer sa connexion après chaque écriture pour forcer le flush des pages cache et les rendre visibles au container.
+
+---
+
+## Schema `inbound.db`
+
+### `messages_in`
+
+```sql
+CREATE TABLE messages_in (
+  id            TEXT PRIMARY KEY,
+  seq           INTEGER UNIQUE NOT NULL,   -- toujours PAIR (host)
+  kind          TEXT NOT NULL,             -- chat | task | webhook | system
+  content       TEXT NOT NULL,             -- JSON stringifié
+  sender_id     TEXT,                      -- user id (nullable pour webhooks)
+  sender_name   TEXT,
+  status        TEXT DEFAULT 'pending',    -- pending | processing | completed | failed
+  status_changed TEXT,
+  process_after TEXT,                      -- ISO timestamp (scheduling)
+  recurrence    TEXT,                      -- cron expression
+  tries         INTEGER DEFAULT 0,
+  created_at    TEXT DEFAULT (datetime('now'))
+);
+```
+
+### `delivered`
+
+```sql
+CREATE TABLE delivered (
+  seq                  INTEGER PRIMARY KEY,   -- seq du messages_out correspondant
+  platform_message_id  TEXT,                  -- ID plateforme retourné par l'adapter
+  delivered_at         TEXT DEFAULT (datetime('now'))
+);
+```
+
+### `destinations`
+
+```sql
+CREATE TABLE destinations (
+  local_name    TEXT PRIMARY KEY,   -- nom utilisé dans send_message(to="...")
+  target_type   TEXT NOT NULL,      -- channel | agent
+  target_id     TEXT NOT NULL,      -- platform_id ou agent_group_id
+  channel_type  TEXT,               -- pour type=channel
+  thread_id     TEXT
+);
+```
+
+### `session_routing`
+
+```sql
+CREATE TABLE session_routing (
+  id           INTEGER PRIMARY KEY CHECK (id = 1),   -- une seule ligne
+  channel_type TEXT NOT NULL,
+  platform_id  TEXT NOT NULL,
+  thread_id    TEXT
+);
+```
+
+---
+
+## Schema `outbound.db`
+
+### `messages_out`
+
+```sql
+CREATE TABLE messages_out (
+  id           TEXT PRIMARY KEY,
+  seq          INTEGER UNIQUE NOT NULL,   -- toujours IMPAIR (container)
+  kind         TEXT NOT NULL,            -- message | system | card | file
+  content      TEXT NOT NULL,            -- JSON (inclut operation, text, files, etc.)
+  channel_type TEXT,
+  platform_id  TEXT,
+  thread_id    TEXT,
+  deliver_after TEXT,                    -- scheduling
+  delivered    INTEGER DEFAULT 0,
+  created_at   TEXT DEFAULT (datetime('now'))
+);
+```
+
+### `processing_ack`
+
+```sql
+CREATE TABLE processing_ack (
+  message_in_id  TEXT PRIMARY KEY,
+  status         TEXT NOT NULL,   -- processing | completed | failed
+  error          TEXT,
+  updated_at     TEXT DEFAULT (datetime('now'))
+);
+```
+
+### `session_state`
+
+```sql
+CREATE TABLE session_state (
+  key    TEXT PRIMARY KEY,
+  value  TEXT NOT NULL
+);
+-- Exemple : key='claude_session_id', value='session_abc123'
+```
+
+---
+
+## Invariant de parité des `seq`
+
+```
+inbound.db messages_in  :  seq = 2, 4, 6, 8, ...   (host, PAIR)
+outbound.db messages_out:  seq = 1, 3, 5, 7, ...   (container, IMPAIR)
+```
+
+**Ce n'est pas juste une anti-collision.** C'est le mécanisme de lookup pour `edit_message` et `add_reaction` : quand l'agent appelle `edit_message(seq=5)`, la lookup cherche dans `messages_out` (seuls les impairs) sans ambiguïté. L'agent voit les seq dans ses prompts et les réutilise pour cibler ses propres messages.
+
+---
+
+## Synchronisation `processing_ack`
+
+Le container ne peut pas écrire dans `inbound.db`. Pour mettre à jour le statut des messages entrants :
+
+```
+Container:
+  processing_ack.insert({ message_in_id, status='completed' })
+  → outbound.db
+
+Host (host-sweep.ts, 60s) :
+  syncProcessingAcks()
+  → lit processing_ack dans outbound.db
+  → met à jour messages_in.status dans inbound.db
+  → supprime les lignes de processing_ack traitées
+```
+
+---
+
+## Heartbeat
+
+Le container touche le fichier `.heartbeat` (mtime) toutes les quelques secondes plutôt que d'écrire en DB. Cela évite de sérialiser derrière d'autres écritures. Le host surveille le mtime pour :
+- **Typing indicator** : affiche "typing" tant que le heartbeat est récent
+- **Stale detection** : si mtime > 10 min → container considéré crashé

--- a/my-docs/05-container-lifecycle.md
+++ b/my-docs/05-container-lifecycle.md
@@ -1,0 +1,142 @@
+# Cycle de vie des containers
+
+## États d'une session
+
+```
+          ┌─────────────────────────────────────────────┐
+          │                                             │
+          ▼                                             │
+       stopped ──── wakeContainer() ────▶ spawning ────┤
+          ▲                                    │        │
+          │                                    ▼        │
+          │                               running       │
+          │                                  │          │
+          │                         idle timeout 30min  │
+          │                                  │          │
+          └─────── killContainer() ─────── idle ────────┘
+                                              │
+                              stale (heartbeat > 10min)
+                                              │
+                                     reset to 'stopped'
+                                     messages_in → pending
+                                     backoff exponentiel
+```
+
+---
+
+## Spawn d'un container (`container-runner.ts`)
+
+```typescript
+wakeContainer(sessionId, agentGroupId)
+
+// 1. Déduplication
+if (wakePromises.has(sessionId)) return wakePromises.get(sessionId)
+if (activeContainers.has(sessionId)) return
+
+// 2. Rafraîchir les projections avant spawn
+writeDestinations(sessionId, agentGroupId)
+writeSessionRouting(sessionId, ...)
+
+// 3. Construire les mounts
+buildMounts() :
+  /workspace/inbound.db   ← ro: data/v2-sessions/<agId>/<sessId>/inbound.db
+  /workspace/outbound.db  ← rw: data/v2-sessions/<agId>/<sessId>/outbound.db
+  /workspace/.heartbeat   ← rw: data/v2-sessions/<agId>/<sessId>/.heartbeat
+  /workspace/outbox/      ← rw: data/v2-sessions/<agId>/<sessId>/outbox/
+  /workspace/agent/       ← ro: groups/<folder>/
+  /workspace/.claude/     ← rw: data/v2-sessions/<agId>/.claude-shared/
+  // + extra mounts du container_config
+
+// 4. Spawn
+spawn(dockerBin, [
+  "run", "--rm",
+  "--name", `nanoclaw-${sessionId}`,
+  "--env", "SESSION_INBOUND_DB_PATH=/workspace/inbound.db",
+  "--env", "SESSION_OUTBOUND_DB_PATH=/workspace/outbound.db",
+  "--env", "AGENT_PROVIDER=claude",
+  "--env", `TZ=${timezone}`,
+  // ... autres env vars
+  ...mounts,
+  "nanoclaw-agent:latest",
+  "exec bun /workspace/agent-runner/src/index.ts"
+])
+
+// 5. Tracking
+activeContainers.set(sessionId, process)
+markContainerRunning(sessionId)
+startIdleTimer(sessionId, 30min)
+```
+
+---
+
+## Idle timer
+
+Chaque livraison réussie appelle `resetIdleTimer()` — le container reste chaud tant que l'agent produit des messages. À la fin de l'inactivité :
+
+```
+idleTimeout fires
+  → killContainer(sessionId)
+  → process.kill('SIGTERM')
+  → activeContainers.delete(sessionId)
+  → markContainerStopped(sessionId)
+  → stopTypingRefresh(sessionId)
+```
+
+---
+
+## Stale detection (`host-sweep.ts`)
+
+Toutes les 60s, `sweepSession()` vérifie chaque session active :
+
+```
+pour chaque session avec container_status='running' :
+  heartbeatAge = now - mtime(.heartbeat)
+  
+  si heartbeatAge > STALE_THRESHOLD (10min) :
+    ET processing_ack contient des entrées 'processing' :
+      → container considéré crashé
+      
+      pour chaque message bloqué en 'processing' :
+        tries++
+        si tries >= MAX_TRIES (5) : status='failed'
+        sinon :
+          backoff = 5s × 2^tries
+          process_after = now + backoff
+          status='pending'
+      
+      markContainerStopped(sessionId)
+```
+
+---
+
+## Mounts détaillés
+
+```
+Host path                                    Container path        Mode
+─────────────────────────────────────────────────────────────────────────
+data/v2-sessions/<agId>/<sessId>/inbound.db  /workspace/inbound.db   ro
+data/v2-sessions/<agId>/<sessId>/outbound.db /workspace/outbound.db  rw
+data/v2-sessions/<agId>/<sessId>/.heartbeat  /workspace/.heartbeat   rw
+data/v2-sessions/<agId>/<sessId>/outbox/     /workspace/outbox/      rw
+data/v2-sessions/<agId>/<sessId>/inbox/      /workspace/inbox/       ro
+groups/<folder>/                             /workspace/agent/       ro
+data/v2-sessions/<agId>/.claude-shared/      /workspace/.claude/     rw
+container/agent-runner/src/                  /app/src/               ro (dev only)
+```
+
+Le container n'a pas accès au reste du système de fichiers host — isolation par design.
+
+---
+
+## Variables d'environnement injectées
+
+```
+SESSION_INBOUND_DB_PATH    /workspace/inbound.db
+SESSION_OUTBOUND_DB_PATH   /workspace/outbound.db
+SESSION_HEARTBEAT_PATH     /workspace/.heartbeat
+AGENT_PROVIDER             claude | opencode | codex
+NANOCLAW_ASSISTANT_NAME    nom de l'agent (depuis agent_groups)
+NANOCLAW_ADMIN_USER_IDS    liste des user IDs admin (pour accès MCP)
+NANOCLAW_MCP_SERVERS       JSON des MCP servers supplémentaires
+TZ                         timezone de l'hôte
+```

--- a/my-docs/06-agent-runner.md
+++ b/my-docs/06-agent-runner.md
@@ -1,0 +1,214 @@
+# Agent-Runner (internals container)
+
+## Architecture interne
+
+```
+/workspace/
+  inbound.db    (ro)
+  outbound.db   (rw)
+  .heartbeat    (rw)
+  agent/        (CLAUDE.md, skills, ...)
+  .claude/      (session SDK data)
+
+┌─────────────────────────────────────────────────────────────────┐
+│                    agent-runner (Bun process)                   │
+│                                                                 │
+│   index.ts                                                      │
+│   → load config (env vars)                                      │
+│   → create provider (claude | codex | opencode)                 │
+│   → build MCP server config                                     │
+│   → start MCP server (STDIO)                                    │
+│   → runPollLoop()                                               │
+│                                                                 │
+│   ┌─────────────────────────────────────────────────────────┐  │
+│   │                   poll-loop.ts                          │  │
+│   │                                                         │  │
+│   │  while(true) :                                          │  │
+│   │    messages = getPendingMessages()                      │  │
+│   │    si vide → sleep 1s                                   │  │
+│   │                                                         │  │
+│   │    markProcessing(messages)                             │  │
+│   │    formatted = formatMessages(messages)  ◀── formatter  │  │
+│   │    systemPrompt = buildSystemPromptAddendum()           │  │
+│   │    sessionId = getStoredSessionId()                     │  │
+│   │                                                         │  │
+│   │    query = provider.query({                             │  │
+│   │      prompt, sessionId, cwd='/workspace/agent',         │  │
+│   │      mcpServers, systemPrompt                           │  │
+│   │    })                                                   │  │
+│   │                                                         │  │
+│   │    // pendant la query : poll continu 500ms             │  │
+│   │    // nouveaux messages → provider.push()               │  │
+│   │                                                         │  │
+│   │    for await (event of query.events) :                  │  │
+│   │      'init'     → setStoredSessionId()                  │  │
+│   │      'progress' → log                                   │  │
+│   │      'result'   → terminé                               │  │
+│   │      'error'    → retry / fail                          │  │
+│   └─────────────────────────────────────────────────────────┘  │
+│                          │ MCP calls                            │
+│   ┌──────────────────────▼──────────────────────────────────┐  │
+│   │                  MCP Tool Server                        │  │
+│   │  (écoute en STDIO, utilisé par Claude Agent SDK)        │  │
+│   │                                                         │  │
+│   │  core.ts        : send_message, send_file, send_card    │  │
+│   │  scheduling.ts  : schedule_task, list/cancel/...        │  │
+│   │  interactive.ts : ask_user_question, edit_message,      │  │
+│   │                   add_reaction                          │  │
+│   │  agents.ts      : send_to_agent                         │  │
+│   │  self-mod.ts    : install_packages, add_mcp_server,     │  │
+│   │                   request_rebuild, register_agent_group  │  │
+│   └─────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Interface Provider
+
+```typescript
+interface AgentProvider {
+  query(input: QueryInput): AgentQuery
+}
+
+interface QueryInput {
+  prompt: string | ContentBlock[]
+  sessionId?: string          // reprise depuis session SDK précédente
+  resumeAt?: string           // point de reprise provider-specific
+  cwd: string                 // /workspace/agent
+  mcpServers: Record<string, McpServerConfig>
+  systemPrompt?: string       // addendum (destinations, etc.)
+  env: Record<string, string>
+  additionalDirectories?: string[]
+}
+
+interface AgentQuery {
+  push(message: string): void  // injecter un follow-up pendant query active
+  end(): void
+  abort(): void
+  events: AsyncIterable<ProviderEvent>
+}
+
+type ProviderEvent =
+  | { type: 'init';     sessionId: string }
+  | { type: 'result';   text: string | null }
+  | { type: 'error';    message: string; retryable: boolean }
+  | { type: 'progress'; message: string }
+```
+
+---
+
+## Provider Claude (`providers/claude.ts`)
+
+```
+provider.query()
+  → @anthropic-ai/claude-agent-sdk  query()
+  
+  Hooks configurés :
+    PreCompact  → archive les transcripts (avant compaction contexte)
+    PreToolUse  → sanitise les commandes bash dangereuses
+  
+  Tools autorisés (allowlist) :
+    Bash, Read, Write, Edit, Glob, Grep
+    WebSearch, WebFetch
+    Task, Skill
+    mcp__nanoclaw__*   (tous les outils MCP custom)
+  
+  Resume :
+    sessionId  → JSONL transcript existant
+    resumeAt   → UUID de reprise dans le transcript
+```
+
+---
+
+## Formatage des messages (`formatter.ts`)
+
+Le formatter produit le prompt final envoyé à Claude :
+
+```
+formatMessages(messages) :
+  
+  pour chaque message :
+    kind=chat :
+      <message sender="Alice" time="2024-01-15 10:30">
+        contenu du message
+      </message>
+    
+    kind=task :
+      <task id="task_abc" scheduled="2024-01-15 10:00">
+        prompt de la tâche
+      </task>
+    
+    kind=system (question_response) :
+      <system type="question_response" questionId="q_123"
+              selectedOption="Approuver">
+        L'utilisateur a répondu : Approuver
+      </system>
+    
+  Images/PDFs :
+    → content blocks natifs si Claude (vision)
+    → sauvegarde disque + référence texte sinon
+```
+
+---
+
+## System prompt addendum (`destinations.ts`)
+
+En plus du CLAUDE.md du groupe, l'agent reçoit un addendum injecté au runtime :
+
+```
+Tu as accès aux destinations suivantes :
+- "general"    → #general sur Discord
+- "tech-team"  → #tech-team sur Slack
+- "alice"      → DM Alice sur Telegram
+- "pr-worker"  → agent group pr-worker
+
+Utilise send_message(to="nom") pour cibler une destination spécifique.
+Par défaut, les messages vont dans la conversation d'origine.
+```
+
+---
+
+## MCP Tools — référence rapide
+
+### Core
+
+| Outil | Description |
+|-------|-------------|
+| `send_message(to?, text)` | Envoie un message (destination optionnelle) |
+| `send_file(to?, path, filename)` | Envoie un fichier depuis /workspace/outbox/ |
+| `send_card(to?, title, body, actions?)` | Envoie une carte interactive |
+
+### Scheduling
+
+| Outil | Description |
+|-------|-------------|
+| `schedule_task(prompt, processAfter, recurrence?)` | Planifie une tâche |
+| `list_tasks()` | Liste les tâches planifiées |
+| `cancel_task(id)` | Annule une tâche |
+| `pause_task(id)` | Met en pause une tâche récurrente |
+| `resume_task(id)` | Reprend une tâche pausée |
+| `update_task(id, ...)` | Met à jour prompt/schedule d'une tâche |
+
+### Interactive
+
+| Outil | Description |
+|-------|-------------|
+| `ask_user_question(title, question, options, timeout?)` | Pose une question avec boutons ; **bloque** jusqu'à réponse |
+| `edit_message(seq, newText)` | Édite un message déjà envoyé (via seq impair) |
+| `add_reaction(seq, emoji)` | Ajoute une réaction à un message |
+
+### Agents
+
+| Outil | Description |
+|-------|-------------|
+| `send_to_agent(agentGroupId, text)` | Envoie un message à un autre agent group |
+
+### Self-Mod
+
+| Outil | Description |
+|-------|-------------|
+| `install_packages(apt?, npm?)` | Demande installation packages (admin approval requis) |
+| `add_mcp_server(name, config)` | Ajoute un MCP server (admin approval requis) |
+| `request_rebuild()` | Demande rebuild du container (admin approval requis) |
+| `register_agent_group(name, folder)` | Crée un nouveau agent group |

--- a/my-docs/07-channels.md
+++ b/my-docs/07-channels.md
@@ -1,0 +1,183 @@
+# Système d'adaptateurs de canaux
+
+## Architecture
+
+```
+                    ┌─────────────────────────────────────────┐
+                    │         Channel Registry                │
+                    │   (src/channels/channel-registry.ts)    │
+                    │                                         │
+                    │  registerChannel(name, factory)         │
+                    │  getChannelAdapter(channelType)         │
+                    └───────────┬─────────────────────────────┘
+                                │
+             ┌──────────────────┼──────────────────────────┐
+             │                  │                          │
+             ▼                  ▼                          ▼
+    ┌─────────────────┐ ┌──────────────────┐  ┌────────────────────┐
+    │  Chat SDK Bridge │ │  Chat SDK Bridge  │  │  Native Adapter    │
+    │  (Discord)       │ │  (Slack, Telegram │  │  (WhatsApp/Baileys) │
+    │                  │ │   Linear, etc.)   │  │                    │
+    │  ChannelAdapter  │ │  ChannelAdapter   │  │  ChannelAdapter    │
+    └─────────────────┘ └──────────────────┘  └────────────────────┘
+```
+
+Les adaptateurs sont installés via des skills (`/add-discord`, `/add-slack`, etc.) depuis la branche `channels`. Trunk ne ship aucun adaptateur spécifique.
+
+---
+
+## Interface `ChannelAdapter`
+
+```typescript
+interface ChannelAdapter {
+  name: string
+  channelType: string           // 'telegram', 'discord', 'slack', ...
+  supportsThreads: boolean      // Discord/Slack/Linear = true ; Telegram/WhatsApp = false
+
+  setup(config: ChannelSetup): Promise<void>
+  teardown(): Promise<void>
+  isConnected(): boolean
+
+  // Livraison
+  deliver(
+    platformId: string,
+    threadId: string | null,
+    message: OutboundMessage
+  ): Promise<string | undefined>  // retourne platform_message_id si dispo
+
+  // Optionnels
+  setTyping?(platformId: string, threadId: string | null): Promise<void>
+  syncConversations?(): Promise<ConversationInfo[]>
+  updateConversations?(conversations: ConversationInfo[]): void
+  openDm?(userHandle: string): Promise<string>  // handle → DM platformId
+}
+```
+
+---
+
+## `ChannelSetup` (config injectée au démarrage)
+
+```typescript
+interface ChannelSetup {
+  onInbound(
+    platformId: string,
+    threadId: string | null,
+    message: InboundMessage
+  ): Promise<void>
+
+  onAction(
+    questionId: string,
+    selectedOption: string,
+    userId: string
+  ): void
+
+  getConversationConfigs(): ConversationConfig[]
+}
+```
+
+---
+
+## Message entrant (`InboundMessage`)
+
+```typescript
+interface InboundMessage {
+  id: string
+  kind: 'chat' | 'chat-sdk'
+  content: unknown     // objet JS → JSON.stringify avant écriture DB
+  timestamp: string    // ISO 8601
+  sender?: {
+    id: string         // platform-native ID
+    name: string
+  }
+  attachments?: Attachment[]
+}
+```
+
+---
+
+## Message sortant (`OutboundMessage`)
+
+```typescript
+interface OutboundMessage {
+  kind: string
+  content: unknown     // JSON depuis messages_out
+  files?: OutboundFile[]
+}
+```
+
+---
+
+## Chat SDK Bridge (`src/channels/bridge.ts`)
+
+Pour les canaux utilisant le Chat SDK (Discord, Slack, Linear, GitHub, etc.) :
+
+```
+Événement Chat SDK
+      │
+      ▼
+bridge.ts
+  → déduplication (évite re-delivery des propres messages)
+  → conversion Chat SDK event → InboundMessage
+  → appel onInbound()
+  
+Livraison via bridge.ts :
+  → adapter.postMessage() / editMessage() / addReaction()
+  → retourne platform_message_id
+```
+
+---
+
+## Enregistrement d'un adaptateur
+
+Chaque skill `/add-<channel>` ajoute une ligne dans `src/channels/index.ts` :
+
+```typescript
+// src/channels/index.ts
+import './adapters/discord'   // ← ajouté par /add-discord
+import './adapters/telegram'  // ← ajouté par /add-telegram
+// ...
+```
+
+Chaque fichier appelle `registerChannel()` à son import :
+
+```typescript
+// src/channels/adapters/discord.ts
+registerChannel('discord', (config) => new DiscordAdapter(config))
+```
+
+---
+
+## Channels supportés (branche `channels`)
+
+| Channel | Skill | Threads | Transport |
+|---------|-------|---------|-----------|
+| Discord | `/add-discord` | oui | Chat SDK |
+| Slack | `/add-slack` | oui | Chat SDK |
+| Telegram | `/add-telegram` | non | Chat SDK |
+| WhatsApp (Baileys) | `/add-whatsapp` | non | Natif |
+| WhatsApp Cloud | `/add-whatsapp-cloud` | non | Chat SDK |
+| Linear | `/add-linear` | oui | Chat SDK |
+| GitHub | `/add-github` | oui | Chat SDK |
+| iMessage | `/add-imessage` | non | Natif |
+| Teams | `/add-teams` | oui | Chat SDK |
+| Matrix | `/add-matrix` | oui | Chat SDK |
+| Google Chat | `/add-gchat` | non | Chat SDK |
+| Webex | `/add-webex` | non | Chat SDK |
+| Resend (email) | `/add-resend` | non | Chat SDK |
+
+---
+
+## Canal `agent` (interne)
+
+Pour la communication agent-to-agent, NanoClaw utilise un `channelType='agent'` virtuel qui ne passe pas par un adaptateur externe mais par le système de routing interne.
+
+```
+Agent A : send_to_agent(agentGroupId='worker', text='...')
+  → messages_out : channel_type='agent', platform_id='worker'
+  
+Host delivery :
+  → channelType='agent' → routing interne
+  → résolution session pour l'agent cible
+  → écriture dans inbound.db de la session cible
+  → wake du container cible
+```

--- a/my-docs/08-delivery.md
+++ b/my-docs/08-delivery.md
@@ -1,0 +1,194 @@
+# Système de livraison
+
+## Deux boucles de poll
+
+```
+                HOST PROCESS
+                     │
+        ┌────────────┴────────────┐
+        │                         │
+        ▼                         ▼
+  Active Poll (1s)           Sweep Poll (60s)
+  sessions running           toutes sessions actives
+        │                         │
+        └────────────┬────────────┘
+                     │
+                     ▼
+          deliverSessionMessages(sessionId)
+                     │
+                     ▼
+          messages_out WHERE delivered=0
+               AND deliver_after <= now()
+                     │
+                for each row
+                     │
+          ┌──────────▼──────────────┐
+          │  inflightDeliveries Set │  ← guard double-delivery
+          │  add(sessionId)         │
+          └──────────┬──────────────┘
+                     │
+                     ▼
+          deliveryAdapter.deliver()
+                     │
+            ┌────────┴──────────┐
+            │                   │
+            ▼                   ▼
+      normal send          operation type ?
+      adapter.deliver()    ├── edit_message
+                           │   → adapter.editMessage(platform_msg_id)
+                           ├── add_reaction
+                           │   → adapter.addReaction(platform_msg_id)
+                           └── card / system action
+                               → host handles directly
+                     │
+                     ▼
+          markDelivered(seq, platform_message_id)
+          → inbound.db delivered table
+                     │
+                     ▼
+          resetIdleTimer(sessionId)
+          inflightDeliveries.delete(sessionId)
+```
+
+---
+
+## Livraison de fichiers
+
+```
+Agent : send_file(path="rapport.pdf")
+  → MCP tool : copie fichier dans /workspace/outbox/<msg_id>/rapport.pdf
+  → messages_out : { kind:'file', files:['rapport.pdf'], ... }
+
+Host delivery :
+  → lit outbox/<msg_id>/rapport.pdf depuis le dossier session
+  → crée FileUpload (Chat SDK) ou appelle upload API natif
+  → envoie via adapter
+  → nettoie le dossier outbox/<msg_id>/
+```
+
+---
+
+## Typing indicator
+
+```
+wakeContainer()
+  → startTypingRefresh(sessionId, channelType, platformId, threadId)
+  
+  loop toutes les ~3s :
+    heartbeatAge = now - mtime(.heartbeat)
+    si heartbeatAge < STALE_THRESHOLD :
+      adapter.setTyping(platformId, threadId)
+    sinon :
+      stop le refresh
+  
+killContainer()
+  → stopTypingRefresh(sessionId)
+```
+
+Le typing indicator n'est affiché que si le container est vivant (heartbeat frais). Si le container crashe, le typing s'arrête automatiquement.
+
+---
+
+## Flux d'approbation (`delivery.ts:requestApproval()`)
+
+Déclenché quand l'agent appelle `install_packages`, `add_mcp_server`, ou `request_rebuild`.
+
+```
+messages_out : { kind:'system', action:'install_packages', payload:{...} }
+                     │
+                     ▼
+          requestApproval(sessionId, action, payload)
+                     │
+                     ▼
+          pickApprover() :
+            1. admins scopés à cet agent_group
+            2. admins globaux
+            3. owners
+            tie-break : préférer même channel_type que l'origin
+                     │
+                     ▼
+          ensureUserDm(approver) :
+            → cache user_dms (central DB)
+            → adapter.openDm(userHandle) si cache miss
+                     │
+                     ▼
+          pending_approvals.insert({
+            approval_id, session_id, action, payload, status='pending'
+          })
+                     │
+                     ▼
+          deliver carte approbation → DM de l'admin
+          ┌──────────────────────────────────────┐
+          │  🔧 Demande d'installation           │
+          │                                      │
+          │  L'agent demande d'installer :       │
+          │  apt: ffmpeg                         │
+          │  npm: sharp@0.33.0                   │
+          │                                      │
+          │  [ Approuver ]  [ Rejeter ]          │
+          └──────────────────────────────────────┘
+                     │
+          admin clique
+                     │
+                     ▼
+          handleApprovalResponse(approvalId, decision)
+            si 'approved' :
+              updateContainerConfig(agentGroupId, ...)
+              buildAgentGroupImage()     ← rebuild Docker image
+              killContainer(sessionId)
+              writeSystemMessage("Container rebuilt, verify packages")
+              → réveille le container sur la nouvelle image
+            si 'rejected' :
+              writeSystemMessage("Request rejected by admin")
+            
+          pending_approvals.delete(approvalId)
+```
+
+---
+
+## Host Sweep (`src/host-sweep.ts`, toutes les 60s)
+
+```
+sweepAllSessions()
+  │
+  ├── syncProcessingAcks()
+  │     → lit processing_ack depuis outbound.db
+  │     → met à jour messages_in.status dans inbound.db
+  │
+  ├── detectStaleContainers()
+  │     → heartbeat > 10min + messages 'processing'
+  │     → reset + backoff exponentiel
+  │
+  ├── wakeForDueMessages()
+  │     → sessions stopped avec messages process_after <= now
+  │     → wakeContainer()
+  │
+  └── handleRecurrence()
+        → messages_in completed avec recurrence != null
+        → next = cronParser.next(recurrence, from=process_after)
+        → insert nouveau messages_in avec process_after=next
+        → NB: calculé depuis le schedule prévu, pas le wall-clock
+          (évite le drift si le sweep est en retard)
+```
+
+---
+
+## Livraison schedulée
+
+```
+Agent : schedule_task("Rapport hebdo", processAfter="2024-01-22 09:00", 
+                       recurrence="0 9 * * 1")
+  
+  MCP tool : messages_in.insert({
+    kind='task',
+    process_after='2024-01-22 09:00',
+    recurrence='0 9 * * 1',
+    status='pending'
+  })
+
+  Host sweep (60s) :
+    → trouve messages_in WHERE process_after <= now AND status='pending'
+    → wakeContainer() → agent traite la tâche
+    → markCompleted()
+    → si recurrence : insert prochain occurrence
+```

--- a/my-docs/09-fonctions-avancees.md
+++ b/my-docs/09-fonctions-avancees.md
@@ -1,0 +1,225 @@
+# Fonctions avancées
+
+## 1. Questions interactives (`ask_user_question`)
+
+```
+AGENT                    HOST                    UTILISATEUR
+  │                        │                          │
+  │  ask_user_question()   │                          │
+  │  (MCP tool)            │                          │
+  │  → messages_out        │                          │
+  │    operation='ask'     │                          │
+  │    questionId='q_123'  │                          │
+  │    options=['Oui','Non']│                         │
+  │                        │                          │
+  │                        │ active poll (1s)         │
+  │                        │ lit messages_out         │
+  │                        │                          │
+  │                        │ pending_questions.insert │
+  │                        │ → central DB             │
+  │                        │                          │
+  │                        │ deliver carte → adapter  │
+  │                        │─────────────────────────▶│
+  │                        │  ┌──────────────────┐    │
+  │                        │  │ Question ?        │    │
+  │                        │  │ [ Oui ] [ Non ]  │    │
+  │                        │  └──────────────────┘    │
+  │                        │                          │
+  │ ... MCP tool bloque    │                          │
+  │ (poll messages_in      │               clique Oui │
+  │  500ms en attendant    │◀─────────────────────────│
+  │  system message)       │ onAction(q_123, 'Oui')   │
+  │                        │                          │
+  │                        │ messages_in.insert({     │
+  │                        │   kind='system',         │
+  │                        │   type='question_resp',  │
+  │                        │   questionId='q_123',    │
+  │                        │   selectedOption='Oui'   │
+  │                        │ })                       │
+  │                        │ wakeContainer()          │
+  │                        │                          │
+  │◀── tool result 'Oui' ──│                          │
+  │                        │ pending_questions.delete │
+```
+
+Le MCP tool `ask_user_question` **bloque** la query Claude jusqu'à réception de la réponse. La boucle de poll container (500ms) détecte le message system et le retourne comme résultat de l'outil.
+
+---
+
+## 2. Scheduling et récurrence
+
+```
+Lifecycle d'une tâche planifiée :
+
+schedule_task(
+  prompt    = "Envoie le rapport de la semaine",
+  processAfter = "2024-01-22 09:00",
+  recurrence   = "0 9 * * 1"   ← chaque lundi à 9h
+)
+   │
+   ▼
+messages_in :
+  kind='task'
+  status='pending'
+  process_after='2024-01-22 09:00'
+  recurrence='0 9 * * 1'
+   │
+   ▼ host-sweep (60s)
+
+Exécution #1 (lundi 22 jan) :
+  wakeContainer() → agent exécute
+  markCompleted(msg_id)
+  
+  handleRecurrence() :
+    next = cronParser.next('0 9 * * 1', from='2024-01-22 09:00')
+         = '2024-01-29 09:00'   ← calculé depuis schedule, pas wall-clock
+    
+    messages_in.insert({
+      kind='task', process_after='2024-01-29 09:00',
+      recurrence='0 9 * * 1', status='pending'
+    })
+
+Exécution #2 (lundi 29 jan) : idem...
+```
+
+**Pourquoi calculer depuis le schedule ?** Si le sweep tourne à 09:01 au lieu de 09:00, calculer depuis `now` produirait la prochaine occurrence à 09:01 la semaine suivante — drift progressif. Calculer depuis le `process_after` prévu évite ce drift.
+
+---
+
+## 3. Communication agent-to-agent
+
+```
+AGENT A (pr-admin)          HOST                  AGENT B (pr-worker)
+      │                       │                          │
+      │ send_to_agent(         │                          │
+      │   'pr-worker',         │                          │
+      │   'Analyse cette PR'   │                          │
+      │ )                      │                          │
+      │ → messages_out :       │                          │
+      │   channel_type='agent' │                          │
+      │   platform_id=         │                          │
+      │     'pr-worker'        │                          │
+      │                        │                          │
+      │                        │ active poll (1s)         │
+      │                        │ channelType='agent'      │
+      │                        │ → routing interne        │
+      │                        │                          │
+      │                        │ résolution session       │
+      │                        │ pour pr-worker           │
+      │                        │                          │
+      │                        │ messages_in.insert(      │
+      │                        │   session=pr-worker,     │
+      │                        │   kind='chat',           │
+      │                        │   sender='agent:pr-admin'│
+      │                        │ )                        │
+      │                        │                          │
+      │                        │ wakeContainer(pr-worker) │
+      │                        │─────────────────────────▶│
+      │                        │                          │ poll + traitement
+      │                        │                          │ sender='agent:pr-admin'
+      │                        │◀──── messages_out ───────│
+      │                        │ livraison → pr-admin      │
+      │◀────── réponse ─────────│                          │
+```
+
+Les ACL sont vérifiées via `agent_destinations` — l'agent A doit avoir `pr-worker` dans ses destinations pour pouvoir lui envoyer un message.
+
+---
+
+## 4. Self-modification (admin approval)
+
+Flux pour `install_packages` (identique pour `add_mcp_server` et `request_rebuild`) :
+
+```
+Agent                 Host                  Admin
+  │                     │                     │
+  │ install_packages(   │                     │
+  │   apt=['ffmpeg'],   │                     │
+  │   npm=['sharp@0.33']│                     │
+  │ )                   │                     │
+  │ → messages_out      │                     │
+  │   action=           │                     │
+  │   'install_packages'│                     │
+  │                     │                     │
+  │                     │ requestApproval()   │
+  │                     │ pending_approvals   │
+  │                     │ carte → DM admin    │
+  │                     │────────────────────▶│
+  │                     │                     │ [ Approuver ]
+  │                     │◀────────────────────│
+  │                     │                     │
+  │                     │ updateContainerConfig()
+  │                     │ → container.json    │
+  │                     │   apt/npm packages  │
+  │                     │                     │
+  │                     │ buildAgentGroupImage()
+  │                     │ → docker build       │
+  │                     │   avec nouveaux pkgs │
+  │                     │                     │
+  │                     │ killContainer()     │
+  │                     │ writeSystemMessage( │
+  │                     │   "Rebuilt, verify" │
+  │                     │ )                   │
+  │                     │ wakeContainer()     │
+  │◀── "Container       │                     │
+  │    rebuilt"         │                     │
+```
+
+---
+
+## 5. Destinations et routing ciblé
+
+```
+Configuration (central DB agent_destinations) :
+  agent_group_id='assistant'
+  local_name='equipe-dev'    → channel_type='slack', platform_id='C123', thread_id=null
+  local_name='alice'         → channel_type='telegram', platform_id='U456'
+  local_name='worker'        → target_type='agent', target_id='pr-worker'
+
+Au wake du container :
+  writeDestinations(sessionId, agentGroupId)
+  → copie dans inbound.db destinations (projection)
+
+L'agent appelle :
+  send_message(to="equipe-dev", text="Déploiement terminé")
+  
+MCP tool :
+  destinations.find('equipe-dev')
+  → { channel_type:'slack', platform_id:'C123' }
+  → messages_out avec ces routing fields
+
+Host delivery :
+  → adapter slack.deliver('C123', null, message)
+```
+
+---
+
+## 6. Isolation des sessions
+
+Trois niveaux d'isolation disponibles dans `messaging_group_agents.session_mode` :
+
+```
+agent-shared :
+  Toutes les conversations de tous les canaux partagent
+  un seul contexte Claude (une session).
+  Usage : agent "oracle" unique qui doit avoir mémoire globale.
+
+  Discord#general ─┐
+  Telegram chat   ─┼──▶ session unique (agent-shared)
+  Slack #random   ─┘
+
+shared :
+  Une session par conversation (messaging_group).
+  Usage : agent spécialisé par canal.
+
+  Discord#general ──▶ session A
+  Telegram chat   ──▶ session B
+
+per-thread :
+  Une session par thread dans la conversation.
+  Usage : support ou ticketing avec contexte isolé.
+
+  Discord#general/thread-1 ──▶ session A
+  Discord#general/thread-2 ──▶ session B
+  Discord#general/thread-3 ──▶ session C
+```

--- a/my-docs/README.md
+++ b/my-docs/README.md
@@ -1,0 +1,17 @@
+# NanoClaw — Documentation personnelle
+
+Documentation complète du fonctionnement de NanoClaw v2.
+
+## Sommaire
+
+| Document | Contenu |
+|----------|---------|
+| [01-vue-ensemble.md](01-vue-ensemble.md) | Vue d'ensemble, philosophie, schéma général |
+| [02-modele-entites.md](02-modele-entites.md) | Modèle d'entités (users, groups, sessions, DB centrale) |
+| [03-flux-message.md](03-flux-message.md) | Flux complet d'un message : réception → agent → livraison |
+| [04-session-db.md](04-session-db.md) | Les deux DBs de session (inbound/outbound) et leurs invariants |
+| [05-container-lifecycle.md](05-container-lifecycle.md) | Cycle de vie des containers (spawn, heartbeat, idle, stale) |
+| [06-agent-runner.md](06-agent-runner.md) | Internals de l'agent-runner (poll loop, provider, MCP tools) |
+| [07-channels.md](07-channels.md) | Système d'adaptateurs de canaux |
+| [08-delivery.md](08-delivery.md) | Système de livraison (active poll, sweep, approbations) |
+| [09-fonctions-avancees.md](09-fonctions-avancees.md) | Questions interactives, scheduling, agent-to-agent, self-mod |

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@chat-adapter/discord": "^4.26.0",
     "@chat-adapter/telegram": "4.26.0",
+    "@nanoco/nanoclaw-dashboard": "^0.3.0",
     "@onecli-sh/sdk": "^0.3.1",
     "better-sqlite3": "11.10.0",
     "chat": "^4.24.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@chat-adapter/discord": "^4.26.0",
+    "@chat-adapter/telegram": "4.26.0",
     "@onecli-sh/sdk": "^0.3.1",
     "better-sqlite3": "11.10.0",
     "chat": "^4.24.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@chat-adapter/telegram':
         specifier: 4.26.0
         version: 4.26.0
+      '@nanoco/nanoclaw-dashboard':
+        specifier: ^0.3.0
+        version: 0.3.0
       '@onecli-sh/sdk':
         specifier: ^0.3.1
         version: 0.3.1
@@ -324,6 +327,10 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@nanoco/nanoclaw-dashboard@0.3.0':
+    resolution: {integrity: sha512-AT1sLe/PxtSMytMqXOH5xeoFw9gyYpEhXC4XIA4/940Fmw45FWAJfdQzyVRi9JZKhb2b6Qr6nqVfQRgAB3LoaA==}
+    hasBin: true
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -1796,6 +1803,8 @@ snapshots:
   '@humanwhocodes/retry@0.4.3': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@nanoco/nanoclaw-dashboard@0.3.0': {}
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@chat-adapter/discord':
+        specifier: ^4.26.0
+        version: 4.26.0
+      '@chat-adapter/telegram':
+        specifier: 4.26.0
+        version: 4.26.0
       '@onecli-sh/sdk':
         specifier: ^0.3.1
         version: 0.3.1
@@ -59,6 +65,43 @@ importers:
         version: 4.1.4(@types/node@22.19.17)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0))
 
 packages:
+
+  '@chat-adapter/discord@4.26.0':
+    resolution: {integrity: sha512-p0Xm/aPjHP9z87/tXtHz0KFmbUcu7SGPQAAlT8mrKRX49jO77Tognj/5poSmV1XQ1C4BLfxpPvTQlLNK/5omkw==}
+
+  '@chat-adapter/shared@4.26.0':
+    resolution: {integrity: sha512-YD0MGktFXrArUqTBsyPfL5vkdD1WBS58PAWO0oVrMQAMmPxpAXfWGjBtZCkf3y8R8Svb0uVuVXiMZSForaEnMQ==}
+
+  '@chat-adapter/telegram@4.26.0':
+    resolution: {integrity: sha512-PE2HoCQ4648VNKZTuHFanQNoYzM/niNoSbDyYlPq6VOoB5qsoo1ctR8TERyl1EfPBNexWZpSWYrrnQPr15LUfA==}
+
+  '@discordjs/builders@1.14.1':
+    resolution: {integrity: sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ==}
+    engines: {node: '>=16.11.0'}
+
+  '@discordjs/collection@1.5.3':
+    resolution: {integrity: sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==}
+    engines: {node: '>=16.11.0'}
+
+  '@discordjs/collection@2.1.1':
+    resolution: {integrity: sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==}
+    engines: {node: '>=18'}
+
+  '@discordjs/formatters@0.6.2':
+    resolution: {integrity: sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==}
+    engines: {node: '>=16.11.0'}
+
+  '@discordjs/rest@2.6.1':
+    resolution: {integrity: sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg==}
+    engines: {node: '>=18'}
+
+  '@discordjs/util@1.2.0':
+    resolution: {integrity: sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==}
+    engines: {node: '>=18'}
+
+  '@discordjs/ws@1.2.3':
+    resolution: {integrity: sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==}
+    engines: {node: '>=16.11.0'}
 
   '@emnapi/core@1.9.2':
     resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
@@ -393,6 +436,22 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.15':
     resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
 
+  '@sapphire/async-queue@1.5.5':
+    resolution: {integrity: sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==}
+    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+
+  '@sapphire/shapeshift@4.0.0':
+    resolution: {integrity: sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==}
+    engines: {node: '>=v16'}
+
+  '@sapphire/snowflake@3.5.3':
+    resolution: {integrity: sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==}
+    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+
+  '@sapphire/snowflake@3.5.5':
+    resolution: {integrity: sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==}
+    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -428,6 +487,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.58.2':
     resolution: {integrity: sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==}
@@ -516,6 +578,10 @@ packages:
 
   '@vitest/utils@4.1.4':
     resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
+
+  '@vladfrangu/async_event_emitter@2.4.7':
+    resolution: {integrity: sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==}
+    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
 
   '@workflow/serde@4.1.0-beta.2':
     resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
@@ -654,6 +720,20 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  discord-api-types@0.37.120:
+    resolution: {integrity: sha512-7xpNK0EiWjjDFp2nAhHXezE4OUWm7s1zhc/UXXN6hnFFU8dfoPHgV0Hx0RPiCa3ILRpdeh152icc68DGCyXYIw==}
+
+  discord-api-types@0.38.47:
+    resolution: {integrity: sha512-XgXQodHQBAE6kfD7kMvVo30863iHX1LHSqNq6MGUTDwIFCCvHva13+rwxyxVXDqudyApMNAd32PGjgVETi5rjA==}
+
+  discord-interactions@4.4.0:
+    resolution: {integrity: sha512-jjJx8iwAeJcj8oEauV43fue9lNqkf38fy60aSs2+G8D1nJmDxUIrk08o3h0F3wgwuBWWJUZO+X/VgfXsxpCiJA==}
+    engines: {node: '>=18.4.0'}
+
+  discord.js@14.26.3:
+    resolution: {integrity: sha512-XEKtYn28YFsiJ5l4fLRyikdbo6RD5oFyqfVHQlvXz2104JhH/E8slN28dbky05w3DCrJcNVWvhVvcJCTSl/KIg==}
+    engines: {node: '>=18'}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -951,12 +1031,21 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  lodash.snakecase@4.1.1:
+    resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
+
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
   luxon@3.7.2:
     resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
     engines: {node: '>=12'}
+
+  magic-bytes.js@1.13.0:
+    resolution: {integrity: sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1295,6 +1384,9 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  ts-mixer@6.0.4:
+    resolution: {integrity: sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -1324,6 +1416,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@6.24.1:
+    resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
+    engines: {node: '>=18.17'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -1453,6 +1549,18 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -1461,6 +1569,80 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@chat-adapter/discord@4.26.0':
+    dependencies:
+      '@chat-adapter/shared': 4.26.0
+      chat: 4.26.0
+      discord-api-types: 0.37.120
+      discord-interactions: 4.4.0
+      discord.js: 14.26.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@chat-adapter/shared@4.26.0':
+    dependencies:
+      chat: 4.26.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@chat-adapter/telegram@4.26.0':
+    dependencies:
+      '@chat-adapter/shared': 4.26.0
+      chat: 4.26.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@discordjs/builders@1.14.1':
+    dependencies:
+      '@discordjs/formatters': 0.6.2
+      '@discordjs/util': 1.2.0
+      '@sapphire/shapeshift': 4.0.0
+      discord-api-types: 0.38.47
+      fast-deep-equal: 3.1.3
+      ts-mixer: 6.0.4
+      tslib: 2.8.1
+
+  '@discordjs/collection@1.5.3': {}
+
+  '@discordjs/collection@2.1.1': {}
+
+  '@discordjs/formatters@0.6.2':
+    dependencies:
+      discord-api-types: 0.38.47
+
+  '@discordjs/rest@2.6.1':
+    dependencies:
+      '@discordjs/collection': 2.1.1
+      '@discordjs/util': 1.2.0
+      '@sapphire/async-queue': 1.5.5
+      '@sapphire/snowflake': 3.5.5
+      '@vladfrangu/async_event_emitter': 2.4.7
+      discord-api-types: 0.38.47
+      magic-bytes.js: 1.13.0
+      tslib: 2.8.1
+      undici: 6.24.1
+
+  '@discordjs/util@1.2.0':
+    dependencies:
+      discord-api-types: 0.38.47
+
+  '@discordjs/ws@1.2.3':
+    dependencies:
+      '@discordjs/collection': 2.1.1
+      '@discordjs/rest': 2.6.1
+      '@discordjs/util': 1.2.0
+      '@sapphire/async-queue': 1.5.5
+      '@types/ws': 8.18.1
+      '@vladfrangu/async_event_emitter': 2.4.7
+      discord-api-types: 0.38.47
+      tslib: 2.8.1
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@emnapi/core@1.9.2':
     dependencies:
@@ -1677,6 +1859,17 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.15': {}
 
+  '@sapphire/async-queue@1.5.5': {}
+
+  '@sapphire/shapeshift@4.0.0':
+    dependencies:
+      fast-deep-equal: 3.1.3
+      lodash: 4.18.1
+
+  '@sapphire/snowflake@3.5.3': {}
+
+  '@sapphire/snowflake@3.5.5': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@tybys/wasm-util@0.10.1':
@@ -1714,6 +1907,10 @@ snapshots:
       undici-types: 6.21.0
 
   '@types/unist@3.0.3': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.19.17
 
   '@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
@@ -1847,6 +2044,8 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@vladfrangu/async_event_emitter@2.4.7': {}
+
   '@workflow/serde@4.1.0-beta.2': {}
 
   acorn-jsx@5.3.2(acorn@8.16.0):
@@ -1977,6 +2176,31 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  discord-api-types@0.37.120: {}
+
+  discord-api-types@0.38.47: {}
+
+  discord-interactions@4.4.0: {}
+
+  discord.js@14.26.3:
+    dependencies:
+      '@discordjs/builders': 1.14.1
+      '@discordjs/collection': 1.5.3
+      '@discordjs/formatters': 0.6.2
+      '@discordjs/rest': 2.6.1
+      '@discordjs/util': 1.2.0
+      '@discordjs/ws': 1.2.3
+      '@sapphire/snowflake': 3.5.3
+      discord-api-types: 0.38.47
+      fast-deep-equal: 3.1.3
+      lodash.snakecase: 4.1.1
+      magic-bytes.js: 1.13.0
+      tslib: 2.8.1
+      undici: 6.24.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   end-of-stream@1.4.5:
     dependencies:
@@ -2251,9 +2475,15 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  lodash.snakecase@4.1.1: {}
+
+  lodash@4.18.1: {}
+
   longest-streak@3.1.0: {}
 
   luxon@3.7.2: {}
+
+  magic-bytes.js@1.13.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -2785,8 +3015,9 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  tslib@2.8.1:
-    optional: true
+  ts-mixer@6.0.4: {}
+
+  tslib@2.8.1: {}
 
   tsx@4.21.0:
     dependencies:
@@ -2817,6 +3048,8 @@ snapshots:
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
+
+  undici@6.24.1: {}
 
   unified@11.0.5:
     dependencies:
@@ -2915,6 +3148,8 @@ snapshots:
   word-wrap@1.2.5: {}
 
   wrappy@1.0.2: {}
+
+  ws@8.20.0: {}
 
   yocto-queue@0.1.0: {}
 

--- a/setup/index.ts
+++ b/setup/index.ts
@@ -13,6 +13,7 @@ const STEPS: Record<
   environment: () => import('./environment.js'),
   container: () => import('./container.js'),
   register: () => import('./register.js'),
+  'pair-telegram': () => import('./pair-telegram.js'),
   mounts: () => import('./mounts.js'),
   service: () => import('./service.js'),
   verify: () => import('./verify.js'),

--- a/setup/pair-telegram.ts
+++ b/setup/pair-telegram.ts
@@ -1,0 +1,116 @@
+/**
+ * Step: pair-telegram — issue a one-time pairing code and wait for the
+ * operator to send `@botname CODE` from the chat they want to register.
+ *
+ * On success, prints platformId / isGroup / pairedUserId / intent. The caller
+ * (skill) can then wire the chat to an agent group (e.g. via /init-first-agent
+ * or setup --step register). telegram.ts's inbound interceptor has already
+ * upserted the paired user and granted owner if no owner existed yet.
+ *
+ * The service must already be running so the telegram adapter is polling.
+ */
+import { initDb } from '../src/db/connection.js';
+import { runMigrations } from '../src/db/migrations/index.js';
+import { DATA_DIR } from '../src/config.js';
+import path from 'path';
+
+import {
+  createPairing,
+  waitForPairing,
+  type PairingIntent,
+} from '../src/channels/telegram-pairing.js';
+import { emitStatus } from './status.js';
+
+function parseArgs(args: string[]): PairingIntent {
+  let intent: PairingIntent = 'main';
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--intent': {
+        const raw = args[++i] || 'main';
+        if (raw === 'main') {
+          intent = 'main';
+        } else if (raw.startsWith('wire-to:')) {
+          intent = { kind: 'wire-to', folder: raw.slice('wire-to:'.length) };
+        } else if (raw.startsWith('new-agent:')) {
+          intent = { kind: 'new-agent', folder: raw.slice('new-agent:'.length) };
+        } else {
+          throw new Error(`Unknown intent: ${raw}`);
+        }
+        break;
+      }
+    }
+  }
+  return intent;
+}
+
+function intentToString(intent: PairingIntent): string {
+  if (intent === 'main') return 'main';
+  return `${intent.kind}:${intent.folder}`;
+}
+
+export async function run(args: string[]): Promise<void> {
+  const intent = parseArgs(args);
+
+  // Pairing reads/writes its JSON store under DATA_DIR; the DB isn't strictly
+  // required for the pairing primitive itself, but the inbound interceptor
+  // (running in the live service) needs it. Touch it here so a fresh install
+  // doesn't blow up on the first match.
+  const db = initDb(path.join(DATA_DIR, 'v2.db'));
+  runMigrations(db);
+
+  const MAX_REGENERATIONS = 5;
+  let record = await createPairing(intent);
+  emitStatus('PAIR_TELEGRAM_ISSUED', {
+    CODE: record.code,
+    INTENT: intentToString(intent),
+    INSTRUCTIONS: `Send "${record.code}" from the Telegram chat you want to register (or "@<botname> ${record.code}" in a group with privacy on).`,
+    REMINDER_TO_ASSISTANT: `Your next user-visible message MUST include this CODE in plain text — the bash tool output this block is in gets collapsed in the UI.`,
+  });
+
+  for (let regen = 0; regen <= MAX_REGENERATIONS; regen++) {
+    try {
+      const consumed = await waitForPairing(record.code, {
+        onAttempt: (a) => {
+          emitStatus('PAIR_TELEGRAM_ATTEMPT', {
+            EXPECTED_CODE: record.code,
+            RECEIVED_CODE: a.candidate,
+            PLATFORM_ID: a.platformId,
+            AT: a.at,
+          });
+        },
+      });
+      emitStatus('PAIR_TELEGRAM', {
+        STATUS: 'success',
+        CODE: record.code,
+        INTENT: intentToString(consumed.intent),
+        PLATFORM_ID: consumed.consumed!.platformId,
+        IS_GROUP: consumed.consumed!.isGroup,
+        PAIRED_USER_ID: consumed.consumed!.adminUserId
+          ? `telegram:${consumed.consumed!.adminUserId}`
+          : '',
+      });
+      return;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const invalidated = /invalidated by wrong code/.test(message);
+      if (invalidated && regen < MAX_REGENERATIONS) {
+        record = await createPairing(intent);
+        emitStatus('PAIR_TELEGRAM_NEW_CODE', {
+          CODE: record.code,
+          INTENT: intentToString(intent),
+          REASON: 'previous code invalidated by wrong attempt',
+          REGENERATIONS_LEFT: MAX_REGENERATIONS - regen - 1,
+          INSTRUCTIONS: `Send "${record.code}" from the Telegram chat you want to register.`,
+          REMINDER_TO_ASSISTANT: `Your next user-visible message MUST include this CODE in plain text — the bash tool output this block is in gets collapsed in the UI.`,
+        });
+        continue;
+      }
+      emitStatus('PAIR_TELEGRAM', {
+        STATUS: 'failed',
+        CODE: record.code,
+        ERROR: invalidated ? 'max-regenerations-exceeded' : message,
+      });
+      process.exit(2);
+    }
+  }
+}

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -1,0 +1,38 @@
+/**
+ * Discord channel adapter (v2) — uses Chat SDK bridge.
+ * Self-registers on import.
+ */
+import { createDiscordAdapter } from '@chat-adapter/discord';
+
+import { readEnvFile } from '../env.js';
+import { createChatSdkBridge, type ReplyContext } from './chat-sdk-bridge.js';
+import { registerChannelAdapter } from './channel-registry.js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function extractReplyContext(raw: Record<string, any>): ReplyContext | null {
+  if (!raw.referenced_message) return null;
+  const reply = raw.referenced_message;
+  return {
+    text: reply.content || '',
+    sender: reply.author?.global_name || reply.author?.username || 'Unknown',
+  };
+}
+
+registerChannelAdapter('discord', {
+  factory: () => {
+    const env = readEnvFile(['DISCORD_BOT_TOKEN', 'DISCORD_PUBLIC_KEY', 'DISCORD_APPLICATION_ID']);
+    if (!env.DISCORD_BOT_TOKEN) return null;
+    const discordAdapter = createDiscordAdapter({
+      botToken: env.DISCORD_BOT_TOKEN,
+      publicKey: env.DISCORD_PUBLIC_KEY,
+      applicationId: env.DISCORD_APPLICATION_ID,
+    });
+    return createChatSdkBridge({
+      adapter: discordAdapter,
+      concurrency: 'concurrent',
+      botToken: env.DISCORD_BOT_TOKEN,
+      extractReplyContext,
+      supportsThreads: true,
+    });
+  },
+});

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -4,3 +4,5 @@
 // v2 ships with no channels baked in. Channel skills (e.g. /add-slack-v2,
 // /add-discord-v2, /add-whatsapp-v2) copy the channel module from the
 // `channels` branch and append a self-registration import below.
+import './telegram.js';
+import './discord.js';

--- a/src/channels/telegram-markdown-sanitize.test.ts
+++ b/src/channels/telegram-markdown-sanitize.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeTelegramLegacyMarkdown } from './telegram-markdown-sanitize.js';
+
+describe('sanitizeTelegramLegacyMarkdown', () => {
+  it('downgrades CommonMark **bold** to legacy *bold*', () => {
+    expect(sanitizeTelegramLegacyMarkdown('**Host path**')).toBe('*Host path*');
+  });
+
+  it('downgrades CommonMark __bold__ to legacy _italic_', () => {
+    expect(sanitizeTelegramLegacyMarkdown('__label__')).toBe('_label_');
+  });
+
+  it('leaves balanced legacy *bold* and _italic_ alone', () => {
+    expect(sanitizeTelegramLegacyMarkdown('a *b* c _d_ e')).toBe('a *b* c _d_ e');
+  });
+
+  it('preserves inline code spans untouched', () => {
+    const input = 'see `file_name.py` and `**not bold**` here';
+    expect(sanitizeTelegramLegacyMarkdown(input)).toBe(input);
+  });
+
+  it('preserves fenced code blocks untouched', () => {
+    const input = '```\nfoo_bar **baz**\n```';
+    expect(sanitizeTelegramLegacyMarkdown(input)).toBe(input);
+  });
+
+  it('strips formatting chars on odd delimiter count (unbalanced *)', () => {
+    expect(sanitizeTelegramLegacyMarkdown('a * b *c*')).toBe('a  b c');
+  });
+
+  it('strips formatting chars on odd delimiter count (unbalanced _)', () => {
+    expect(sanitizeTelegramLegacyMarkdown('file_name has _one italic_')).toBe('filename has one italic');
+  });
+
+  it('strips brackets when unbalanced', () => {
+    expect(sanitizeTelegramLegacyMarkdown('see [docs here')).toBe('see docs here');
+  });
+
+  it('leaves matched brackets (e.g. links) alone when counts balance', () => {
+    const input = 'see [docs](https://example.com) for more';
+    expect(sanitizeTelegramLegacyMarkdown(input)).toBe(input);
+  });
+
+  it('fixes the real failing message', () => {
+    const input =
+      'Sure! What do you want to mount, and where should it appear inside the container?\n\n' +
+      '- **Host path** (on your machine): e.g. `~/projects/webapp`\n' +
+      '- **Container path**: e.g. `workspace/webapp`\n' +
+      '- **Read-only or read-write?**';
+    const out = sanitizeTelegramLegacyMarkdown(input);
+    expect(out).not.toContain('**');
+    expect(out).toContain('*Host path*');
+    expect(out).toContain('`~/projects/webapp`');
+    expect((out.match(/\*/g) ?? []).length % 2).toBe(0);
+  });
+
+  it('is a no-op on empty string', () => {
+    expect(sanitizeTelegramLegacyMarkdown('')).toBe('');
+  });
+
+  it('replaces dash list bullets with • so the adapter does not re-emit `*` markers', () => {
+    expect(sanitizeTelegramLegacyMarkdown('- one\n- two')).toBe('• one\n• two');
+  });
+
+  it('preserves indented list structure', () => {
+    expect(sanitizeTelegramLegacyMarkdown('  - nested')).toBe('  • nested');
+  });
+});

--- a/src/channels/telegram-markdown-sanitize.ts
+++ b/src/channels/telegram-markdown-sanitize.ts
@@ -1,0 +1,50 @@
+/**
+ * Sanitize outbound text for Telegram's legacy `Markdown` parse mode.
+ *
+ * WORKAROUND: The @chat-adapter/telegram adapter hardcodes parse_mode=Markdown
+ * (legacy) but its converter emits CommonMark. Messages with `**bold**`, odd
+ * delimiter counts, or malformed links are rejected by Telegram and dropped
+ * after retries. Remove this once upstream ships real mode-aware conversion
+ * (vercel/chat PR #367 adds the knob; a follow-up is needed for the converter).
+ */
+
+const CODE_PATTERN = /```[\s\S]*?```|`[^`\n]*`/g;
+const PLACEHOLDER_PREFIX = '\x00CODE';
+const PLACEHOLDER_SUFFIX = '\x00';
+
+export function sanitizeTelegramLegacyMarkdown(input: string): string {
+  if (!input) return input;
+
+  const codeSegments: string[] = [];
+  let text = input.replace(CODE_PATTERN, (m) => {
+    codeSegments.push(m);
+    return `${PLACEHOLDER_PREFIX}${codeSegments.length - 1}${PLACEHOLDER_SUFFIX}`;
+  });
+
+  // The adapter re-parses and re-stringifies markdown before sending, which
+  // rewrites `- item` list bullets into `* item` — injecting unbalanced
+  // asterisks that Telegram's legacy Markdown parser then rejects. Replace
+  // list bullets with a plain Unicode bullet so the adapter treats the line
+  // as prose.
+  text = text.replace(/^(\s*)[-+]\s+/gm, '$1• ');
+
+  text = text.replace(/\*\*([^*\n]+?)\*\*/g, '*$1*');
+  text = text.replace(/__([^_\n]+?)__/g, '_$1_');
+
+  const starCount = (text.match(/\*/g) ?? []).length;
+  const underCount = (text.match(/_/g) ?? []).length;
+  if (starCount % 2 !== 0 || underCount % 2 !== 0) {
+    text = text.replace(/[*_]/g, '');
+  }
+
+  const openBrackets = (text.match(/\[/g) ?? []).length;
+  const closeBrackets = (text.match(/\]/g) ?? []).length;
+  if (openBrackets !== closeBrackets) {
+    text = text.replace(/[[\]]/g, '');
+  }
+
+  return text.replace(
+    new RegExp(`${PLACEHOLDER_PREFIX}(\\d+)${PLACEHOLDER_SUFFIX}`, 'g'),
+    (_, i) => codeSegments[Number(i)],
+  );
+}

--- a/src/channels/telegram-pairing.test.ts
+++ b/src/channels/telegram-pairing.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+vi.mock('../log.js', () => ({ log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } }));
+
+import {
+  createPairing,
+  tryConsume,
+  getStatus,
+  getPairing,
+  waitForPairing,
+  extractCode,
+  extractAddressedText,
+  _setStorePathForTest,
+  _resetForTest,
+} from './telegram-pairing.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-pair-'));
+  _setStorePathForTest(path.join(tmpDir, 'pairings.json'));
+});
+
+afterEach(() => {
+  _resetForTest();
+  _setStorePathForTest(null);
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('extractAddressedText', () => {
+  it('strips @botname prefix', () => {
+    expect(extractAddressedText('@nanobot 1234', 'nanobot')).toBe('1234');
+  });
+  it('is case-insensitive', () => {
+    expect(extractAddressedText('@NanoBot hello', 'nanobot')).toBe('hello');
+  });
+  it('returns null when not addressed', () => {
+    expect(extractAddressedText('hello 1234', 'nanobot')).toBeNull();
+  });
+  it('returns null when address is mid-text', () => {
+    expect(extractAddressedText('hi @nanobot 1234', 'nanobot')).toBeNull();
+  });
+});
+
+describe('extractCode', () => {
+  it('accepts a bare 4-digit code', () => {
+    expect(extractCode('0349', 'nanobot')).toBe('0349');
+  });
+  it('accepts 4-digit code after @botname', () => {
+    expect(extractCode('@nanobot 0042', 'nanobot')).toBe('0042');
+  });
+  it('rejects non-4-digit numbers', () => {
+    expect(extractCode('@nanobot 12345', 'nanobot')).toBeNull();
+    expect(extractCode('@nanobot 12', 'nanobot')).toBeNull();
+    expect(extractCode('12345', 'nanobot')).toBeNull();
+  });
+  it('rejects loose matches with surrounding text', () => {
+    expect(extractCode('my pin is 0349', 'nanobot')).toBeNull();
+    expect(extractCode('0349 thanks', 'nanobot')).toBeNull();
+  });
+});
+
+describe('createPairing', () => {
+  it('generates a 4-digit code', async () => {
+    const r = await createPairing('main');
+    expect(r.code).toMatch(/^\d{4}$/);
+    expect(r.status).toBe('pending');
+  });
+
+  it('does not collide with active codes', async () => {
+    const codes = new Set<string>();
+    for (let i = 0; i < 20; i++) {
+      const r = await createPairing('main');
+      expect(codes.has(r.code)).toBe(false);
+      codes.add(r.code);
+    }
+  });
+});
+
+describe('tryConsume', () => {
+  it('matches and marks consumed', async () => {
+    const r = await createPairing('main');
+    const consumed = await tryConsume({
+      text: `@nanobot ${r.code}`,
+      botUsername: 'nanobot',
+      platformId: 'telegram:123',
+      isGroup: false,
+      adminUserId: 'u1',
+    });
+    expect(consumed).not.toBeNull();
+    expect(consumed!.status).toBe('consumed');
+    expect(consumed!.consumed?.platformId).toBe('telegram:123');
+    expect(consumed!.consumed?.adminUserId).toBe('u1');
+    expect(getStatus(r.code)).toBe('consumed');
+  });
+
+  it('returns null on no match (silent drop)', async () => {
+    await createPairing('main');
+    const out = await tryConsume({
+      text: '@nanobot 9999',
+      botUsername: 'nanobot',
+      platformId: 'x',
+      isGroup: false,
+    });
+    expect(out).toBeNull();
+  });
+
+  it('matches a bare code without @botname addressing', async () => {
+    const r = await createPairing('main');
+    const out = await tryConsume({
+      text: r.code,
+      botUsername: 'nanobot',
+      platformId: 'x',
+      isGroup: false,
+    });
+    expect(out).not.toBeNull();
+    expect(out!.status).toBe('consumed');
+  });
+
+  it('cannot be consumed twice', async () => {
+    const r = await createPairing('main');
+    await tryConsume({ text: `@b ${r.code}`, botUsername: 'b', platformId: 'p', isGroup: false });
+    const second = await tryConsume({ text: `@b ${r.code}`, botUsername: 'b', platformId: 'p', isGroup: false });
+    expect(second).toBeNull();
+  });
+
+  it('cannot consume an invalidated pairing', async () => {
+    const r = await createPairing('main');
+    // Invalidate by sending a wrong code
+    await tryConsume({ text: '9999', botUsername: 'b', platformId: 'p', isGroup: false });
+    const out = await tryConsume({ text: `@b ${r.code}`, botUsername: 'b', platformId: 'p', isGroup: false });
+    expect(out).toBeNull();
+    expect(getStatus(r.code)).toBe('invalidated');
+  });
+});
+
+describe('getStatus', () => {
+  it('returns unknown for missing codes', () => {
+    expect(getStatus('0000')).toBe('unknown');
+  });
+});
+
+describe('waitForPairing', () => {
+  it('resolves when consumed', async () => {
+    const r = await createPairing('main');
+    const p = waitForPairing(r.code, { pollMs: 50 });
+    setTimeout(() => {
+      tryConsume({ text: `@b ${r.code}`, botUsername: 'b', platformId: 'tg:1', isGroup: true, name: 'Group' });
+    }, 100);
+    const consumed = await p;
+    expect(consumed.status).toBe('consumed');
+    expect(consumed.consumed?.name).toBe('Group');
+  });
+
+  it('rejects on invalidation', async () => {
+    const r = await createPairing('main');
+    const waiter = waitForPairing(r.code, { pollMs: 30 });
+    setTimeout(() => {
+      tryConsume({ text: '0000', botUsername: 'b', platformId: 'tg:1', isGroup: false });
+    }, 60);
+    await expect(waiter).rejects.toThrow(/invalidated/);
+  });
+});
+
+describe('replace-by-default', () => {
+  it('supersedes an existing pending pairing with the same intent', async () => {
+    const first = await createPairing('main');
+    const second = await createPairing('main');
+    expect(getStatus(first.code)).toBe('invalidated');
+    expect(getStatus(second.code)).toBe('pending');
+  });
+
+  it('does not supersede pairings with a different intent', async () => {
+    const a = await createPairing({ kind: 'wire-to', folder: 'work' });
+    const b = await createPairing({ kind: 'wire-to', folder: 'side' });
+    expect(getStatus(a.code)).toBe('pending');
+    expect(getStatus(b.code)).toBe('pending');
+  });
+
+  it('causes waitForPairing on the old code to reject as invalidated', async () => {
+    const first = await createPairing('main');
+    const waiter = waitForPairing(first.code, { pollMs: 30 });
+    await new Promise((r) => setTimeout(r, 50));
+    await createPairing('main');
+    await expect(waiter).rejects.toThrow(/invalidated/);
+  });
+});
+
+describe('attempt tracking', () => {
+  it('fires onAttempt for a wrong code, invalidates the pairing, and rejects the waiter', async () => {
+    const r = await createPairing('main');
+    const attempts: string[] = [];
+    const waiter = waitForPairing(r.code, {
+      pollMs: 30,
+      onAttempt: (a) => attempts.push(a.candidate),
+    });
+    setTimeout(() => {
+      tryConsume({ text: '9999', botUsername: 'b', platformId: 'tg:1', isGroup: false });
+    }, 60);
+    await expect(waiter).rejects.toThrow(/invalidated by wrong code \(9999\)/);
+    expect(attempts).toEqual(['9999']);
+    expect(getStatus(r.code)).toBe('invalidated');
+  });
+
+  it('a correct code consumes without firing onAttempt', async () => {
+    const r = await createPairing('main');
+    const attempts: string[] = [];
+    const waiter = waitForPairing(r.code, {
+      pollMs: 30,
+      onAttempt: (a) => attempts.push(a.candidate),
+    });
+    setTimeout(() => {
+      tryConsume({ text: r.code, botUsername: 'b', platformId: 'tg:1', isGroup: false });
+    }, 60);
+    const consumed = await waiter;
+    expect(consumed.status).toBe('consumed');
+    expect(attempts).toEqual([]);
+  });
+
+  it('ignores non-code messages and keeps the pairing pending', async () => {
+    const r = await createPairing('main');
+    await tryConsume({ text: 'hello there', botUsername: 'b', platformId: 'p', isGroup: false });
+    const after = getPairing(r.code);
+    expect(after?.status).toBe('pending');
+    expect(after?.attempts ?? []).toHaveLength(0);
+  });
+
+  it('a second code attempt after invalidation does not match', async () => {
+    const r = await createPairing('main');
+    await tryConsume({ text: '9999', botUsername: 'b', platformId: 'p', isGroup: false });
+    const retry = await tryConsume({ text: r.code, botUsername: 'b', platformId: 'p', isGroup: false });
+    expect(retry).toBeNull();
+  });
+});
+
+describe('intent passthrough', () => {
+  it('preserves wire-to and new-agent intents', async () => {
+    const a = await createPairing({ kind: 'wire-to', folder: 'work' });
+    const b = await createPairing({ kind: 'new-agent', folder: 'side' });
+    const ca = await tryConsume({ text: `@b ${a.code}`, botUsername: 'b', platformId: 'p1', isGroup: true });
+    const cb = await tryConsume({ text: `@b ${b.code}`, botUsername: 'b', platformId: 'p2', isGroup: true });
+    expect(ca!.intent).toEqual({ kind: 'wire-to', folder: 'work' });
+    expect(cb!.intent).toEqual({ kind: 'new-agent', folder: 'side' });
+  });
+});

--- a/src/channels/telegram-pairing.ts
+++ b/src/channels/telegram-pairing.ts
@@ -1,0 +1,339 @@
+/**
+ * Telegram pairing — proves the operator owns the chat they're registering.
+ *
+ * BotFather hands out tokens with no user binding, so anyone who guesses the
+ * bot's username can DM it. Pairing closes that gap: setup creates a one-time
+ * 4-digit code and the operator echoes it back from the chat they want to
+ * register. The message must be exactly the 4 digits (optionally prefixed by
+ * `@botname ` for groups with privacy ON) — arbitrary messages that happen to
+ * contain a 4-digit number do NOT match. The inbound interceptor in
+ * telegram.ts matches the code, records the chat, upserts the paired user,
+ * and (if no owner exists yet) promotes them to owner — all before the
+ * message ever reaches the router.
+ *
+ * Storage is a JSON file at data/telegram-pairings.json — single-process,
+ * read-modify-write under an in-process mutex.
+ */
+import fs from 'fs';
+import path from 'path';
+
+import { DATA_DIR } from '../config.js';
+import { log } from '../log.js';
+
+export type PairingIntent = 'main' | { kind: 'wire-to'; folder: string } | { kind: 'new-agent'; folder: string };
+export type PairingStatus = 'pending' | 'consumed' | 'invalidated' | 'unknown';
+
+export interface ConsumedDetails {
+  platformId: string;
+  isGroup: boolean;
+  name: string | null;
+  adminUserId: string | null;
+  consumedAt: string;
+}
+
+export interface PairingAttempt {
+  candidate: string;
+  platformId: string;
+  at: string;
+  matched: boolean;
+}
+
+export interface PairingRecord {
+  code: string;
+  intent: PairingIntent;
+  createdAt: string;
+  status: Exclude<PairingStatus, 'unknown'>;
+  consumed?: ConsumedDetails;
+  /** Recent pairing attempts observed while this record was pending. Capped. */
+  attempts?: PairingAttempt[];
+}
+
+const MAX_ATTEMPTS_PER_RECORD = 10;
+
+function intentEquals(a: PairingIntent, b: PairingIntent): boolean {
+  if (a === 'main' || b === 'main') return a === b;
+  return a.kind === b.kind && a.folder === b.folder;
+}
+
+interface Store {
+  pairings: PairingRecord[];
+}
+
+/** Pairing codes do not expire — they are consumed on match or invalidated by wrong guesses. */
+const FILE_NAME = 'telegram-pairings.json';
+
+let storePathOverride: string | null = null;
+export function _setStorePathForTest(p: string | null): void {
+  storePathOverride = p;
+}
+
+function storePath(): string {
+  return storePathOverride ?? path.join(DATA_DIR, FILE_NAME);
+}
+
+let mutex: Promise<unknown> = Promise.resolve();
+function withLock<T>(fn: () => Promise<T> | T): Promise<T> {
+  const next = mutex.then(() => fn());
+  mutex = next.catch(() => {});
+  return next;
+}
+
+function readStore(): Store {
+  try {
+    const raw = fs.readFileSync(storePath(), 'utf8');
+    const parsed = JSON.parse(raw) as Store;
+    if (!Array.isArray(parsed.pairings)) return { pairings: [] };
+    return parsed;
+  } catch {
+    return { pairings: [] };
+  }
+}
+
+function writeStore(store: Store): void {
+  const p = storePath();
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  const tmp = `${p}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(store, null, 2));
+  fs.renameSync(tmp, p);
+}
+
+/** Clean up old consumed/invalidated records (keep last 50). */
+function sweep(store: Store): boolean {
+  if (store.pairings.length <= 50) return false;
+  store.pairings = store.pairings.slice(-50);
+  return true;
+}
+
+function generateCode(active: Set<string>): string {
+  // 4-digit numeric, zero-padded. 10k space, fine for one-at-a-time intents.
+  for (let i = 0; i < 50; i++) {
+    const code = Math.floor(Math.random() * 10000)
+      .toString()
+      .padStart(4, '0');
+    if (!active.has(code)) return code;
+  }
+  throw new Error('Could not allocate a free pairing code (too many active).');
+}
+
+export async function createPairing(intent: PairingIntent): Promise<PairingRecord> {
+  return withLock(() => {
+    const store = readStore();
+    sweep(store);
+    // Replace-by-default: a new pairing for an intent supersedes any existing
+    // pending pairing for the same intent. Old waitForPairing calls observe
+    // `invalidated` and exit on their own.
+    for (const r of store.pairings) {
+      if (r.status === 'pending' && intentEquals(r.intent, intent)) {
+        r.status = 'invalidated';
+        log.info('Pairing superseded by new request', { code: r.code, intent });
+      }
+    }
+    const active = new Set(store.pairings.filter((r) => r.status === 'pending').map((r) => r.code));
+    const record: PairingRecord = {
+      code: generateCode(active),
+      intent,
+      createdAt: new Date().toISOString(),
+      status: 'pending',
+    };
+    store.pairings.push(record);
+    writeStore(store);
+    log.info('Pairing created', { code: record.code, intent });
+    return record;
+  });
+}
+
+export interface ConsumeInput {
+  text: string;
+  botUsername: string;
+  platformId: string;
+  isGroup: boolean;
+  name?: string | null;
+  adminUserId?: string | null;
+}
+
+/** Strip leading @botname and return the trimmed remainder, or null if not addressed. */
+export function extractAddressedText(text: string, botUsername: string): string | null {
+  const trimmed = text.trim();
+  const re = new RegExp(`^@${botUsername.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\$&')}\\b`, 'i');
+  const m = trimmed.match(re);
+  if (!m) return null;
+  return trimmed.slice(m[0].length).trim();
+}
+
+/**
+ * Extract a pairing code from an inbound message. The message must be exactly
+ * 4 digits (optionally prefixed by `@botname `) — loose matches like
+ * "my pin is 1234" are rejected to avoid false positives from chatter.
+ */
+export function extractCode(text: string, botUsername: string): string | null {
+  const addressed = extractAddressedText(text, botUsername);
+  const candidate = (addressed !== null ? addressed : text).trim();
+  const m = candidate.match(/^(\d{4})$/);
+  return m ? m[1] : null;
+}
+
+/**
+ * Try to match an inbound message against a pending pairing. On match,
+ * marks the pairing consumed atomically and returns the record. Returns
+ * null on no match or expiry (silent drop).
+ */
+export async function tryConsume(input: ConsumeInput): Promise<PairingRecord | null> {
+  const code = extractCode(input.text, input.botUsername);
+  if (!code) return null;
+  return withLock(() => {
+    const store = readStore();
+    const now = Date.now();
+    sweep(store);
+    const record = store.pairings.find((r) => r.code === code && r.status === 'pending');
+    if (!record) {
+      // Miss: record the attempt on every currently-pending record so each
+      // waitForPairing caller can surface it as user feedback.
+      const attempt: PairingAttempt = {
+        candidate: code,
+        platformId: input.platformId,
+        at: new Date(now).toISOString(),
+        matched: false,
+      };
+      let recorded = false;
+      for (const r of store.pairings) {
+        if (r.status !== 'pending') continue;
+        r.attempts = [...(r.attempts ?? []), attempt].slice(-MAX_ATTEMPTS_PER_RECORD);
+        // One attempt per code. A wrong guess invalidates the pairing
+        // immediately — pair-telegram observes the `invalidated` signal and
+        // auto-issues a fresh code (up to a retry cap).
+        r.status = 'invalidated';
+        recorded = true;
+      }
+      writeStore(store);
+      if (recorded) {
+        log.info('Pairing invalidated by wrong attempt', { candidate: code, platformId: input.platformId });
+      }
+      return null;
+    }
+    record.status = 'consumed';
+    record.consumed = {
+      platformId: input.platformId,
+      isGroup: input.isGroup,
+      name: input.name ?? null,
+      adminUserId: input.adminUserId ?? null,
+      consumedAt: new Date(now).toISOString(),
+    };
+    record.attempts = [
+      ...(record.attempts ?? []),
+      { candidate: code, platformId: input.platformId, at: new Date(now).toISOString(), matched: true },
+    ].slice(-MAX_ATTEMPTS_PER_RECORD);
+    writeStore(store);
+    log.info('Pairing consumed', { code, platformId: input.platformId, intent: record.intent });
+    return record;
+  });
+}
+
+export function getStatus(code: string): PairingStatus {
+  const store = readStore();
+  sweep(store);
+  const r = store.pairings.find((p) => p.code === code);
+  if (!r) return 'unknown';
+  return r.status;
+}
+
+export function getPairing(code: string): PairingRecord | null {
+  const store = readStore();
+  sweep(store);
+  return store.pairings.find((p) => p.code === code) ?? null;
+}
+
+export interface WaitForPairingOptions {
+  /** Polling interval as a fallback when fs.watch misses an event. */
+  pollMs?: number;
+  /** Fires once per new attempt recorded against this pairing (misses only). */
+  onAttempt?: (attempt: PairingAttempt) => void;
+}
+
+/**
+ * Resolve when the pairing is consumed; reject when it is invalidated
+ * (wrong code guess). Waits indefinitely — codes do not expire.
+ * Uses fs.watch as the primary signal with a slow poll fallback.
+ */
+export async function waitForPairing(code: string, opts: WaitForPairingOptions = {}): Promise<PairingRecord> {
+  const pollMs = opts.pollMs ?? 1000;
+  const initial = getPairing(code);
+  if (!initial) throw new Error(`Unknown pairing code: ${code}`);
+
+  return new Promise<PairingRecord>((resolve, reject) => {
+    let watcher: fs.FSWatcher | null = null;
+    let interval: NodeJS.Timeout | null = null;
+    let settled = false;
+
+    const cleanup = () => {
+      settled = true;
+      if (watcher)
+        try {
+          watcher.close();
+        } catch {
+          /* ignore */
+        }
+      if (interval) clearInterval(interval);
+    };
+
+    let seenAttempts = 0;
+    const check = () => {
+      if (settled) return;
+      const r = getPairing(code);
+      if (!r) {
+        cleanup();
+        reject(new Error(`Pairing ${code} disappeared`));
+        return;
+      }
+      // Surface any new miss attempts since the last tick. Only fire for
+      // misses — matches are signaled by `status === 'consumed'` below.
+      if (opts.onAttempt && r.attempts) {
+        for (let i = seenAttempts; i < r.attempts.length; i++) {
+          const a = r.attempts[i];
+          if (!a.matched) {
+            try {
+              opts.onAttempt(a);
+            } catch {
+              /* ignore */
+            }
+          }
+        }
+        seenAttempts = r.attempts.length;
+      }
+      if (r.status === 'consumed') {
+        cleanup();
+        resolve(r);
+        return;
+      }
+      if (r.status === 'invalidated') {
+        cleanup();
+        const lastMiss = r.attempts
+          ?.slice()
+          .reverse()
+          .find((a) => !a.matched);
+        reject(new Error(`Pairing ${code} invalidated by wrong code${lastMiss ? ` (${lastMiss.candidate})` : ''}`));
+        return;
+      }
+    };
+
+    try {
+      const dir = path.dirname(storePath());
+      fs.mkdirSync(dir, { recursive: true });
+      watcher = fs.watch(dir, (_event, fname) => {
+        if (!fname || fname.toString().startsWith(path.basename(storePath()))) check();
+      });
+    } catch {
+      // fs.watch unsupported — poll-only is fine
+    }
+    interval = setInterval(check, pollMs);
+    check();
+  });
+}
+
+/** Test helper — wipe the store. */
+export function _resetForTest(): void {
+  try {
+    fs.unlinkSync(storePath());
+  } catch {
+    // ignore
+  }
+}

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -1,0 +1,229 @@
+/**
+ * Telegram channel adapter (v2) — uses Chat SDK bridge, with a pairing
+ * interceptor wrapped around onInbound to verify chat ownership before
+ * registration. See telegram-pairing.ts for the why.
+ */
+import { createTelegramAdapter } from '@chat-adapter/telegram';
+
+import { readEnvFile } from '../env.js';
+import { log } from '../log.js';
+import { createMessagingGroup, getMessagingGroupByPlatform, updateMessagingGroup } from '../db/messaging-groups.js';
+import { grantRole, hasAnyOwner } from '../db/user-roles.js';
+import { upsertUser } from '../db/users.js';
+import { createChatSdkBridge, type ReplyContext } from './chat-sdk-bridge.js';
+import { sanitizeTelegramLegacyMarkdown } from './telegram-markdown-sanitize.js';
+import { registerChannelAdapter } from './channel-registry.js';
+import type { ChannelAdapter, ChannelSetup, InboundMessage } from './adapter.js';
+import { tryConsume } from './telegram-pairing.js';
+
+/**
+ * Retry a one-shot operation that can fail on transient network errors at
+ * cold-start (DNS hiccups, brief upstream outages). Exponential backoff capped
+ * at 5 attempts — if the network is truly down we surface it instead of
+ * hanging the service indefinitely.
+ */
+async function withRetry<T>(fn: () => Promise<T>, label: string, maxAttempts = 5): Promise<T> {
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      if (attempt === maxAttempts) break;
+      const delay = Math.min(16000, 1000 * 2 ** (attempt - 1));
+      log.warn('Telegram setup failed, retrying', { label, attempt, delayMs: delay, err });
+      await new Promise((r) => setTimeout(r, delay));
+    }
+  }
+  throw lastErr;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function extractReplyContext(raw: Record<string, any>): ReplyContext | null {
+  if (!raw.reply_to_message) return null;
+  const reply = raw.reply_to_message;
+  return {
+    text: reply.text || reply.caption || '',
+    sender: reply.from?.first_name || reply.from?.username || 'Unknown',
+  };
+}
+
+/** Look up the bot username via Telegram getMe. Cached after first call. */
+async function fetchBotUsername(token: string): Promise<string | null> {
+  try {
+    const res = await fetch(`https://api.telegram.org/bot${token}/getMe`);
+    const json = (await res.json()) as { ok: boolean; result?: { username?: string } };
+    return json.ok ? (json.result?.username ?? null) : null;
+  } catch (err) {
+    log.warn('Telegram getMe failed', { err });
+    return null;
+  }
+}
+
+function isGroupPlatformId(platformId: string): boolean {
+  // platformId is "telegram:<chatId>". Negative chat IDs are groups/channels.
+  const id = platformId.split(':').pop() ?? '';
+  return id.startsWith('-');
+}
+
+interface InboundFields {
+  text: string;
+  authorUserId: string | null;
+}
+
+function readInboundFields(message: InboundMessage): InboundFields {
+  if (message.kind !== 'chat-sdk' || !message.content || typeof message.content !== 'object') {
+    return { text: '', authorUserId: null };
+  }
+  const c = message.content as { text?: string; author?: { userId?: string } };
+  return { text: c.text ?? '', authorUserId: c.author?.userId ?? null };
+}
+
+/**
+ * Build an onInbound interceptor that consumes pairing codes before they
+ * reach the router. On match: records the chat + its paired user, promotes
+ * the user to owner if the instance has no owner yet, and short-circuits.
+ * On miss: forwards to the host.
+ */
+/**
+ * Send a one-shot confirmation back to the paired chat. Best-effort — failures
+ * are logged but never propagated, so a Telegram outage can't undo a successful
+ * pairing or trigger the interceptor's fail-open path.
+ */
+async function sendPairingConfirmation(token: string, platformId: string): Promise<void> {
+  const chatId = platformId.split(':').slice(1).join(':');
+  if (!chatId) return;
+  try {
+    const res = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        chat_id: chatId,
+        text: "Pairing success! I'm spinning up the agent now, you'll get a message from them shortly.",
+      }),
+    });
+    if (!res.ok) {
+      log.warn('Telegram pairing confirmation non-OK', { status: res.status });
+    }
+  } catch (err) {
+    log.warn('Telegram pairing confirmation failed', { err });
+  }
+}
+
+function createPairingInterceptor(
+  botUsernamePromise: Promise<string | null>,
+  hostOnInbound: ChannelSetup['onInbound'],
+  token: string,
+): ChannelSetup['onInbound'] {
+  return async (platformId, threadId, message) => {
+    try {
+      const botUsername = await botUsernamePromise;
+      if (!botUsername) {
+        hostOnInbound(platformId, threadId, message);
+        return;
+      }
+      const { text, authorUserId } = readInboundFields(message);
+      if (!text) {
+        hostOnInbound(platformId, threadId, message);
+        return;
+      }
+      const consumed = await tryConsume({
+        text,
+        botUsername,
+        platformId,
+        isGroup: isGroupPlatformId(platformId),
+        adminUserId: authorUserId,
+      });
+      if (!consumed) {
+        hostOnInbound(platformId, threadId, message);
+        return;
+      }
+      // Pairing matched — record the chat and short-circuit so the
+      // code-bearing message never reaches an agent. Privilege is now a
+      // property of the paired user, not the chat: upsert the user, and if
+      // this instance has no owner yet, promote them to owner.
+      const existing = getMessagingGroupByPlatform('telegram', platformId);
+      if (existing) {
+        updateMessagingGroup(existing.id, {
+          is_group: consumed.consumed!.isGroup ? 1 : 0,
+        });
+      } else {
+        createMessagingGroup({
+          id: `mg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+          channel_type: 'telegram',
+          platform_id: platformId,
+          name: consumed.consumed!.name,
+          is_group: consumed.consumed!.isGroup ? 1 : 0,
+          unknown_sender_policy: 'strict',
+          created_at: new Date().toISOString(),
+        });
+      }
+
+      const pairedUserId = `telegram:${consumed.consumed!.adminUserId}`;
+      upsertUser({
+        id: pairedUserId,
+        kind: 'telegram',
+        display_name: null,
+        created_at: new Date().toISOString(),
+      });
+
+      let promotedToOwner = false;
+      if (!hasAnyOwner()) {
+        grantRole({
+          user_id: pairedUserId,
+          role: 'owner',
+          agent_group_id: null,
+          granted_by: null,
+          granted_at: new Date().toISOString(),
+        });
+        promotedToOwner = true;
+      }
+
+      log.info('Telegram pairing accepted — chat registered', {
+        platformId,
+        pairedUser: pairedUserId,
+        promotedToOwner,
+        intent: consumed.intent,
+      });
+
+      await sendPairingConfirmation(token, platformId);
+    } catch (err) {
+      log.error('Telegram pairing interceptor error', { err });
+      // Fail open: pass through so a pairing bug doesn't break normal traffic.
+      hostOnInbound(platformId, threadId, message);
+    }
+  };
+}
+
+registerChannelAdapter('telegram', {
+  factory: () => {
+    const env = readEnvFile(['TELEGRAM_BOT_TOKEN']);
+    if (!env.TELEGRAM_BOT_TOKEN) return null;
+    const token = env.TELEGRAM_BOT_TOKEN;
+    const telegramAdapter = createTelegramAdapter({
+      botToken: token,
+      mode: 'polling',
+    });
+    const bridge = createChatSdkBridge({
+      adapter: telegramAdapter,
+      concurrency: 'concurrent',
+      extractReplyContext,
+      supportsThreads: false,
+      transformOutboundText: sanitizeTelegramLegacyMarkdown,
+    });
+
+    const botUsernamePromise = fetchBotUsername(token);
+
+    const wrapped: ChannelAdapter = {
+      ...bridge,
+      async setup(hostConfig: ChannelSetup) {
+        const intercepted: ChannelSetup = {
+          ...hostConfig,
+          onInbound: createPairingInterceptor(botUsernamePromise, hostConfig.onInbound, token),
+        };
+        return withRetry(() => bridge.setup(intercepted), 'bridge.setup');
+      },
+    };
+    return wrapped;
+  },
+});

--- a/src/dashboard-pusher.ts
+++ b/src/dashboard-pusher.ts
@@ -1,0 +1,581 @@
+/**
+ * Dashboard pusher — collects NanoClaw state and POSTs a JSON
+ * snapshot to the dashboard's /api/ingest endpoint every interval.
+ */
+import fs from 'fs';
+import path from 'path';
+import http from 'http';
+import Database from 'better-sqlite3';
+
+import { getAllAgentGroups, getAgentGroup } from './db/agent-groups.js';
+import { getSessionsByAgentGroup } from './db/sessions.js';
+import { getAllMessagingGroups, getMessagingGroupAgents } from './db/messaging-groups.js';
+import { getDestinations } from './db/agent-destinations.js';
+import { getMembers } from './db/agent-group-members.js';
+import { getAllUsers, getUser } from './db/users.js';
+import { getUserRoles, getAdminsOfAgentGroup } from './db/user-roles.js';
+import { getUserDmsForUser } from './db/user-dms.js';
+import { getActiveAdapters, getRegisteredChannelNames } from './channels/channel-registry.js';
+import { DATA_DIR, ASSISTANT_NAME } from './config.js';
+import { getDb } from './db/connection.js';
+import { log } from './log.js';
+
+interface PusherConfig {
+  port: number;
+  secret: string;
+  intervalMs?: number;
+}
+
+let timer: ReturnType<typeof setInterval> | null = null;
+let logTimer: ReturnType<typeof setInterval> | null = null;
+let logOffset = 0;
+
+export function startDashboardPusher(config: PusherConfig): void {
+  const interval = config.intervalMs || 60000;
+
+  // Push immediately on start, then on interval
+  push(config).catch((err) => log.error('Dashboard push failed', { err }));
+  timer = setInterval(() => {
+    push(config).catch((err) => log.error('Dashboard push failed', { err }));
+  }, interval);
+
+  // Start log file tailing
+  startLogTail(config);
+
+  log.info('Dashboard pusher started', { intervalMs: interval });
+}
+
+export function stopDashboardPusher(): void {
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+  if (logTimer) {
+    clearInterval(logTimer);
+    logTimer = null;
+  }
+}
+
+/** Fire-and-forget POST to the dashboard. */
+function postJson(config: PusherConfig, urlPath: string, data: unknown): void {
+  const body = JSON.stringify(data);
+  const req = http.request({
+    hostname: '127.0.0.1',
+    port: config.port,
+    path: urlPath,
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Length': Buffer.byteLength(body),
+      Authorization: `Bearer ${config.secret}`,
+    },
+  });
+  req.on('error', () => {});
+  req.write(body);
+  req.end();
+}
+
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
+
+function startLogTail(config: PusherConfig): void {
+  const logFile = path.resolve(process.cwd(), 'logs', 'nanoclaw.log');
+  if (!fs.existsSync(logFile)) return;
+
+  // Send last 200 lines as backfill
+  try {
+    const allLines = fs
+      .readFileSync(logFile, 'utf-8')
+      .split('\n')
+      .filter((l) => l.trim());
+    logOffset = fs.statSync(logFile).size;
+    const tail = allLines.slice(-200).map((l) => l.replace(ANSI_RE, ''));
+    if (tail.length > 0) postJson(config, '/api/logs/push', { lines: tail });
+  } catch {
+    return;
+  }
+
+  // Poll every 2s for new lines
+  logTimer = setInterval(() => {
+    try {
+      const stat = fs.statSync(logFile);
+      if (stat.size <= logOffset) {
+        logOffset = stat.size;
+        return;
+      }
+      const buf = Buffer.alloc(stat.size - logOffset);
+      const fd = fs.openSync(logFile, 'r');
+      fs.readSync(fd, buf, 0, buf.length, logOffset);
+      fs.closeSync(fd);
+      logOffset = stat.size;
+      const lines = buf
+        .toString()
+        .split('\n')
+        .filter((l) => l.trim())
+        .map((l) => l.replace(ANSI_RE, ''));
+      if (lines.length > 0) postJson(config, '/api/logs/push', { lines });
+    } catch {
+      /* ignore */
+    }
+  }, 2000);
+}
+
+async function push(config: PusherConfig): Promise<void> {
+  const snapshot = collectSnapshot();
+  postJson(config, '/api/ingest', snapshot);
+  log.debug('Dashboard snapshot pushed');
+}
+
+function collectSnapshot(): Record<string, unknown> {
+  return {
+    timestamp: new Date().toISOString(),
+    assistant_name: ASSISTANT_NAME,
+    uptime: Math.floor(process.uptime()),
+    agent_groups: collectAgentGroups(),
+    sessions: collectSessions(),
+    channels: collectChannels(),
+    users: collectUsers(),
+    tokens: collectTokens(),
+    context_windows: collectContextWindows(),
+    activity: collectActivity(),
+    messages: collectMessages(),
+  };
+}
+
+function collectAgentGroups() {
+  return getAllAgentGroups().map((g) => {
+    const sessions = getSessionsByAgentGroup(g.id);
+    const running = sessions.filter((s) => s.container_status === 'running' || s.container_status === 'idle');
+    const destinations = getDestinations(g.id);
+    const members = getMembers(g.id).map((m) => {
+      const user = getUser(m.user_id);
+      return { ...m, display_name: user?.display_name ?? null };
+    });
+    const admins = getAdminsOfAgentGroup(g.id).map((a) => {
+      const user = getUser(a.user_id);
+      return { ...a, display_name: user?.display_name ?? null };
+    });
+
+    // Wirings
+    const db = getDb();
+    const wirings = db
+      .prepare(
+        `SELECT mga.*, mg.channel_type, mg.platform_id, mg.name as mg_name, mg.is_group, mg.unknown_sender_policy
+         FROM messaging_group_agents mga
+         JOIN messaging_groups mg ON mg.id = mga.messaging_group_id
+         WHERE mga.agent_group_id = ?`,
+      )
+      .all(g.id) as Array<Record<string, unknown>>;
+
+    return {
+      id: g.id,
+      name: g.name,
+      folder: g.folder,
+      agent_provider: g.agent_provider,
+      container_config: (g as unknown as Record<string, string>).container_config
+        ? JSON.parse((g as unknown as Record<string, string>).container_config)
+        : null,
+      sessionCount: sessions.length,
+      runningSessions: running.length,
+      wirings,
+      destinations,
+      members,
+      admins,
+      created_at: g.created_at,
+    };
+  });
+}
+
+function collectSessions() {
+  const db = getDb();
+  return db
+    .prepare(
+      `SELECT s.*, ag.name as agent_group_name, ag.folder as agent_group_folder,
+              mg.channel_type, mg.platform_id, mg.name as messaging_group_name
+       FROM sessions s
+       LEFT JOIN agent_groups ag ON ag.id = s.agent_group_id
+       LEFT JOIN messaging_groups mg ON mg.id = s.messaging_group_id
+       ORDER BY s.last_active DESC NULLS LAST`,
+    )
+    .all() as Array<Record<string, unknown>>;
+}
+
+function collectChannels() {
+  const messagingGroups = getAllMessagingGroups();
+  const liveAdapters = getActiveAdapters().map((a) => a.channelType);
+  const registeredChannels = getRegisteredChannelNames();
+
+  const byType: Record<string, { channelType: string; isLive: boolean; isRegistered: boolean; groups: unknown[] }> = {};
+
+  for (const mg of messagingGroups) {
+    if (!byType[mg.channel_type]) {
+      byType[mg.channel_type] = {
+        channelType: mg.channel_type,
+        isLive: liveAdapters.includes(mg.channel_type),
+        isRegistered: registeredChannels.includes(mg.channel_type),
+        groups: [],
+      };
+    }
+
+    const agents = getMessagingGroupAgents(mg.id).map((a) => {
+      const group = getAgentGroup(a.agent_group_id);
+      return { agent_group_id: a.agent_group_id, agent_group_name: group?.name ?? null, priority: a.priority };
+    });
+
+    byType[mg.channel_type].groups.push({
+      messagingGroup: {
+        id: mg.id,
+        platform_id: mg.platform_id,
+        name: mg.name,
+        is_group: mg.is_group,
+        unknown_sender_policy: (mg as unknown as Record<string, unknown>).unknown_sender_policy ?? 'strict',
+      },
+      agents,
+    });
+  }
+
+  // Include live adapters with no messaging groups
+  for (const ct of liveAdapters) {
+    if (!byType[ct]) {
+      byType[ct] = { channelType: ct, isLive: true, isRegistered: true, groups: [] };
+    }
+  }
+
+  return Object.values(byType).sort((a, b) => a.channelType.localeCompare(b.channelType));
+}
+
+function collectUsers() {
+  return getAllUsers().map((u) => {
+    const roles = getUserRoles(u.id);
+    const dms = getUserDmsForUser(u.id);
+
+    const db = getDb();
+    const memberships = db
+      .prepare(
+        `SELECT agm.agent_group_id, ag.name as agent_group_name
+         FROM agent_group_members agm
+         JOIN agent_groups ag ON ag.id = agm.agent_group_id
+         WHERE agm.user_id = ?`,
+      )
+      .all(u.id) as Array<Record<string, unknown>>;
+
+    let privilege = 'none';
+    if (roles.some((r) => r.role === 'owner')) privilege = 'owner';
+    else if (roles.some((r) => r.role === 'admin' && !r.agent_group_id)) privilege = 'global_admin';
+    else if (roles.some((r) => r.role === 'admin')) privilege = 'admin';
+    else if (memberships.length > 0) privilege = 'member';
+
+    return {
+      id: u.id,
+      kind: u.kind,
+      display_name: u.display_name,
+      privilege,
+      roles,
+      memberships,
+      dmChannels: dms.map((d) => ({ channel_type: d.channel_type })),
+      created_at: u.created_at,
+    };
+  });
+}
+
+function collectTokens() {
+  const sessionsDir = path.join(DATA_DIR, 'v2-sessions');
+  const allEntries: Array<{
+    model: string;
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheCreationTokens: number;
+    agentGroupId: string;
+  }> = [];
+  const agentGroups = getAllAgentGroups();
+  const nameMap = new Map(agentGroups.map((g) => [g.id, g.name]));
+
+  if (fs.existsSync(sessionsDir)) {
+    for (const agDir of fs.readdirSync(sessionsDir).filter((d) => d.startsWith('ag-'))) {
+      const entries = scanJsonlTokens(path.join(sessionsDir, agDir));
+      allEntries.push(...entries.map((e) => ({ ...e, agentGroupId: agDir })));
+    }
+  }
+
+  const byModel: Record<
+    string,
+    {
+      requests: number;
+      inputTokens: number;
+      outputTokens: number;
+      cacheReadTokens: number;
+      cacheCreationTokens: number;
+    }
+  > = {};
+  const byGroup: Record<
+    string,
+    {
+      requests: number;
+      inputTokens: number;
+      outputTokens: number;
+      cacheReadTokens: number;
+      cacheCreationTokens: number;
+      name: string;
+    }
+  > = {};
+  const totals = { requests: 0, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 };
+
+  for (const e of allEntries) {
+    if (!byModel[e.model])
+      byModel[e.model] = { requests: 0, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 };
+    byModel[e.model].requests++;
+    byModel[e.model].inputTokens += e.inputTokens;
+    byModel[e.model].outputTokens += e.outputTokens;
+    byModel[e.model].cacheReadTokens += e.cacheReadTokens;
+    byModel[e.model].cacheCreationTokens += e.cacheCreationTokens;
+
+    if (!byGroup[e.agentGroupId])
+      byGroup[e.agentGroupId] = {
+        requests: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        name: nameMap.get(e.agentGroupId) || e.agentGroupId,
+      };
+    byGroup[e.agentGroupId].requests++;
+    byGroup[e.agentGroupId].inputTokens += e.inputTokens;
+    byGroup[e.agentGroupId].outputTokens += e.outputTokens;
+    byGroup[e.agentGroupId].cacheReadTokens += e.cacheReadTokens;
+    byGroup[e.agentGroupId].cacheCreationTokens += e.cacheCreationTokens;
+
+    totals.requests++;
+    totals.inputTokens += e.inputTokens;
+    totals.outputTokens += e.outputTokens;
+    totals.cacheReadTokens += e.cacheReadTokens;
+    totals.cacheCreationTokens += e.cacheCreationTokens;
+  }
+
+  return { totals, byModel, byGroup };
+}
+
+function scanJsonlTokens(agentDir: string) {
+  const claudeDir = path.join(agentDir, '.claude-shared', 'projects');
+  if (!fs.existsSync(claudeDir)) return [];
+
+  const entries: Array<{
+    model: string;
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheCreationTokens: number;
+  }> = [];
+
+  const walk = (dir: string): void => {
+    try {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) walk(full);
+        else if (entry.name.endsWith('.jsonl')) {
+          try {
+            for (const line of fs.readFileSync(full, 'utf-8').split('\n')) {
+              if (!line.trim()) continue;
+              try {
+                const r = JSON.parse(line);
+                if (r.type === 'assistant' && r.message?.usage) {
+                  const u = r.message.usage;
+                  entries.push({
+                    model: r.message.model || 'unknown',
+                    inputTokens: u.input_tokens || 0,
+                    outputTokens: u.output_tokens || 0,
+                    cacheReadTokens: u.cache_read_input_tokens || 0,
+                    cacheCreationTokens: u.cache_creation_input_tokens || 0,
+                  });
+                }
+              } catch {
+                /* skip line */
+              }
+            }
+          } catch {
+            /* skip file */
+          }
+        }
+      }
+    } catch {
+      /* skip dir */
+    }
+  };
+  walk(claudeDir);
+  return entries;
+}
+
+function collectContextWindows() {
+  const sessionsDir = path.join(DATA_DIR, 'v2-sessions');
+  if (!fs.existsSync(sessionsDir)) return [];
+
+  const results: unknown[] = [];
+  const agentGroups = getAllAgentGroups();
+  const nameMap = new Map(agentGroups.map((g) => [g.id, g.name]));
+
+  for (const agDir of fs.readdirSync(sessionsDir).filter((d) => d.startsWith('ag-'))) {
+    const claudeDir = path.join(sessionsDir, agDir, '.claude-shared', 'projects');
+    if (!fs.existsSync(claudeDir)) continue;
+
+    // Find most recent JSONL
+    const jsonlFiles: string[] = [];
+    const walk = (dir: string): void => {
+      try {
+        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+          const full = path.join(dir, entry.name);
+          if (entry.isDirectory()) walk(full);
+          else if (entry.name.endsWith('.jsonl')) jsonlFiles.push(full);
+        }
+      } catch {
+        /* skip */
+      }
+    };
+    walk(claudeDir);
+    if (jsonlFiles.length === 0) continue;
+
+    jsonlFiles.sort((a, b) => {
+      try {
+        return fs.statSync(b).mtimeMs - fs.statSync(a).mtimeMs;
+      } catch {
+        return 0;
+      }
+    });
+
+    // Read last assistant turn from newest file
+    const content = fs.readFileSync(jsonlFiles[0], 'utf-8');
+    const lines = content.split('\n');
+    for (let i = lines.length - 1; i >= 0; i--) {
+      if (!lines[i].trim()) continue;
+      try {
+        const r = JSON.parse(lines[i]);
+        if (r.type === 'assistant' && r.message?.usage) {
+          const u = r.message.usage;
+          const model = r.message.model || 'unknown';
+          const ctx = (u.input_tokens || 0) + (u.cache_read_input_tokens || 0) + (u.cache_creation_input_tokens || 0);
+          const max = 200000;
+          results.push({
+            agentGroupId: agDir,
+            agentGroupName: nameMap.get(agDir),
+            sessionId: path.basename(jsonlFiles[0], '.jsonl'),
+            model,
+            contextTokens: ctx,
+            outputTokens: u.output_tokens || 0,
+            cacheReadTokens: u.cache_read_input_tokens || 0,
+            cacheCreationTokens: u.cache_creation_input_tokens || 0,
+            maxContext: max,
+            usagePercent: max > 0 ? Math.round((ctx / max) * 100) : 0,
+            timestamp: r.timestamp || '',
+          });
+          break;
+        }
+      } catch {
+        /* skip */
+      }
+    }
+  }
+
+  return results;
+}
+
+function collectActivity() {
+  const now = Date.now();
+  const buckets: Record<string, { inbound: number; outbound: number }> = {};
+
+  for (let i = 0; i < 24; i++) {
+    const key = new Date(now - i * 3600000).toISOString().slice(0, 13);
+    buckets[key] = { inbound: 0, outbound: 0 };
+  }
+
+  const sessionsDir = path.join(DATA_DIR, 'v2-sessions');
+  if (!fs.existsSync(sessionsDir)) return toBucketArray(buckets);
+
+  const cutoff = new Date(now - 86400000).toISOString();
+
+  try {
+    for (const agDir of fs.readdirSync(sessionsDir).filter((d) => d.startsWith('ag-'))) {
+      const agPath = path.join(sessionsDir, agDir);
+      for (const sessDir of fs.readdirSync(agPath).filter((d) => d.startsWith('sess-'))) {
+        for (const [dbName, direction] of [
+          ['outbound.db', 'outbound'],
+          ['inbound.db', 'inbound'],
+        ] as const) {
+          const dbPath = path.join(agPath, sessDir, dbName);
+          if (!fs.existsSync(dbPath)) continue;
+          try {
+            const db = new Database(dbPath, { readonly: true });
+            const table = direction === 'outbound' ? 'messages_out' : 'messages_in';
+            const rows = db.prepare(`SELECT timestamp FROM ${table} WHERE timestamp > ?`).all(cutoff) as {
+              timestamp: string;
+            }[];
+            for (const row of rows) {
+              const key = row.timestamp.slice(0, 13);
+              if (buckets[key]) buckets[key][direction]++;
+            }
+            db.close();
+          } catch {
+            /* skip */
+          }
+        }
+      }
+    }
+  } catch {
+    /* skip */
+  }
+
+  return toBucketArray(buckets);
+}
+
+function toBucketArray(buckets: Record<string, { inbound: number; outbound: number }>) {
+  return Object.entries(buckets)
+    .map(([hour, counts]) => ({ hour, ...counts }))
+    .sort((a, b) => a.hour.localeCompare(b.hour));
+}
+
+function collectMessages() {
+  const sessionsDir = path.join(DATA_DIR, 'v2-sessions');
+  if (!fs.existsSync(sessionsDir)) return [];
+
+  const results: Array<{ agentGroupId: string; sessionId: string; inbound: unknown[]; outbound: unknown[] }> = [];
+  const limit = 50;
+
+  try {
+    for (const agDir of fs.readdirSync(sessionsDir).filter((d) => d.startsWith('ag-'))) {
+      const agPath = path.join(sessionsDir, agDir);
+      for (const sessDir of fs.readdirSync(agPath).filter((d) => d.startsWith('sess-'))) {
+        const inbound: unknown[] = [];
+        const outbound: unknown[] = [];
+
+        const inDbPath = path.join(agPath, sessDir, 'inbound.db');
+        if (fs.existsSync(inDbPath)) {
+          try {
+            const db = new Database(inDbPath, { readonly: true });
+            const rows = db.prepare('SELECT * FROM messages_in ORDER BY seq DESC LIMIT ?').all(limit);
+            inbound.push(...(rows as unknown[]).reverse());
+            db.close();
+          } catch {
+            /* skip */
+          }
+        }
+
+        const outDbPath = path.join(agPath, sessDir, 'outbound.db');
+        if (fs.existsSync(outDbPath)) {
+          try {
+            const db = new Database(outDbPath, { readonly: true });
+            const rows = db.prepare('SELECT * FROM messages_out ORDER BY seq DESC LIMIT ?').all(limit);
+            outbound.push(...(rows as unknown[]).reverse());
+            db.close();
+          } catch {
+            /* skip */
+          }
+        }
+
+        if (inbound.length > 0 || outbound.length > 0) {
+          results.push({ agentGroupId: agDir, sessionId: sessDir, inbound, outbound });
+        }
+      }
+    }
+  } catch {
+    /* skip */
+  }
+
+  return results;
+}

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -58,3 +58,11 @@ export {
   deletePendingApproval,
   getPendingApprovalsByAction,
 } from './sessions.js';
+export {
+  createDestination,
+  getDestinations,
+  getDestinationByName,
+  getDestinationByTarget,
+  hasDestination,
+  deleteDestination,
+} from './agent-destinations.js';

--- a/src/db/session-db.ts
+++ b/src/db/session-db.ts
@@ -114,7 +114,7 @@ export function insertTask(
 ): void {
   db.prepare(
     `INSERT INTO messages_in (id, seq, timestamp, status, tries, process_after, recurrence, kind, platform_id, channel_type, thread_id, content, series_id)
-     VALUES (@id, @seq, datetime('now'), 'pending', 0, @processAfter, @recurrence, 'task', @platformId, @channelType, @threadId, @content, @id)`,
+     VALUES (@id, @seq, strftime('%Y-%m-%dT%H:%M:%fZ','now'), 'pending', 0, @processAfter, @recurrence, 'task', @platformId, @channelType, @threadId, @content, @id)`,
   ).run({
     ...task,
     seq: nextEvenSeq(db),
@@ -255,7 +255,7 @@ export function insertRecurrence(
 ): void {
   db.prepare(
     `INSERT INTO messages_in (id, seq, kind, timestamp, status, process_after, recurrence, platform_id, channel_type, thread_id, content, series_id)
-     VALUES (?, ?, ?, datetime('now'), 'pending', ?, ?, ?, ?, ?, ?, ?)`,
+     VALUES (?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'), 'pending', ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     newId,
     nextEvenSeq(db),
@@ -334,13 +334,13 @@ export function getDeliveredIds(db: Database.Database): Set<string> {
 
 export function markDelivered(db: Database.Database, messageOutId: string, platformMessageId: string | null): void {
   db.prepare(
-    "INSERT OR IGNORE INTO delivered (message_out_id, platform_message_id, status, delivered_at) VALUES (?, ?, 'delivered', datetime('now'))",
+    "INSERT OR IGNORE INTO delivered (message_out_id, platform_message_id, status, delivered_at) VALUES (?, ?, 'delivered', strftime('%Y-%m-%dT%H:%M:%fZ','now'))",
   ).run(messageOutId, platformMessageId ?? null);
 }
 
 export function markDeliveryFailed(db: Database.Database, messageOutId: string): void {
   db.prepare(
-    "INSERT OR IGNORE INTO delivered (message_out_id, platform_message_id, status, delivered_at) VALUES (?, NULL, 'failed', datetime('now'))",
+    "INSERT OR IGNORE INTO delivered (message_out_id, platform_message_id, status, delivered_at) VALUES (?, NULL, 'failed', strftime('%Y-%m-%dT%H:%M:%fZ','now'))",
   ).run(messageOutId);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { startActiveDeliveryPoll, startSweepDeliveryPoll, setDeliveryAdapter, st
 import { startHostSweep, stopHostSweep } from './host-sweep.js';
 import { routeInbound } from './router.js';
 import { log } from './log.js';
+import { readEnvFile } from './env.js';
 
 // Response + shutdown registries live in response-registry.ts to break the
 // circular import cycle: src/index.ts imports src/modules/index.js for side
@@ -146,6 +147,20 @@ async function main(): Promise<void> {
   // 6. Start host sweep
   startHostSweep();
   log.info('Host sweep started');
+
+  // 7. Dashboard (optional)
+  const dashboardEnv = readEnvFile(['DASHBOARD_SECRET', 'DASHBOARD_PORT']);
+  const dashboardSecret = process.env.DASHBOARD_SECRET || dashboardEnv.DASHBOARD_SECRET;
+  const dashboardPort = parseInt(process.env.DASHBOARD_PORT || dashboardEnv.DASHBOARD_PORT || '3100', 10);
+  if (dashboardSecret) {
+    const { startDashboard } = await import('@nanoco/nanoclaw-dashboard');
+    const { startDashboardPusher } = await import('./dashboard-pusher.js');
+    startDashboard({ port: dashboardPort, secret: dashboardSecret });
+    startDashboardPusher({ port: dashboardPort, secret: dashboardSecret, intervalMs: 60000 });
+  } else {
+    log.info('Dashboard disabled (no DASHBOARD_SECRET)');
+  }
+
 
   log.info('NanoClaw running');
 }


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [x] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description

Auto-generated timestamps in the session DBs used SQLite's `datetime('now')` which produces `2026-04-18 13:29:12` (space separator, no `T`, no `Z`, no milliseconds). Channel adapters already produce ISO 8601 strings like `2026-04-18T13:31:43.160Z`, making the dashboard display inconsistent.

Replace all `datetime('now')` used as timestamp values with `strftime('%Y-%m-%dT%H:%M:%fZ','now')` in:
- `src/db/session-db.ts` — `insertTask`, `insertRecurrence`, `markDelivered`, `markDeliveryFailed`
- `container/agent-runner/src/db/messages-out.ts` — `writeMessageOut`
- `container/agent-runner/src/db/messages-in.ts` — `markProcessing`, `markCompleted`, `markFailed`

No DB migration needed — `timestamp` columns are `TEXT`, the format change is backward-compatible. Existing `datetime()` comparisons (e.g. `deliver_after <= datetime('now')`) handle both formats correctly.