### PR TITLE
chore: ignore .env* variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ groups/global/*
 # Secrets
 *.keys.json
 .env
+.env*
 
 # Temp files
 .tmp-*


### PR DESCRIPTION
## Summary

- Adds `.env*` glob to catch `.env.local`, `.env.test`, `.env.production`, and other variant files that should never be committed
- `.env` stays for clarity; `.env*` is the effective catch-all

## Test plan
- [ ] Verify `git status` does not track any `.env.*` files after the change