### PR TITLE
fix(container): v2 -- point SDK to pnpm-installed Claude Code binary

### DIFF
--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -271,6 +271,7 @@ export class ClaudeProvider implements AgentProvider {
         cwd: input.cwd,
         additionalDirectories: this.additionalDirectories,
         resume: input.continuation,
+        pathToClaudeCodeExecutable: '/pnpm/claude',
         systemPrompt: instructions ? { type: 'preset' as const, preset: 'claude_code' as const, append: instructions } : undefined,
         allowedTools: TOOL_ALLOWLIST,
         disallowedTools: SDK_DISALLOWED_TOOLS,


### PR DESCRIPTION
## Summary
- The Agent SDK's default binary resolution picks the musl-linked native binary, which cannot execute on the Debian-based container image (glibc)
- Explicitly set `pathToClaudeCodeExecutable` to `/pnpm/claude` — the pnpm global symlink that resolves to the correct glibc binary regardless of architecture

## Test plan
- [ ] Rebuild container image and verify the agent-runner starts without "native binary not found" errors
- [ ] Send a message and confirm Claude Code processes it (check container logs for SDK message count > 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)