### PR TITLE
feat(skill): T-Watch S3 — wrist-worn voice terminal channel + OTA firmware delivery

### DIFF
--- a/.claude/skills/add-twatch/SKILL.md
+++ b/.claude/skills/add-twatch/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: add-twatch
+description: Add T-Watch S3 as a wrist-worn voice terminal channel. HTTP server for speak, memo, remind, notifications, OTA firmware updates, and Signal mirror. Open-source firmware at github.com/jorgenclaw/nanoclaw-watch.
+---
+
+# Add T-Watch Channel (V2)
+
+Turn a LilyGo T-Watch S3 into a wrist-worn voice terminal for your NanoClaw agent. The watch communicates over WiFi via an HTTP API — tap to speak, capture voice memos, set reminders, check inbox, find your phone, and control your TV via IR.
+
+**Not a notification display.** The watch is a full input device — voice capture, button actions, and two-way communication with your agent. Your agent replies directly on the watch face.
+
+**Open-source firmware:** [github.com/jorgenclaw/nanoclaw-watch](https://github.com/jorgenclaw/nanoclaw-watch) — PlatformIO project, flash via USB or OTA.
+
+**Battle-tested:** Production-proven since April 2026. Daily voice input, memo capture, and status checks.
+
+## What you get
+
+### Watch → Agent (input)
+- **Speak** — tap to record voice, transcribed and sent to agent, reply on watch face
+- **Capture** — voice memo filed to daily journal (no agent round-trip)
+- **Remind** — "remind me at 3pm to call Mom" → agent schedules a one-shot Signal reminder
+- **Inbox** — agent summarizes unread Proton Mail
+- **Status** — plain-language system status (online, last active, pending tasks, next scheduled)
+- **Find Phone** — sends "FIND MY PHONE" to Scott's Signal so the phone buzzes
+
+### Agent → Watch (output)
+- **Sync reply** — agent response displayed on watch face within the HTTP request (fast path)
+- **Poll fallback** — if agent takes >45s, watch polls `/api/watch/poll` for queued replies
+- **Notifications** — Signal messages and emails pushed to watch as banner alerts (90s poll)
+- **OTA updates** — watch checks `/api/watch/version`, downloads firmware from `/api/watch/firmware`
+
+### Signal mirror
+Every watch interaction is mirrored to Scott's Signal chat — both inbound ("Watch: Scott said X") and outbound ("↳ agent replied Y"). Lets you follow watch conversations from your phone.
+
+## Architecture
+
+```
+T-Watch S3 (WiFi, HTTP client)
+  ↓ POST /api/watch/message (JSON or audio/wav)
+  ↓ POST /api/watch/memo, /api/watch/reminder
+  ↓ GET  /api/watch/poll, /api/watch/notifications
+  ↓ GET  /api/watch/version, /api/watch/firmware (OTA)
+NanoClaw Watch Adapter (src/channels/watch.ts, HTTP server on port 3000)
+  ↓ InboundMessage → Router → Session → Container → Agent
+  ↓ OutboundMessage → deliver() → sync reply or poll queue
+  ↓ mirrorToSignal() → Signal adapter
+```
+
+All endpoints authenticated via `X-Watch-Token` header (HMAC timing-safe comparison).
+
+## HTTP API
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/watch/message` | POST | Voice or text to agent (sync reply) |
+| `/api/watch/memo` | POST | Voice memo → transcribe → daily journal file |
+| `/api/watch/reminder` | POST | Voice → transcribe → agent schedules reminder |
+| `/api/watch/poll` | GET | Retrieve queued replies after sync timeout |
+| `/api/watch/notify` | POST | Push notification to watch (from other adapters) |
+| `/api/watch/notifications` | GET | Poll for new notifications since timestamp |
+| `/api/watch/version` | GET | Current published firmware version |
+| `/api/watch/firmware` | GET | Download firmware binary (OTA update) |
+
+## Prerequisites
+
+### 1. T-Watch S3 hardware
+
+Buy a [LilyGo T-Watch S3](https://www.lilygo.cc/products/t-watch-s3) (~$45). The S3 Plus (with GPS) also works.
+
+### 2. Flash the firmware
+
+Clone and flash via USB (first time only — future updates via OTA):
+
+```bash
+git clone https://github.com/jorgenclaw/nanoclaw-watch.git
+cd nanoclaw-watch
+
+# Edit src/config.h:
+# - NANOCLAW_HOST_URL = "http://YOUR_HOST_IP:3000"
+# - WATCH_AUTH_TOKEN = (generate a 64-char hex secret)
+# - WEATHER_LOCATION = "YourCity,State"
+
+# Install PlatformIO and flash:
+pio run --target upload
+```
+
+### 3. WiFi
+
+The watch connects via WiFi. First boot opens a captive portal ("Jorgenclaw-Setup") to enter WiFi credentials. Supports up to 10 saved networks.
+
+## Install (host side)
+
+### Phase 1: Pre-flight
+
+```bash
+test -f src/channels/watch.ts && echo "Already installed" || echo "Ready to install"
+```
+
+### Phase 2: Apply
+
+```bash
+git fetch origin skill/twatch-v2
+git checkout origin/skill/twatch-v2 -- src/channels/watch.ts
+```
+
+Add the import to `src/channels/index.ts`:
+
+```typescript
+import './watch.js';
+```
+
+Add config exports to `src/config.ts`:
+
+```typescript
+// In readEnvFile array:
+'WATCH_AUTH_TOKEN',
+'WATCH_HTTP_PORT',
+'WATCH_HTTP_BIND',
+'WATCH_JID',
+'WATCH_GROUP_FOLDER',
+'WATCH_SYNC_TIMEOUT_MS',
+'WATCH_SIGNAL_MIRROR_JID',
+'WATCH_FIRMWARE_DIR',
+
+// Exports:
+export const WATCH_AUTH_TOKEN = process.env.WATCH_AUTH_TOKEN || envConfig.WATCH_AUTH_TOKEN || '';
+export const WATCH_HTTP_PORT = parseInt(process.env.WATCH_HTTP_PORT || envConfig.WATCH_HTTP_PORT || '3000', 10);
+export const WATCH_HTTP_BIND = process.env.WATCH_HTTP_BIND || envConfig.WATCH_HTTP_BIND || '0.0.0.0';
+export const WATCH_JID = process.env.WATCH_JID || envConfig.WATCH_JID || 'watch:device';
+export const WATCH_GROUP_FOLDER = process.env.WATCH_GROUP_FOLDER || envConfig.WATCH_GROUP_FOLDER || 'watch';
+export const WATCH_SYNC_TIMEOUT_MS = parseInt(
+  process.env.WATCH_SYNC_TIMEOUT_MS || envConfig.WATCH_SYNC_TIMEOUT_MS || '45000', 10);
+export const WATCH_SIGNAL_MIRROR_JID = process.env.WATCH_SIGNAL_MIRROR_JID || envConfig.WATCH_SIGNAL_MIRROR_JID || '';
+export const WATCH_FIRMWARE_DIR = process.env.WATCH_FIRMWARE_DIR || envConfig.WATCH_FIRMWARE_DIR || path.join(DATA_DIR, 'watch-firmware');
+```
+
+Add to `.env`:
+
+```bash
+WATCH_AUTH_TOKEN=<same-64-char-hex-as-firmware-config.h>
+WATCH_SIGNAL_MIRROR_JID=signal:<your-signal-uuid>  # optional, for Signal mirror
+```
+
+### Phase 3: Build and restart
+
+```bash
+pnpm run build
+systemctl --user restart nanoclaw
+```
+
+### Phase 4: Wire the watch to an agent group
+
+After the watch sends its first message, the router auto-creates a messaging group. Wire it:
+
+```bash
+# Find the watch messaging group
+sqlite3 data/v2.db "SELECT id FROM messaging_groups WHERE channel_type='watch'"
+
+# Wire to your agent group
+sqlite3 data/v2.db "INSERT INTO messaging_group_agents (id, messaging_group_id, agent_group_id, session_mode, priority, created_at) VALUES ('mga-'||hex(randomblob(8)), 'mg-WATCHID', 'ag-YOURID', 'shared', 0, datetime('now'))"
+
+# Add the watch device as a member
+sqlite3 data/v2.db "INSERT OR IGNORE INTO agent_group_members (user_id, agent_group_id, added_by, added_at) VALUES ('watch:device', 'ag-YOURID', NULL, datetime('now'))"
+```
+
+## OTA firmware updates
+
+Publish new firmware for wireless updates:
+
+```bash
+# scripts/publish-firmware.sh builds and copies the binary
+./scripts/publish-firmware.sh
+```
+
+Users tap "Update" on the watch → checks `/api/watch/version` → downloads → flashes → reboots.
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `WATCH_AUTH_TOKEN` | (required) | Shared secret matching firmware config.h |
+| `WATCH_HTTP_PORT` | `3000` | HTTP server port |
+| `WATCH_HTTP_BIND` | `0.0.0.0` | Bind address |
+| `WATCH_JID` | `watch:device` | Platform ID for the watch channel |
+| `WATCH_SYNC_TIMEOUT_MS` | `45000` | Max wait for sync reply before poll fallback |
+| `WATCH_SIGNAL_MIRROR_JID` | (none) | Signal UUID to mirror watch conversations to |
+| `WATCH_FIRMWARE_DIR` | `data/watch-firmware/` | Where OTA firmware binary + version.json live |
+
+## Firmware features (v11)
+
+| Tile | Function |
+|------|----------|
+| Weather | 3-day forecast via wttr.in |
+| Capture | Voice memo → daily journal |
+| Remind | Voice → scheduled Signal reminder |
+| Clock | Alarm, timer, stopwatch, Pomodoro |
+| Remote | IR remote for Vizio TV (customizable NEC codes) |
+| WiFi | Saved network manager, tap-to-forget |
+| Status | Plain-language system status |
+| DND | Do Not Disturb (suppress notification buzzes) |
+| Inbox | Unread email summary |
+| Find Phone | Ring Scott's phone via Signal |
+| Flashlight | Full white screen |
+| Update | OTA firmware update |
+
+## Troubleshooting
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| Watch shows "Host unreachable" | Wrong IP or port in firmware config.h | Reflash with correct NANOCLAW_HOST_URL |
+| Messages dropped with `not_member` | Watch device not in agent group | Add `watch:device` to agent_group_members |
+| Signal mirror not working | WATCH_SIGNAL_MIRROR_JID has `signal:` prefix | Adapter strips it automatically (V2 fix) |
+| OTA says "Up to date" | Published version <= flashed version | Bump FIRMWARE_VERSION in config.h, run publish-firmware.sh |
+| Blank reply on watch | Sync timeout + no poll | Check agent is responding; watch polls at 60s intervals |
+
+## Removal
+
+```bash
+rm src/channels/watch.ts
+# Remove watch import from src/channels/index.ts
+# Remove WATCH_* exports from src/config.ts
+# Remove WATCH_* from .env
+pnpm run build
+```

--- a/src/channels/watch.ts
+++ b/src/channels/watch.ts
@@ -1,0 +1,486 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import http from 'http';
+import path from 'path';
+
+import {
+  GROUPS_DIR,
+  STORE_DIR,
+  WATCH_AUTH_TOKEN,
+  WATCH_FIRMWARE_DIR,
+  WATCH_GROUP_FOLDER,
+  WATCH_HTTP_BIND,
+  WATCH_HTTP_PORT,
+  WATCH_JID,
+  WATCH_SIGNAL_MIRROR_JID,
+  WATCH_SYNC_TIMEOUT_MS,
+} from '../config.js';
+import { log } from '../log.js';
+import { transcribeAudio } from '../transcription.js';
+import type { ChannelAdapter, ChannelRegistration, ChannelSetup, InboundMessage, OutboundMessage } from './adapter.js';
+import { getChannelAdapter, registerChannelAdapter } from './channel-registry.js';
+
+const WATCH_UPLOADS_DIR = path.join(STORE_DIR, 'watch-uploads');
+const MAX_UPLOAD_BYTES = 2 * 1024 * 1024;
+const POLL_QUEUE_MAX = 20;
+const NOTIF_QUEUE_MAX = 50;
+const NOTIF_PREVIEW_LEN = 60;
+const NOTIF_MAX_AGE_MS = 3600_000;
+
+interface PendingResolver {
+  resolve: (text: string) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+interface QueuedReply {
+  ts: number;
+  text: string;
+}
+
+export interface WatchNotification {
+  id: string;
+  type: 'email' | 'signal';
+  from: string;
+  preview: string;
+  full_text: string;
+  timestamp: string;
+}
+
+function normalizeForWatch(text: string): string {
+  return text
+    .replace(/[\u2014\u2013]/g, '-')
+    .replace(/[\u201C\u201D]/g, '"')
+    .replace(/[\u2018\u2019]/g, "'")
+    .replace(/\u2026/g, '...')
+    .replace(/\u2022/g, '*')
+    .replace(/\u2192/g, '->')
+    .replace(/\u00A0/g, ' ')
+    .replace(/[^\x09\x0A\x0D\x20-\x7E]/g, '');
+}
+
+function createWatchAdapter(): ChannelAdapter | null {
+  if (!WATCH_AUTH_TOKEN) return null;
+
+  let config: ChannelSetup;
+  let server: http.Server | undefined;
+  let pendingResolvers: PendingResolver[] = [];
+  let pollQueue: QueuedReply[] = [];
+  let notificationQueue: WatchNotification[] = [];
+
+  function mirrorToSignal(text: string): void {
+    if (!WATCH_SIGNAL_MIRROR_JID) return;
+    const signalAdapter = getChannelAdapter('signal');
+    if (!signalAdapter) return;
+    const platformId = WATCH_SIGNAL_MIRROR_JID.replace(/^signal:/, '');
+    signalAdapter
+      .deliver(platformId, null, {
+        kind: 'text',
+        content: { text },
+      })
+      .catch((err) => log.warn('watch: signal mirror send failed', { err }));
+  }
+
+  function checkAuth(req: http.IncomingMessage): boolean {
+    const provided = req.headers['x-watch-token'];
+    if (typeof provided !== 'string' || !WATCH_AUTH_TOKEN) return false;
+    const a = Buffer.from(provided, 'utf-8');
+    const b = Buffer.from(WATCH_AUTH_TOKEN, 'utf-8');
+    if (a.length !== b.length) return false;
+    return crypto.timingSafeEqual(a, b);
+  }
+
+  function readBody(req: http.IncomingMessage): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      let total = 0;
+      req.on('data', (chunk: Buffer) => {
+        total += chunk.length;
+        if (total > MAX_UPLOAD_BYTES) {
+          reject(new Error('body too large'));
+          req.destroy();
+          return;
+        }
+        chunks.push(chunk);
+      });
+      req.on('end', () => resolve(Buffer.concat(chunks)));
+      req.on('error', reject);
+    });
+  }
+
+  function sendJson(res: http.ServerResponse, status: number, body: Record<string, unknown>): void {
+    const buf = Buffer.from(JSON.stringify(body), 'utf-8');
+    res.writeHead(status, {
+      'Content-Type': 'application/json',
+      'Content-Length': String(buf.length),
+      Connection: 'close',
+    });
+    res.end(buf);
+  }
+
+  async function transcribeWav(body: Buffer): Promise<string> {
+    const fname = `watch-${Date.now()}-${crypto.randomBytes(4).toString('hex')}.wav`;
+    const fpath = path.join(WATCH_UPLOADS_DIR, fname);
+    fs.writeFileSync(fpath, body);
+    try {
+      return (await transcribeAudio(fpath)).trim();
+    } catch (err) {
+      log.warn('watch: transcription failed', { err });
+      return '';
+    } finally {
+      fs.unlink(fpath, () => {});
+    }
+  }
+
+  async function transcribeAndClean(body: Buffer): Promise<string> {
+    const transcribed = await transcribeWav(body);
+    if (!transcribed) return '';
+    return transcribed
+      .replace(/\([^)]*\)/g, ' ')
+      .replace(/\[[^\]]*\]/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
+  function injectAndAwaitReply(text: string, deviceId: string): Promise<string> {
+    return new Promise<string>((resolve) => {
+      const timer = setTimeout(() => {
+        const idx = pendingResolvers.findIndex((r) => r.resolve === wrappedResolve);
+        if (idx >= 0) pendingResolvers.splice(idx, 1);
+        log.info('watch: sync reply timeout — reply will go through poll queue', { textLen: text.length });
+        resolve('');
+      }, WATCH_SYNC_TIMEOUT_MS);
+
+      const wrappedResolve = (replyText: string) => {
+        clearTimeout(timer);
+        resolve(replyText);
+      };
+      pendingResolvers.push({ resolve: wrappedResolve, timer });
+
+      const now = new Date();
+      const inbound: InboundMessage = {
+        id: `watch-${now.getTime()}-${crypto.randomBytes(4).toString('hex')}`,
+        kind: 'chat',
+        content: {
+          text,
+          sender: WATCH_JID,
+          senderId: `watch:${deviceId}`,
+          senderName: 'Scott (watch)',
+        },
+        timestamp: now.toISOString(),
+      };
+      config.onMetadata(WATCH_JID, `NanoClaw Watch (${deviceId})`, false);
+      void config.onInbound(WATCH_JID, null, inbound);
+    });
+  }
+
+  async function handleMessagePost(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    const ct = String(req.headers['content-type'] || '').toLowerCase();
+    const deviceId = (req.headers['x-device-id'] as string | undefined) || 'unknown';
+
+    let text: string;
+    try {
+      if (ct.includes('application/json')) {
+        const body = await readBody(req);
+        const parsed = JSON.parse(body.toString('utf-8')) as { text?: unknown };
+        if (typeof parsed.text !== 'string' || !parsed.text.trim()) {
+          sendJson(res, 400, { error: 'missing text field' });
+          return;
+        }
+        text = parsed.text.trim();
+      } else if (ct.includes('audio/')) {
+        const body = await readBody(req);
+        if (body.length === 0) {
+          sendJson(res, 400, { error: 'empty audio body' });
+          return;
+        }
+        const cleaned = await transcribeAndClean(body);
+        if (!cleaned) {
+          sendJson(res, 200, { reply: '(no speech detected)' });
+          return;
+        }
+        text = cleaned;
+      } else {
+        sendJson(res, 415, { error: `unsupported Content-Type: ${ct}` });
+        return;
+      }
+    } catch (err) {
+      log.warn('watch: bad inbound body', { err, ct });
+      if (!res.headersSent) sendJson(res, 400, { error: 'bad request' });
+      return;
+    }
+
+    log.info('watch: inbound message', { deviceId, textLen: text.length, preview: text.slice(0, 100) });
+    mirrorToSignal(`⌚ [Watch] Scott: ${text}`);
+    const reply = await injectAndAwaitReply(text, deviceId);
+    sendJson(res, 200, { reply });
+  }
+
+  async function handleMemoPost(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    try {
+      const ct = String(req.headers['content-type'] || '').toLowerCase();
+      if (!ct.includes('audio/')) {
+        sendJson(res, 415, { error: `unsupported Content-Type: ${ct}` });
+        return;
+      }
+      const body = await readBody(req);
+      if (body.length === 0) {
+        sendJson(res, 400, { error: 'empty audio body' });
+        return;
+      }
+      const cleaned = await transcribeAndClean(body);
+      if (!cleaned) {
+        sendJson(res, 200, { reply: '(no speech detected)' });
+        return;
+      }
+
+      const now = new Date();
+      const dateStr = now.toISOString().slice(0, 10);
+      const timeStr = now.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true });
+      const memosDir = path.join(GROUPS_DIR, WATCH_GROUP_FOLDER, 'memos');
+      fs.mkdirSync(memosDir, { recursive: true });
+      const memoFile = path.join(memosDir, `${dateStr}.md`);
+      if (!fs.existsSync(memoFile)) fs.writeFileSync(memoFile, `# Memos — ${dateStr}\n\n`);
+      fs.appendFileSync(memoFile, `## ${timeStr}\n\n${cleaned}\n\n`);
+
+      log.info('watch: memo saved', { file: memoFile, len: cleaned.length });
+      mirrorToSignal(`[Memo] ${cleaned}`);
+      sendJson(res, 200, { reply: `Saved (${cleaned.length} chars)\n\n${cleaned}` });
+    } catch (err) {
+      log.warn('watch: memo error', { err });
+      if (!res.headersSent) sendJson(res, 500, { error: 'internal' });
+    }
+  }
+
+  async function handleReminderPost(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    try {
+      const ct = String(req.headers['content-type'] || '').toLowerCase();
+      if (!ct.includes('audio/')) {
+        sendJson(res, 415, { error: `unsupported Content-Type: ${ct}` });
+        return;
+      }
+      const body = await readBody(req);
+      if (body.length === 0) {
+        sendJson(res, 400, { error: 'empty audio body' });
+        return;
+      }
+      const cleaned = await transcribeAndClean(body);
+      if (!cleaned) {
+        sendJson(res, 200, { reply: '(no speech detected)' });
+        return;
+      }
+
+      const deviceId = (req.headers['x-device-id'] as string | undefined) || 'unknown';
+      log.info('watch: reminder request — routing to agent', { deviceId, preview: cleaned.slice(0, 100) });
+      mirrorToSignal(`⌚ [Watch reminder] Scott: ${cleaned}`);
+
+      const framed =
+        `SYSTEM: Scott tapped the 'Remind' tile on his watch and said: ` +
+        `"${cleaned}". Parse the time from his statement and schedule a ` +
+        `one-shot task for that exact time using the schedule_task tool ` +
+        `with schedule_type "once". The scheduled task's prompt should ` +
+        `send Scott a Signal reminder of the action. Reply with only a ` +
+        `short confirmation, e.g. "Reminder set for 3:45 PM: call Mom".`;
+
+      const reply = await injectAndAwaitReply(framed, deviceId);
+      sendJson(res, 200, { reply });
+    } catch (err) {
+      log.warn('watch: reminder error', { err });
+      if (!res.headersSent) sendJson(res, 500, { error: 'internal' });
+    }
+  }
+
+  async function handleRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    const url = new URL(req.url || '/', `http://${req.headers.host || 'localhost'}`);
+    if (!checkAuth(req)) {
+      sendJson(res, 401, { error: 'unauthorized' });
+      return;
+    }
+
+    if (req.method === 'POST' && url.pathname === '/api/watch/notify') {
+      try {
+        const body = await readBody(req);
+        const parsed = JSON.parse(body.toString('utf-8')) as { type?: string; from?: string; text?: string };
+        const type = (parsed.type === 'email' ? 'email' : 'signal') as 'email' | 'signal';
+        const from = parsed.from || 'System';
+        const text = parsed.text || '';
+        if (!text) {
+          sendJson(res, 400, { error: 'missing text field' });
+          return;
+        }
+        addNotification(type, from, text);
+        sendJson(res, 200, { ok: true });
+      } catch {
+        sendJson(res, 400, { error: 'bad request' });
+      }
+      return;
+    }
+
+    if (req.method === 'POST' && url.pathname === '/api/watch/message') {
+      await handleMessagePost(req, res);
+      return;
+    }
+    if (req.method === 'POST' && url.pathname === '/api/watch/memo') {
+      await handleMemoPost(req, res);
+      return;
+    }
+    if (req.method === 'POST' && url.pathname === '/api/watch/reminder') {
+      await handleReminderPost(req, res);
+      return;
+    }
+
+    if (req.method === 'GET' && url.pathname === '/api/watch/poll') {
+      const next = pollQueue.shift();
+      sendJson(res, 200, next ? { has_new: true, reply: next.text } : { has_new: false });
+      return;
+    }
+
+    if (req.method === 'GET' && url.pathname === '/api/watch/notifications') {
+      const since = url.searchParams.get('since') || '1970-01-01T00:00:00.000Z';
+      const sinceMs = new Date(since).getTime();
+      sendJson(res, 200, { notifications: notificationQueue.filter((n) => new Date(n.timestamp).getTime() > sinceMs) });
+      return;
+    }
+
+    if (req.method === 'GET' && url.pathname === '/api/watch/version') {
+      const versionFile = path.join(WATCH_FIRMWARE_DIR, 'version.json');
+      try {
+        const data = JSON.parse(fs.readFileSync(versionFile, 'utf-8'));
+        sendJson(res, 200, data);
+      } catch {
+        sendJson(res, 200, { version: 0, note: 'no firmware published' });
+      }
+      return;
+    }
+
+    if (req.method === 'GET' && url.pathname === '/api/watch/firmware') {
+      const binFile = path.join(WATCH_FIRMWARE_DIR, 'firmware.bin');
+      if (!fs.existsSync(binFile)) {
+        sendJson(res, 404, { error: 'no firmware available' });
+        return;
+      }
+      const stat = fs.statSync(binFile);
+      res.writeHead(200, {
+        'Content-Type': 'application/octet-stream',
+        'Content-Length': String(stat.size),
+        Connection: 'close',
+      });
+      fs.createReadStream(binFile).pipe(res);
+      return;
+    }
+
+    sendJson(res, 404, { error: 'not found' });
+  }
+
+  function addNotification(type: 'email' | 'signal', from: string, fullText: string): void {
+    const normalized = normalizeForWatch(fullText);
+    const preview =
+      normalized.length > NOTIF_PREVIEW_LEN ? normalized.slice(0, NOTIF_PREVIEW_LEN - 3) + '...' : normalized;
+    notificationQueue.push({
+      id: `notif-${Date.now()}-${crypto.randomBytes(4).toString('hex')}`,
+      type,
+      from: normalizeForWatch(from),
+      preview,
+      full_text: normalized.slice(0, 1024),
+      timestamp: new Date().toISOString(),
+    });
+    const cutoff = Date.now() - NOTIF_MAX_AGE_MS;
+    notificationQueue = notificationQueue.filter((n) => new Date(n.timestamp).getTime() > cutoff);
+    while (notificationQueue.length > NOTIF_QUEUE_MAX) notificationQueue.shift();
+  }
+
+  const adapter: ChannelAdapter = {
+    name: 'Watch',
+    channelType: 'watch',
+    supportsThreads: false,
+
+    async setup(cfg: ChannelSetup): Promise<void> {
+      config = cfg;
+      fs.mkdirSync(WATCH_UPLOADS_DIR, { recursive: true });
+
+      server = http.createServer((req, res) => {
+        handleRequest(req, res).catch((err) => {
+          log.error('watch: unhandled HTTP handler error', { err });
+          if (!res.headersSent) sendJson(res, 500, { error: 'internal' });
+        });
+      });
+
+      await new Promise<void>((resolve, reject) => {
+        const onError = (err: Error) => {
+          server?.removeListener('error', onError);
+          reject(err);
+        };
+        server!.once('error', onError);
+        server!.listen(WATCH_HTTP_PORT, WATCH_HTTP_BIND, () => {
+          server!.removeListener('error', onError);
+          log.info('watch: HTTP server listening', { port: WATCH_HTTP_PORT, bind: WATCH_HTTP_BIND });
+          resolve();
+        });
+      });
+    },
+
+    async teardown(): Promise<void> {
+      for (const r of pendingResolvers) {
+        clearTimeout(r.timer);
+        r.resolve('');
+      }
+      pendingResolvers = [];
+      if (server) {
+        await new Promise<void>((resolve) => server!.close(() => resolve()));
+        server = undefined;
+      }
+    },
+
+    isConnected(): boolean {
+      return !!server?.listening;
+    },
+
+    async deliver(platformId: string, _threadId: string | null, message: OutboundMessage): Promise<string | undefined> {
+      if (platformId !== WATCH_JID) return undefined;
+
+      const content = message.content as Record<string, unknown> | string | undefined;
+      let text: string | undefined;
+      if (typeof content === 'string') text = content;
+      else if (content && typeof content.text === 'string') text = content.text;
+      if (!text) return undefined;
+
+      // Mirror full Unicode text to Signal before normalizing for watch LCD
+      mirrorToSignal(`↳ ${text}`);
+      text = normalizeForWatch(text);
+
+      // Fast path: fulfill oldest pending sync request
+      const resolver = pendingResolvers.shift();
+      if (resolver) {
+        clearTimeout(resolver.timer);
+        log.info('watch: reply delivered via fast path', { textLen: text.length });
+        resolver.resolve(text);
+        return `watch-${Date.now()}`;
+      }
+
+      // Slow path: queue for poll endpoint
+      pollQueue.push({ ts: Date.now(), text });
+      while (pollQueue.length > POLL_QUEUE_MAX) pollQueue.shift();
+      log.info('watch: reply queued for poll endpoint', { textLen: text.length, queueSize: pollQueue.length });
+      return `watch-${Date.now()}`;
+    },
+  };
+
+  // Expose addNotification for external callers (e.g. Signal mirror hook in index.ts)
+  (adapter as ChannelAdapter & { addNotification: typeof addNotification }).addNotification = addNotification;
+
+  return adapter;
+}
+
+const registration: ChannelRegistration = {
+  factory: createWatchAdapter,
+  containerConfig: {
+    mounts: [
+      {
+        hostPath: path.join(STORE_DIR, 'watch-uploads'),
+        containerPath: '/workspace/watch-uploads',
+        readonly: false,
+      },
+    ],
+  },
+};
+
+registerChannelAdapter('watch', registration);


### PR DESCRIPTION
## Summary

- HTTP channel adapter turning a $45 LilyGo T-Watch S3 into a wrist-worn voice terminal
- Voice capture, memos, reminders, inbox check, status, find-phone, IR remote, notifications
- OTA firmware updates — publish new firmware, watch downloads wirelessly
- Signal mirror — watch conversations copied to phone in real-time
- Open-source firmware: [github.com/jorgenclaw/nanoclaw-watch](https://github.com/jorgenclaw/nanoclaw-watch)

## Why

Nobody else has hardware integration for NanoClaw. This is the first wearable channel — your agent on your wrist. No phone needed for quick voice input.

## Features

- **12 grid tiles** on the watch: Weather, Capture, Remind, Clock, Remote (IR), WiFi, Status, DND, Inbox, Find Phone, Flashlight, Update (OTA)
- **Voice capture** → whisper transcription → agent reply displayed on watch face
- **Voice memo** → transcribed, filed to daily journal markdown, no agent round-trip
- **Notifications** → Signal/email alerts pushed to watch as banner overlays
- **OTA** → `/api/watch/version` + `/api/watch/firmware` endpoints for wireless firmware updates
- **Signal mirror** → every watch interaction mirrored to operator's Signal chat

## Files

- `src/channels/watch.ts` (486 lines) — the HTTP adapter
- `.claude/skills/add-twatch/SKILL.md` — complete guide: hardware, firmware flash, host setup, wiring, OTA, troubleshooting

## How it was tested

Running in production since April 2026. Daily voice input, memo capture, status checks, OTA updates (v10→v11 delivered wirelessly). Firmware at v11 with 12 tiles, IR remote (Vizio TV), WiFi manager.

## Usage

```
/add-twatch
```

- [x] Feature skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)