### PR TITLE
Private/feat 1547 youtube history tool

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -375,6 +375,7 @@ async function runQuery(
   prompt: string,
   sessionId: string | undefined,
   mcpServerPath: string,
+  youtubeMcpServerPath: string,
   containerInput: ContainerInput,
   sdkEnv: Record<string, string | undefined>,
   resumeAt?: string,
@@ -469,6 +470,7 @@ async function runQuery(
         'Skill',
         'NotebookEdit',
         'mcp__nanoclaw__*',
+        'mcp__youtube__*',
       ],
       env: sdkEnv,
       permissionMode: 'bypassPermissions',
@@ -482,6 +484,14 @@ async function runQuery(
             NANOCLAW_CHAT_JID: containerInput.chatJid,
             NANOCLAW_GROUP_FOLDER: containerInput.groupFolder,
             NANOCLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
+          },
+        },
+        youtube: {
+          command: 'node',
+          args: [youtubeMcpServerPath],
+          env: {
+            YOUTUBE_HOST:
+              process.env.YOUTUBE_HOST || 'http://host.docker.internal:3002',
           },
         },
       },
@@ -630,6 +640,10 @@ async function main(): Promise<void> {
 
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
   const mcpServerPath = path.join(__dirname, 'ipc-mcp-stdio.js');
+  const youtubeMcpServerPath = path.join(
+    __dirname,
+    'youtube-mcp-stdio.js',
+  );
 
   let sessionId = containerInput.sessionId;
   fs.mkdirSync(IPC_INPUT_DIR, { recursive: true });
@@ -686,6 +700,7 @@ async function main(): Promise<void> {
         prompt,
         sessionId,
         mcpServerPath,
+        youtubeMcpServerPath,
         containerInput,
         sdkEnv,
         resumeAt,

--- a/container/agent-runner/src/youtube-mcp-stdio.ts
+++ b/container/agent-runner/src/youtube-mcp-stdio.ts
@@ -1,0 +1,155 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+
+interface SearchResponse {
+  ok?: boolean;
+  items?: unknown[];
+  error?: string;
+  details?: string;
+}
+
+const configuredHost = process.env.YOUTUBE_HOST || 'http://host.docker.internal:3002';
+const normalizedConfigured = configuredHost.replace(/\/$/, '');
+const configuredUrl = new URL(normalizedConfigured);
+const fallbackUrl = new URL(normalizedConfigured);
+fallbackUrl.hostname = 'localhost';
+const baseCandidates = Array.from(
+  new Set([configuredUrl.toString(), fallbackUrl.toString()]),
+);
+
+async function requestJson<T>(
+  method: 'GET' | 'POST',
+  endpoint: string,
+  body?: unknown,
+): Promise<T> {
+  let lastError: Error | null = null;
+  for (const base of baseCandidates) {
+    const url = `${base}${endpoint}`;
+    try {
+      const response = await fetch(url, {
+        method,
+        headers:
+          method === 'POST' ? { 'content-type': 'application/json' } : undefined,
+        body: method === 'POST' ? JSON.stringify(body || {}) : undefined,
+        signal: AbortSignal.timeout(60_000),
+      });
+      const payload = (await response.json()) as SearchResponse;
+      if (!response.ok || payload?.ok === false) {
+        throw new Error(
+          payload?.details ||
+            payload?.error ||
+            `YouTube service request failed with ${response.status}`,
+        );
+      }
+      return payload as T;
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+    }
+  }
+  throw lastError || new Error('YouTube service request failed');
+}
+
+const server = new McpServer({
+  name: 'youtube',
+  version: '1.0.0',
+});
+
+server.tool(
+  'search_history',
+  'Search YouTube watch history by query text and return matched watched videos.',
+  {
+    query: z.string().describe('Search query text'),
+    max_results: z
+      .number()
+      .int()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe('Maximum number of results to return (default 20)'),
+  },
+  async (args) => {
+    const payload = await requestJson<{
+      count: number;
+      items: unknown[];
+    }>('POST', '/api/search', {
+      query: args.query,
+      maxResults: args.max_results,
+    });
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(
+            {
+              count: payload.count,
+              items: payload.items,
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    };
+  },
+);
+
+server.tool(
+  'recent_history',
+  'Fetch most recent YouTube watch history entries.',
+  {
+    max_results: z
+      .number()
+      .int()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe('Maximum number of results to return (default 20)'),
+  },
+  async (args) => {
+    const limit = args.max_results || 20;
+    const payload = await requestJson<{
+      count: number;
+      items: unknown[];
+    }>('GET', `/api/recent?limit=${encodeURIComponent(String(limit))}`);
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(
+            {
+              count: payload.count,
+              items: payload.items,
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    };
+  },
+);
+
+server.tool(
+  'status',
+  'Check YouTube history service status and whether login cookies are available.',
+  {},
+  async () => {
+    const payload = await requestJson<{
+      browserRunning: boolean;
+      loggedIn: boolean;
+      profileDir: string;
+    }>('GET', '/api/status');
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(payload, null, 2),
+        },
+      ],
+    };
+  },
+);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/container/agent-runner/src/youtube-mcp-stdio.ts
+++ b/container/agent-runner/src/youtube-mcp-stdio.ts
@@ -55,100 +55,134 @@ const server = new McpServer({
   version: '1.0.0',
 });
 
+const searchSchema = {
+  query: z.string().describe('Search query text'),
+  max_results: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .describe('Maximum number of results to return (default 20)'),
+};
+
+async function runSearch(args: { query: string; max_results?: number }) {
+  const payload = await requestJson<{
+    count: number;
+    items: unknown[];
+  }>('POST', '/api/search', {
+    query: args.query,
+    maxResults: args.max_results,
+  });
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(
+          {
+            count: payload.count,
+            items: payload.items,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
+  };
+}
+
+const recentSchema = {
+  max_results: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .describe('Maximum number of results to return (default 20)'),
+};
+
+async function runRecent(args: { max_results?: number }) {
+  const limit = args.max_results || 20;
+  const payload = await requestJson<{
+    count: number;
+    items: unknown[];
+  }>('GET', `/api/recent?limit=${encodeURIComponent(String(limit))}`);
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(
+          {
+            count: payload.count,
+            items: payload.items,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
+  };
+}
+
+async function runStatus() {
+  const payload = await requestJson<{
+    browserRunning: boolean;
+    loggedIn: boolean;
+    profileDir: string;
+  }>('GET', '/api/status');
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(payload, null, 2),
+      },
+    ],
+  };
+}
+
+server.tool(
+  'youtube_search_history',
+  'Search YouTube watch history by query text and return matched watched videos.',
+  searchSchema,
+  runSearch,
+);
+
+// Backward-compatible alias.
 server.tool(
   'search_history',
   'Search YouTube watch history by query text and return matched watched videos.',
-  {
-    query: z.string().describe('Search query text'),
-    max_results: z
-      .number()
-      .int()
-      .min(1)
-      .max(100)
-      .optional()
-      .describe('Maximum number of results to return (default 20)'),
-  },
-  async (args) => {
-    const payload = await requestJson<{
-      count: number;
-      items: unknown[];
-    }>('POST', '/api/search', {
-      query: args.query,
-      maxResults: args.max_results,
-    });
-    return {
-      content: [
-        {
-          type: 'text' as const,
-          text: JSON.stringify(
-            {
-              count: payload.count,
-              items: payload.items,
-            },
-            null,
-            2,
-          ),
-        },
-      ],
-    };
-  },
+  searchSchema,
+  runSearch,
 );
 
 server.tool(
-  'recent_history',
+  'youtube_recent_history',
   'Fetch most recent YouTube watch history entries.',
-  {
-    max_results: z
-      .number()
-      .int()
-      .min(1)
-      .max(100)
-      .optional()
-      .describe('Maximum number of results to return (default 20)'),
-  },
-  async (args) => {
-    const limit = args.max_results || 20;
-    const payload = await requestJson<{
-      count: number;
-      items: unknown[];
-    }>('GET', `/api/recent?limit=${encodeURIComponent(String(limit))}`);
-    return {
-      content: [
-        {
-          type: 'text' as const,
-          text: JSON.stringify(
-            {
-              count: payload.count,
-              items: payload.items,
-            },
-            null,
-            2,
-          ),
-        },
-      ],
-    };
-  },
+  recentSchema,
+  runRecent,
 );
 
+// Backward-compatible alias.
+server.tool(
+  'recent_history',
+  'Fetch most recent YouTube watch history entries.',
+  recentSchema,
+  runRecent,
+);
+
+server.tool(
+  'youtube_status',
+  'Check YouTube history service status and whether login cookies are available.',
+  {},
+  runStatus,
+);
+
+// Backward-compatible alias.
 server.tool(
   'status',
   'Check YouTube history service status and whether login cookies are available.',
   {},
-  async () => {
-    const payload = await requestJson<{
-      browserRunning: boolean;
-      loggedIn: boolean;
-      profileDir: string;
-    }>('GET', '/api/status');
-    return {
-      content: [
-        {
-          type: 'text' as const,
-          text: JSON.stringify(payload, null, 2),
-        },
-      ],
-    };
-  },
+  runStatus,
 );
 
 const transport = new StdioServerTransport();

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@onecli-sh/sdk": "^0.2.0",
         "better-sqlite3": "11.10.0",
-        "cron-parser": "5.5.0"
+        "cron-parser": "5.5.0",
+        "playwright": "^1.53.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.35.0",
@@ -2616,6 +2617,50 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "dependencies": {
     "@onecli-sh/sdk": "^0.2.0",
     "better-sqlite3": "11.10.0",
-    "cron-parser": "5.5.0"
+    "cron-parser": "5.5.0",
+    "playwright": "^1.53.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.35.0",

--- a/scripts/youtube-login.ts
+++ b/scripts/youtube-login.ts
@@ -1,0 +1,61 @@
+import os from 'os';
+import path from 'path';
+import readline from 'readline/promises';
+
+import { chromium } from 'playwright';
+
+function getProfileDir(): string {
+  return path.join(
+    os.homedir(),
+    '.config',
+    'nanoclaw',
+    'youtube-chrome-profile',
+  );
+}
+
+function hasAuthCookies(cookies: { name: string }[]): boolean {
+  const names = new Set(cookies.map((c) => c.name));
+  return (
+    names.has('SAPISID') ||
+    names.has('__Secure-3PSID') ||
+    names.has('__Secure-1PSID')
+  );
+}
+
+async function main(): Promise<void> {
+  const profileDir = getProfileDir();
+  const context = await chromium.launchPersistentContext(profileDir, {
+    headless: false,
+    viewport: { width: 1440, height: 900 },
+  });
+  const page = await context.newPage();
+  await page.goto('https://www.youtube.com/feed/history', {
+    waitUntil: 'domcontentloaded',
+  });
+  console.log(`Opened browser with persistent profile: ${profileDir}`);
+  console.log('Log into Google/YouTube in the opened browser window.');
+  console.log('After login is complete, press Enter here to verify cookies.');
+
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  await rl.question('Press Enter to continue...');
+  rl.close();
+
+  const cookies = await context.cookies(['https://www.youtube.com']);
+  const loggedIn = hasAuthCookies(cookies);
+  if (!loggedIn) {
+    throw new Error(
+      'Login cookies were not detected. Please run the script again and complete login first.',
+    );
+  }
+
+  console.log('✅ Login cookies detected. YouTube profile setup complete.');
+  await context.close();
+}
+
+main().catch((err) => {
+  console.error(`❌ youtube-login failed: ${err instanceof Error ? err.message : String(err)}`);
+  process.exit(1);
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,9 @@ const envConfig = readEnvFile([
   'ASSISTANT_HAS_OWN_NUMBER',
   'ONECLI_URL',
   'ONECLI_API_KEY',
+  'PROXY_BIND_HOST',
+  'YOUTUBE_HOST',
+  'YOUTUBE_HISTORY_PORT',
   'TZ',
 ]);
 
@@ -55,6 +58,32 @@ export const CONTAINER_MAX_OUTPUT_SIZE = parseInt(
 export const ONECLI_URL = process.env.ONECLI_URL || envConfig.ONECLI_URL;
 export const ONECLI_API_KEY =
   process.env.ONECLI_API_KEY || envConfig.ONECLI_API_KEY;
+function resolveDefaultProxyBindHost(): string {
+  if (process.platform !== 'linux') return '127.0.0.1';
+  const interfaces = os.networkInterfaces();
+  for (const [name, addresses] of Object.entries(interfaces)) {
+    if (!addresses) continue;
+    const looksLikeBridge = name === 'docker0' || name.startsWith('br-');
+    if (!looksLikeBridge) continue;
+    const ipv4 = addresses.find(
+      (addr) => addr.family === 'IPv4' && !addr.internal,
+    );
+    if (ipv4?.address) return ipv4.address;
+  }
+  return '127.0.0.1';
+}
+export const PROXY_BIND_HOST =
+  process.env.PROXY_BIND_HOST ||
+  envConfig.PROXY_BIND_HOST ||
+  resolveDefaultProxyBindHost();
+export const YOUTUBE_HISTORY_PORT = parseInt(
+  process.env.YOUTUBE_HISTORY_PORT || envConfig.YOUTUBE_HISTORY_PORT || '3002',
+  10,
+);
+export const YOUTUBE_HOST =
+  process.env.YOUTUBE_HOST ||
+  envConfig.YOUTUBE_HOST ||
+  `http://host.docker.internal:${YOUTUBE_HISTORY_PORT}`;
 export const MAX_MESSAGES_PER_PROMPT = Math.max(
   1,
   parseInt(process.env.MAX_MESSAGES_PER_PROMPT || '10', 10) || 10,

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -16,6 +16,7 @@ import {
   ONECLI_API_KEY,
   ONECLI_URL,
   TIMEZONE,
+  YOUTUBE_HOST,
 } from './config.js';
 import { resolveGroupFolderPath, resolveGroupIpcPath } from './group-folder.js';
 import { logger } from './logger.js';
@@ -252,6 +253,7 @@ async function buildContainerArgs(
 
   // Pass host timezone so container's local time matches the user's
   args.push('-e', `TZ=${TIMEZONE}`);
+  args.push('-e', `YOUTUBE_HOST=${YOUTUBE_HOST}`);
 
   // OneCLI gateway handles credential injection — containers never see real secrets.
   // The gateway intercepts HTTPS traffic and injects API keys or OAuth tokens.

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,9 @@ import {
   MAX_MESSAGES_PER_PROMPT,
   ONECLI_URL,
   POLL_INTERVAL,
+  PROXY_BIND_HOST,
   TIMEZONE,
+  YOUTUBE_HISTORY_PORT,
 } from './config.js';
 import './channels/index.js';
 import {
@@ -65,6 +67,7 @@ import { startSessionCleanup } from './session-cleanup.js';
 import { startSchedulerLoop } from './task-scheduler.js';
 import { Channel, NewMessage, RegisteredGroup } from './types.js';
 import { logger } from './logger.js';
+import { startYouTubeHistoryService } from './youtube-history-service.js';
 
 // Re-export for backwards compatibility during refactor
 export { escapeXml, formatMessages } from './router.js';
@@ -570,6 +573,7 @@ function ensureContainerSystemRunning(): void {
 
 async function main(): Promise<void> {
   ensureContainerSystemRunning();
+  await startYouTubeHistoryService(YOUTUBE_HISTORY_PORT, PROXY_BIND_HOST);
   initDatabase();
   logger.info('Database initialized');
   loadState();

--- a/src/youtube-history-service.ts
+++ b/src/youtube-history-service.ts
@@ -1,0 +1,320 @@
+import http, { IncomingMessage, ServerResponse } from 'http';
+import os from 'os';
+import path from 'path';
+
+import { chromium, BrowserContext, Page } from 'playwright';
+
+import { logger } from './logger.js';
+
+export interface HistoryEntry {
+  title: string;
+  url: string;
+  channelName: string;
+  channelUrl: string;
+  watchedAt: string;
+  duration: string;
+}
+
+interface SearchPayload {
+  query: string;
+  maxResults?: number;
+}
+
+interface YouTubeHistoryServiceHandle {
+  close: () => Promise<void>;
+}
+
+const DEFAULT_IDLE_MS = 5 * 60 * 1000;
+const YOUTUBE_HISTORY_URL = 'https://www.youtube.com/feed/history';
+
+function getProfileDir(): string {
+  return path.join(
+    os.homedir(),
+    '.config',
+    'nanoclaw',
+    'youtube-chrome-profile',
+  );
+}
+
+function toHttpUrl(rawUrl: string): string {
+  if (!rawUrl) return '';
+  if (rawUrl.startsWith('http://') || rawUrl.startsWith('https://')) {
+    return rawUrl;
+  }
+  if (rawUrl.startsWith('//')) return `https:${rawUrl}`;
+  if (rawUrl.startsWith('/')) return `https://www.youtube.com${rawUrl}`;
+  return rawUrl;
+}
+
+function normalizeResultsLimit(raw: unknown, fallback: number): number {
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(1, Math.min(100, Math.floor(parsed)));
+}
+
+function sendJson(res: ServerResponse, status: number, payload: unknown): void {
+  res.statusCode = status;
+  res.setHeader('content-type', 'application/json; charset=utf-8');
+  res.end(JSON.stringify(payload));
+}
+
+function sendError(
+  res: ServerResponse,
+  status: number,
+  message: string,
+  details?: string,
+): void {
+  sendJson(res, status, {
+    ok: false,
+    error: message,
+    details,
+  });
+}
+
+async function readJsonBody(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  if (chunks.length === 0) return {};
+  const body = Buffer.concat(chunks).toString('utf8').trim();
+  if (!body) return {};
+  return JSON.parse(body);
+}
+
+function isLoggedInFromCookies(cookies: { name: string }[]): boolean {
+  const names = new Set(cookies.map((c) => c.name));
+  return (
+    names.has('SAPISID') ||
+    names.has('__Secure-3PSID') ||
+    names.has('__Secure-1PSID')
+  );
+}
+
+async function waitForHistorySearchInput(page: Page): Promise<string> {
+  const selectors = [
+    'input#search',
+    'input[aria-label*="Search watch history" i]',
+    'input[placeholder*="Search watch history" i]',
+    'ytd-feed-filter-chip-bar-renderer input#search',
+    'ytd-search-box input#search',
+  ];
+  for (const selector of selectors) {
+    const handle = await page.$(selector);
+    if (!handle) continue;
+    await handle.scrollIntoViewIfNeeded().catch(() => undefined);
+    return selector;
+  }
+  throw new Error('Could not find YouTube watch-history search input');
+}
+
+async function scrapeEntries(
+  page: Page,
+  limit: number,
+): Promise<HistoryEntry[]> {
+  const selector =
+    'ytd-video-renderer, ytd-item-section-renderer ytd-video-renderer';
+  await page.waitForSelector(selector, { timeout: 15000 });
+  const rows = await page.$$eval(
+    selector,
+    (items, max) =>
+      items.slice(0, max).map((item) => {
+        const titleAnchor = item.querySelector('a#video-title');
+        const channelAnchor = item.querySelector(
+          '#channel-name a, ytd-channel-name a',
+        );
+        const metadataSpans = Array.from(
+          item.querySelectorAll('#metadata-line span'),
+        )
+          .map((el) =>
+            String((el as { textContent?: string }).textContent || '').trim(),
+          )
+          .filter(Boolean);
+        const durationEl = item.querySelector(
+          'ytd-thumbnail-overlay-time-status-renderer span',
+        );
+        const watchedAt =
+          metadataSpans.find((span) =>
+            /ago|分钟前|小时前|天前|周前|月前|年前/i.test(span),
+          ) ||
+          metadataSpans[metadataSpans.length - 1] ||
+          '';
+        return {
+          title: titleAnchor?.textContent?.trim() || '',
+          url: titleAnchor?.href || '',
+          channelName: channelAnchor?.textContent?.trim() || '',
+          channelUrl: channelAnchor?.href || '',
+          watchedAt,
+          duration: durationEl?.textContent?.trim() || '',
+        };
+      }),
+    limit,
+  );
+  return rows.map((row) => ({
+    title: row.title,
+    url: toHttpUrl(row.url),
+    channelName: row.channelName,
+    channelUrl: toHttpUrl(row.channelUrl),
+    watchedAt: row.watchedAt,
+    duration: row.duration,
+  }));
+}
+
+export function startYouTubeHistoryService(
+  port: number,
+  bindHost: string,
+): Promise<YouTubeHistoryServiceHandle> {
+  let context: BrowserContext | null = null;
+  let idleTimer: NodeJS.Timeout | null = null;
+  let pending = Promise.resolve();
+
+  const touchIdle = () => {
+    if (idleTimer) clearTimeout(idleTimer);
+    idleTimer = setTimeout(() => {
+      closeBrowser().catch((err) =>
+        logger.warn({ err }, 'Failed to close YouTube browser on idle'),
+      );
+    }, DEFAULT_IDLE_MS);
+  };
+
+  const closeBrowser = async () => {
+    if (!context) return;
+    const oldContext = context;
+    context = null;
+    await oldContext.close();
+    logger.info('YouTube history browser closed');
+  };
+
+  const ensureContext = async (): Promise<BrowserContext> => {
+    if (context) {
+      touchIdle();
+      return context;
+    }
+    context = await chromium.launchPersistentContext(getProfileDir(), {
+      headless: true,
+      viewport: { width: 1440, height: 900 },
+      args: ['--disable-dev-shm-usage'],
+    });
+    logger.info(
+      { profileDir: getProfileDir() },
+      'YouTube history browser opened',
+    );
+    touchIdle();
+    return context;
+  };
+
+  const withLock = <T>(fn: () => Promise<T>): Promise<T> => {
+    const run = pending.then(fn);
+    pending = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  };
+
+  const getStatus = async () =>
+    withLock(async () => {
+      const running = !!context;
+      const cookies = running
+        ? await context!.cookies(['https://www.youtube.com'])
+        : [];
+      return {
+        browserRunning: running,
+        loggedIn: isLoggedInFromCookies(cookies),
+        profileDir: getProfileDir(),
+      };
+    });
+
+  const runSearch = async (query: string, maxResults: number) =>
+    withLock(async () => {
+      const ctx = await ensureContext();
+      const page = await ctx.newPage();
+      try {
+        await page.goto(YOUTUBE_HISTORY_URL, { waitUntil: 'domcontentloaded' });
+        const selector = await waitForHistorySearchInput(page);
+        await page.fill(selector, query);
+        await page.keyboard.press('Enter');
+        await page.waitForLoadState('networkidle').catch(() => undefined);
+        const entries = await scrapeEntries(page, maxResults);
+        return entries;
+      } finally {
+        await page.close().catch(() => undefined);
+      }
+    });
+
+  const runRecent = async (maxResults: number) =>
+    withLock(async () => {
+      const ctx = await ensureContext();
+      const page = await ctx.newPage();
+      try {
+        await page.goto(YOUTUBE_HISTORY_URL, { waitUntil: 'domcontentloaded' });
+        await page.waitForLoadState('networkidle').catch(() => undefined);
+        return await scrapeEntries(page, maxResults);
+      } finally {
+        await page.close().catch(() => undefined);
+      }
+    });
+
+  const server = http.createServer(async (req, res) => {
+    try {
+      const method = req.method || 'GET';
+      const requestUrl = new URL(req.url || '/', 'http://localhost');
+
+      if (method === 'GET' && requestUrl.pathname === '/api/status') {
+        const status = await getStatus();
+        return sendJson(res, 200, { ok: true, ...status });
+      }
+
+      if (method === 'POST' && requestUrl.pathname === '/api/search') {
+        const body = (await readJsonBody(req)) as SearchPayload;
+        const query = String(body.query || '').trim();
+        if (!query) {
+          return sendError(res, 400, 'query is required');
+        }
+        const maxResults = normalizeResultsLimit(body.maxResults, 20);
+        const entries = await runSearch(query, maxResults);
+        return sendJson(res, 200, {
+          ok: true,
+          query,
+          count: entries.length,
+          items: entries,
+        });
+      }
+
+      if (method === 'GET' && requestUrl.pathname === '/api/recent') {
+        const maxResults = normalizeResultsLimit(
+          requestUrl.searchParams.get('limit'),
+          20,
+        );
+        const entries = await runRecent(maxResults);
+        return sendJson(res, 200, {
+          ok: true,
+          count: entries.length,
+          items: entries,
+        });
+      }
+
+      return sendError(res, 404, 'not found');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error({ err }, 'YouTube history service request failed');
+      return sendError(res, 500, 'request failed', message);
+    }
+  });
+
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, bindHost, () => {
+      logger.info({ bindHost, port }, 'YouTube history service started');
+      resolve({
+        close: async () => {
+          if (idleTimer) clearTimeout(idleTimer);
+          await closeBrowser();
+          await new Promise<void>((done, fail) =>
+            server.close((err) => (err ? fail(err) : done())),
+          );
+        },
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Type of Change

- [x] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)

## Description

### Problem

YouTube removed the watch history API endpoints in 2016. The Data API v3 has no endpoint for retrieving a user's viewing history. This made it impossible for NanoClaw agents to query "what videos have I watched about X topic" — a valuable capability for personalized recommendations and context-aware assistance.

### Solution

Implemented a browser automation approach using Playwright to scrape YouTube watch history directly from the web interface at `youtube.com/feed/history`, exposed via MCP tools for container agents. The architecture follows the same pattern as Ollama/MLX: host-side HTTP service + container-side MCP server.

**Workflow:**
```
Agent calls mcp__youtube__search_history("machine learning")
  → youtube-mcp-stdio.ts (MCP server in container)
  → HTTP POST http://<gateway>:3002/api/search
  → youtube-history-service.ts (host, Playwright)
  → drives Chrome on youtube.com/feed/history
  → scrapes results, returns JSON
```

### Changes

#### New Files

**1. `scripts/youtube-login.ts`**
- One-time setup script for Google authentication
- Launches Playwright in headed mode with persistent Chrome profile
- Profile stored at `~/.config/nanoclaw/youtube-chrome-profile/`
- Interactive: opens browser for user login, verifies cookies on completion
- Usage: `npx tsx scripts/youtube-login.ts`

**2. `src/youtube-history-service.ts`**
- Host-side HTTP server using `http.createServer`
- Binds to `PROXY_BIND_HOST:YOUTUBE_HISTORY_PORT` (bridge interface only, not LAN)
- Uses `playwright.chromium.launchPersistentContext()` with persistent profile
- Lazy launch: browser starts on first request, closes after 5 min idle
- Headless mode for normal operation
- **Endpoints:**
  - `POST /api/search` — `{ query: string, maxResults?: number }` → navigate to history page, use search bar, scrape results
  - `GET /api/recent?limit=N` — history page without search, scrape top N items
  - `GET /api/status` — health check: browser running? logged in?

**Response shape:**
```typescript
interface HistoryEntry {
  title: string;
  url: string;           // youtube.com/watch?v=...
  channelName: string;
  channelUrl: string;
  watchedAt: string;     // relative time from page ("2 days ago")
  duration: string;      // "12:34"
}
```

**3. `container/agent-runner/src/youtube-mcp-stdio.ts`**
- Container-side MCP server following the `ollama-mcp-stdio.ts` pattern
- `YOUTUBE_HOST` env var with fallback to `http://host.docker.internal:3002`
- **Tools:**
  - `search_history` — `{ query: string, max_results?: number }` → calls `POST /api/search`
  - `recent_history` — `{ max_results?: number }` → calls `GET /api/recent`
  - `status` — no params → calls `GET /api/status`
- Same fallback pattern: try gateway URL, fall back to localhost

#### Modified Files

**4. `src/config.ts`**
- Added `YOUTUBE_HOST` config (default: `http://host.docker.internal:${YOUTUBE_HISTORY_PORT}`)
- Added `YOUTUBE_HISTORY_PORT` config (default: 3002)
- Both configurable via environment variables

**5. `src/container-runner.ts`**
- Forwards `YOUTUBE_HOST` env var to containers

**6. `src/index.ts`**
- Starts YouTube history service on startup: `startYouTubeHistoryService(YOUTUBE_HISTORY_PORT, PROXY_BIND_HOST)`

**7. `container/agent-runner/src/index.ts`**
- Registers YouTube MCP server in `mcpServers` config
- Adds `mcp__youtube__*` to `allowedTools`

**8. `package.json`**
- Added `playwright` dependency

### Files Changed

```
container/agent-runner/src/index.ts             | 15 ++
container/agent-runner/src/youtube-mcp-stdio.ts | 155 +++++++++++++++
package.json                                    |  3 +-
scripts/youtube-login.ts                        | 61 ++++++
src/config.ts                                   | 29 ++++
src/container-runner.ts                         |  2 +
src/index.ts                                    | 4 +
src/youtube-history-service.ts                  | 320 +++++++++++++++++++++++++
9 files changed, 634 insertions(+), 2 deletions(-)
```

### Usage

1. **Setup:** Run login script to authenticate with Google
   ```bash
   npx tsx scripts/youtube-login.ts
   ```

2. **Login:** In the opened browser window, log into your Google/YouTube account

3. **Verify:** Press Enter in terminal to verify cookies are saved

4. **Restart:** Restart nanoclaw — YouTube history tools are now available to agents

5. **Query:** Agents can now use:
   - `mcp__youtube__search_history` — search watch history by query
   - `mcp__youtube__recent_history` — get recent watch history
   - `mcp__youtube__status` — check service status

### Testing

- TypeScript compiles cleanly for both host and container
- Build passes for agent-runner
- Service properly initializes on startup

### Related Issue

Closes #1547