### PR TITLE
fix(container-runner): v2 -- copy OneCLI certs to project dir for Colima

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -296,6 +296,23 @@ async function buildContainerArgs(
     }
     const onecliApplied = await onecli.applyContainerConfig(args, { addHostMapping: false, agent: agentIdentifier });
     if (onecliApplied) {
+      // OneCLI writes certs to $TMPDIR (e.g. /var/folders/…/T/ on macOS).
+      // VMs like Colima only share /Users/ — copy the specific .pem files
+      // to a project-local dir so the volume mounts resolve inside the VM.
+      const certsDir = path.join(DATA_DIR, 'onecli-certs');
+      fs.mkdirSync(certsDir, { recursive: true });
+      for (let i = 0; i < args.length; i++) {
+        if (args[i] === '-v' && args[i + 1]?.includes('/onecli-') && args[i + 1]?.includes('.pem')) {
+          const [src, ...rest] = args[i + 1].split(':');
+          const localCert = path.join(certsDir, path.basename(src));
+          try {
+            fs.copyFileSync(src, localCert);
+            args[i + 1] = [localCert, ...rest].join(':');
+          } catch {
+            /* source missing — leave original mount, will fail visibly */
+          }
+        }
+      }
       log.info('OneCLI gateway applied', { containerName });
     } else {
       log.warn('OneCLI gateway not applied — container will have no credentials', { containerName });


### PR DESCRIPTION
## Summary
- OneCLI SDK v0.3.1 hardcodes CA cert output to `tmpdir()` (`/var/folders/…/T/` on macOS) with no option to override — no env var, constructor param, or method argument
- Colima only shares `/Users/` with the VM, so containers can't read certs under `/var/folders/`
- A setup-time fix (sharing the user's temp dir) was rejected: the `.pem` files sit at the root of `$TMPDIR` alongside all other apps' temp files, creating unnecessary exposure
- Instead, copy just the two specific `.pem` files to `data/onecli-certs/` after `applyContainerConfig()` and rewrite the volume mount paths — scoped, no user setup needed

## Test plan
- [ ] On macOS with Colima, rebuild and send a message through an OneCLI-credentialed agent
- [ ] Verify `data/onecli-certs/` contains the two `.pem` files after first container launch
- [ ] Confirm container logs show "OneCLI gateway applied" without cert errors
- [ ] On Docker Desktop (non-Colima), verify no regression — certs still work via original paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)