### PR TITLE
fix(container): v2 -- make /home/node writable for mapped host UIDs

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -103,7 +103,7 @@ RUN chmod +x /app/entrypoint.sh
 # ---- Workspace + permissions -------------------------------------------------
 RUN mkdir -p /workspace/group /workspace/global /workspace/extra && \
     chown -R node:node /workspace && \
-    chmod 755 /home/node
+    chmod 777 /home/node
 
 USER node
 WORKDIR /workspace/group


### PR DESCRIPTION
## Summary
- `container-runner.ts` maps the host UID into the container (e.g. 501 on macOS) so bind-mounted files have correct ownership
- But `/home/node` is owned by UID 1000 with mode 755, so the mapped UID cannot write `.claude.json` — causing Claude Code to silently fail with 0 SDK messages
- Widen to 777 so any mapped UID can write config files; safe because the container is ephemeral, single-process, and isolated

## Test plan
- [ ] Rebuild container image with `./container/build.sh`
- [ ] On macOS (UID 501), send a message and confirm the agent responds
- [ ] Check container logs for absence of EACCES errors on `/home/node`

🤖 Generated with [Claude Code](https://claude.com/claude-code)