### PR TITLE
fix: repeat typing indicator every 4s during long agent turns

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -280,6 +280,9 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   };
 
   await channel.setTyping?.(chatJid, true);
+  const typingInterval = setInterval(() => {
+    channel.setTyping?.(chatJid, true);
+  }, 4000);
   let hadError = false;
   let outputSentToUser = false;
 
@@ -308,6 +311,8 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     if (result.status === 'error') {
       hadError = true;
     }
+  }).finally(() => {
+    clearInterval(typingInterval);
   });
 
   await channel.setTyping?.(chatJid, false);


### PR DESCRIPTION
## Problem

Telegram's `typing…` indicator expires after ~5 seconds. NanoClaw sends it once at turn start, so any agent turn longer than that appears completely silent — users can't distinguish "processing" from "crashed".

Reported in #1805.

## Fix

Add a 4-second heartbeat that re-sends `setTyping` while the agent is running. The interval is cleared in a `.finally()` so it always stops even if `runAgent` throws.

```ts
await channel.setTyping?.(chatJid, true);
const typingInterval = setInterval(() => {
  channel.setTyping?.(chatJid, true);
}, 4000);

const output = await runAgent(...).finally(() => {
  clearInterval(typingInterval);
});
```

## Notes

- 4s interval keeps a safe margin under Telegram's ~5s expiry with no visible gap
- Idempotent for all other channels — `setTyping?.(jid, true)` repeated is a no-op for channels that don't implement it, and harmless for those that do (WhatsApp, Discord, Slack)
- All 301 existing tests pass