### PR TITLE
feat: add OpenAI Codex SDK as fallback provider

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -59,6 +59,7 @@ RUN printf '#!/bin/bash\nset -e\ncd /app && npx tsc --outDir /tmp/dist 2>&1 >&2\
 
 # Set ownership to node user (non-root) for writable directories
 RUN chown -R node:node /workspace && chmod 777 /home/node
+RUN mkdir -p /home/node/.codex/sessions && chown -R node:node /home/node/.codex
 
 # Switch to non-root user (required for --dangerously-skip-permissions)
 USER node

--- a/container/agent-runner/package.json
+++ b/container/agent-runner/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.92",
     "@modelcontextprotocol/sdk": "^1.12.1",
+    "@openai/codex-sdk": "^1.0.0",
     "cron-parser": "^5.0.0",
     "zod": "^4.0.0"
   },

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -33,6 +33,10 @@ interface ContainerInput {
   isScheduledTask?: boolean;
   assistantName?: string;
   script?: string;
+  providerConfig?: {
+    primary?: 'claude' | 'codex';
+    fallback?: 'codex' | 'none';
+  };
 }
 
 interface ContainerOutput {
@@ -58,6 +62,20 @@ interface SDKUserMessage {
   message: { role: 'user'; content: string };
   parent_tool_use_id: null;
   session_id: string;
+}
+
+function isRateLimitError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return /429|rate.?limit|too.?many.?requests/i.test(msg);
+}
+
+function isAuthError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return /401|unauthorized|authentication failed|invalid.*key|token.*expired/i.test(msg);
+}
+
+function shouldFallbackToCodex(err: unknown): boolean {
+  return isRateLimitError(err) || isAuthError(err);
 }
 
 const IPC_INPUT_DIR = '/workspace/ipc/input';
@@ -544,6 +562,56 @@ async function runQuery(
   return { newSessionId, lastAssistantUuid, closedDuringQuery };
 }
 
+/**
+ * Run a query using the OpenAI Codex SDK.
+ * Used as fallback when Claude hits rate limits or auth errors.
+ */
+async function runCodexQuery(
+  prompt: string,
+  codexThreadId: string | undefined,
+  _mcpServerPath: string,
+  _containerInput: ContainerInput,
+): Promise<{ newThreadId: string }> {
+  const { Codex } = await import('@openai/codex-sdk');
+
+  const codex = new Codex();
+
+  let thread: Awaited<ReturnType<typeof codex.startThread>>;
+  if (codexThreadId) {
+    thread = codex.resumeThread(codexThreadId);
+  } else {
+    thread = codex.startThread({
+      workingDirectory: '/workspace/group',
+      skipGitRepoCheck: true,
+    });
+  }
+
+  const streamed = await thread.runStreamed(prompt);
+  let text = '';
+
+  for await (const event of streamed.events) {
+    if (event.type === 'item.completed') {
+      const item = (event as { type: string; item?: { type?: string; content?: string; output?: string } }).item;
+      if (item) {
+        const content = item.content ?? item.output ?? '';
+        if (typeof content === 'string' && content) {
+          text += content;
+        }
+      }
+    }
+  }
+
+  const threadId = thread.id ?? `codex-${Date.now()}`;
+
+  writeOutput({
+    status: 'success',
+    result: text || null,
+    newSessionId: 'codex:' + threadId,
+  });
+
+  return { newThreadId: threadId };
+}
+
 interface ScriptResult {
   wakeAgent: boolean;
   data?: unknown;
@@ -674,22 +742,90 @@ async function main(): Promise<void> {
     prompt = `[SCHEDULED TASK]\n\nScript output:\n${JSON.stringify(scriptResult.data, null, 2)}\n\nInstructions:\n${containerInput.prompt}`;
   }
 
+  // Determine initial provider: parse 'codex:' prefix from sessionId
+  let useCodex = containerInput.providerConfig?.primary === 'codex';
+  let codexThreadId: string | undefined;
+  if (sessionId?.startsWith('codex:')) {
+    useCodex = true;
+    codexThreadId = sessionId.slice('codex:'.length);
+    sessionId = undefined; // Claude session ID is not applicable
+  }
+
   // Query loop: run query → wait for IPC message → run new query → repeat
   let resumeAt: string | undefined;
   try {
     while (true) {
       log(
-        `Starting query (session: ${sessionId || 'new'}, resumeAt: ${resumeAt || 'latest'})...`,
+        `Starting query (provider: ${useCodex ? 'codex' : 'claude'}, session: ${useCodex ? (codexThreadId || 'new') : (sessionId || 'new')}, resumeAt: ${resumeAt || 'latest'})...`,
       );
 
-      const queryResult = await runQuery(
-        prompt,
-        sessionId,
-        mcpServerPath,
-        containerInput,
-        sdkEnv,
-        resumeAt,
-      );
+      if (useCodex) {
+        const codexResult = await runCodexQuery(
+          prompt,
+          codexThreadId,
+          mcpServerPath,
+          containerInput,
+        );
+        codexThreadId = codexResult.newThreadId;
+        sessionId = 'codex:' + codexThreadId;
+
+        // Emit session update so host can track it
+        writeOutput({ status: 'success', result: null, newSessionId: sessionId });
+
+        log('Codex query ended, waiting for next IPC message...');
+        const nextMessage = await waitForIpcMessage();
+        if (nextMessage === null) {
+          log('Close sentinel received, exiting');
+          break;
+        }
+        log(`Got new message (${nextMessage.length} chars), starting new query`);
+        prompt = nextMessage;
+        continue;
+      }
+
+      let queryResult: Awaited<ReturnType<typeof runQuery>>;
+      try {
+        queryResult = await runQuery(
+          prompt,
+          sessionId,
+          mcpServerPath,
+          containerInput,
+          sdkEnv,
+          resumeAt,
+        );
+      } catch (claudeErr) {
+        const fallback = containerInput.providerConfig?.fallback;
+        if (shouldFallbackToCodex(claudeErr) && fallback !== 'none') {
+          log(
+            `Claude error, falling back to Codex: ${claudeErr instanceof Error ? claudeErr.message : String(claudeErr)}`,
+          );
+          useCodex = true;
+          sessionId = undefined;
+          codexThreadId = undefined;
+          const codexResult = await runCodexQuery(
+            prompt,
+            undefined,
+            mcpServerPath,
+            containerInput,
+          );
+          codexThreadId = codexResult.newThreadId;
+          sessionId = 'codex:' + codexThreadId;
+
+          writeOutput({ status: 'success', result: null, newSessionId: sessionId });
+
+          log('Codex fallback query ended, waiting for next IPC message...');
+          const nextMessage = await waitForIpcMessage();
+          if (nextMessage === null) {
+            log('Close sentinel received, exiting');
+            break;
+          }
+          log(`Got new message (${nextMessage.length} chars), starting new query`);
+          prompt = nextMessage;
+          continue;
+        }
+        throw claudeErr;
+      }
+
       if (queryResult.newSessionId) {
         sessionId = queryResult.newSessionId;
       }

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -4,6 +4,7 @@
  */
 import { ChildProcess, spawn } from 'child_process';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
 import {
@@ -44,6 +45,10 @@ export interface ContainerInput {
   isScheduledTask?: boolean;
   assistantName?: string;
   script?: string;
+  providerConfig?: {
+    primary?: 'claude' | 'codex';
+    fallback?: 'codex' | 'none';
+  };
 }
 
 export interface ContainerOutput {
@@ -184,6 +189,22 @@ function buildVolumeMounts(
     containerPath: '/home/node/.claude',
     readonly: false,
   });
+
+  // Per-group Codex sessions directory (isolated from other groups)
+  const groupCodexDir = path.join(DATA_DIR, 'sessions', group.folder, '.codex');
+  fs.mkdirSync(groupCodexDir, { recursive: true });
+  mounts.push({
+    hostPath: groupCodexDir,
+    containerPath: '/home/node/.codex',
+    readonly: false,
+  });
+
+  // Seed OAuth credentials from host if not already present
+  const hostCodexAuth = path.join(os.homedir(), '.codex', 'auth.json');
+  const groupCodexAuth = path.join(groupCodexDir, 'auth.json');
+  if (fs.existsSync(hostCodexAuth) && !fs.existsSync(groupCodexAuth)) {
+    fs.copyFileSync(hostCodexAuth, groupCodexAuth);
+  }
 
   // Per-group IPC namespace: each group gets its own IPC directory
   // This prevents cross-group privilege escalation via IPC

--- a/src/index.ts
+++ b/src/index.ts
@@ -392,6 +392,7 @@ async function runAgent(
         chatJid,
         isMain,
         assistantName: ASSISTANT_NAME,
+        providerConfig: group.containerConfig?.provider,
       },
       (proc, containerName) =>
         queue.registerProcess(chatJid, proc, containerName, group.folder),

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -181,6 +181,7 @@ async function runTask(
         isScheduledTask: true,
         assistantName: ASSISTANT_NAME,
         script: task.script || undefined,
+        providerConfig: group.containerConfig?.provider,
       },
       (proc, containerName) =>
         deps.onProcess(task.chat_jid, proc, containerName, task.group_folder),

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,10 @@ export interface AllowedRoot {
 export interface ContainerConfig {
   additionalMounts?: AdditionalMount[];
   timeout?: number; // Default: 300000 (5 minutes)
+  provider?: {
+    primary?: 'claude' | 'codex';
+    fallback?: 'codex' | 'none';
+  };
 }
 
 export interface RegisteredGroup {


### PR DESCRIPTION
Adds automatic fallback to OpenAI Codex SDK when Claude hits rate limits (429) or auth errors (401). Auth is via OAuth credentials (~/.codex/auth.json).

- Add runCodexQuery() in agent-runner using @openai/codex-sdk
- Add error detection helpers (isRateLimitError, isAuthError)
- Parse 'codex:' session ID prefix to resume Codex threads
- Add per-group .codex/ volume mount with OAuth credential seeding
- Extend ContainerInput/ContainerConfig with providerConfig
- MCP server (ipc-mcp-stdio.ts) unchanged - works with both providers

<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description


## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
