### PR TITLE
fix: persist SDK session_id on init + split long outbound messages

### DIFF
--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -322,6 +322,13 @@ async function processQuery(query: AgentQuery, routing: RoutingContext): Promise
 
       if (event.type === 'init') {
         queryContinuation = event.continuation;
+        // Persist immediately so a mid-turn container crash still lets the
+        // next wake resume the conversation. Without this, the session id
+        // was only written after the full stream completed — if the
+        // container died between `init` and `result`, the SDK session was
+        // effectively orphaned and the next message started a blank
+        // Claude session with no prior context.
+        setStoredSessionId(event.continuation);
       } else if (event.type === 'result' && event.text) {
         dispatchResultText(event.text, routing);
       }

--- a/src/channels/chat-sdk-bridge.test.ts
+++ b/src/channels/chat-sdk-bridge.test.ts
@@ -2,11 +2,39 @@ import { describe, expect, it } from 'vitest';
 
 import type { Adapter } from 'chat';
 
-import { createChatSdkBridge } from './chat-sdk-bridge.js';
+import { createChatSdkBridge, splitForLimit } from './chat-sdk-bridge.js';
 
 function stubAdapter(partial: Partial<Adapter>): Adapter {
   return { name: 'stub', ...partial } as unknown as Adapter;
 }
+
+describe('splitForLimit', () => {
+  it('returns a single chunk when text fits', () => {
+    expect(splitForLimit('short text', 100)).toEqual(['short text']);
+  });
+
+  it('splits on paragraph boundaries when available', () => {
+    const text = 'para one line one\npara one line two\n\npara two line one\npara two line two';
+    const chunks = splitForLimit(text, 40);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const c of chunks) expect(c.length).toBeLessThanOrEqual(40);
+  });
+
+  it('falls back to line boundaries when no paragraph fits', () => {
+    const text = 'alpha\nbravo\ncharlie\ndelta\necho\nfoxtrot';
+    const chunks = splitForLimit(text, 15);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const c of chunks) expect(c.length).toBeLessThanOrEqual(15);
+  });
+
+  it('hard-cuts when no whitespace is available', () => {
+    const text = 'a'.repeat(100);
+    const chunks = splitForLimit(text, 30);
+    expect(chunks.length).toBe(Math.ceil(100 / 30));
+    for (const c of chunks) expect(c.length).toBeLessThanOrEqual(30);
+    expect(chunks.join('')).toBe(text);
+  });
+});
 
 describe('createChatSdkBridge', () => {
   // The bridge is now transport-only: forward inbound events, relay outbound

--- a/src/channels/chat-sdk-bridge.ts
+++ b/src/channels/chat-sdk-bridge.ts
@@ -63,6 +63,38 @@ export interface ChatSdkBridgeConfig {
    * quirk (e.g. Telegram's legacy Markdown parse mode).
    */
   transformOutboundText?: (text: string) => string;
+  /**
+   * Maximum text length the underlying adapter accepts in a single message.
+   * When set, the bridge splits outbound text longer than this on paragraph
+   * → line → hard-char boundaries and posts multiple messages. Without this,
+   * adapters like Discord (2000) and Telegram (4096) silently truncate
+   * mid-response. The returned id is the first chunk's id so subsequent edits
+   * and reactions still target the head of the reply.
+   */
+  maxTextLength?: number;
+}
+
+/**
+ * Split `text` into chunks no larger than `limit`, preferring paragraph
+ * breaks, then line breaks, then a hard character cut as a last resort.
+ * Preserves code fences only structurally — a fenced block that straddles a
+ * chunk boundary will render as two independent blocks on the receiving
+ * platform, which is the same behavior as manually re-opening a fence.
+ */
+export function splitForLimit(text: string, limit: number): string[] {
+  if (text.length <= limit) return [text];
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > limit) {
+    let cut = remaining.lastIndexOf('\n\n', limit);
+    if (cut <= 0) cut = remaining.lastIndexOf('\n', limit);
+    if (cut <= 0) cut = remaining.lastIndexOf(' ', limit);
+    if (cut <= 0) cut = limit;
+    chunks.push(remaining.slice(0, cut).trimEnd());
+    remaining = remaining.slice(cut).trimStart();
+  }
+  if (remaining.length > 0) chunks.push(remaining);
+  return chunks;
 }
 
 export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter {
@@ -338,13 +370,23 @@ export function createChatSdkBridge(config: ChatSdkBridgeConfig): ChannelAdapter
           data: f.data,
           filename: f.filename,
         }));
-        if (fileUploads && fileUploads.length > 0) {
-          const result = await adapter.postMessage(tid, { markdown: text, files: fileUploads });
-          return result?.id;
-        } else {
-          const result = await adapter.postMessage(tid, { markdown: text });
-          return result?.id;
+        // Split if over the adapter's max length. Files ride on the first
+        // chunk so the head of the reply still carries them.
+        const chunks =
+          config.maxTextLength && text.length > config.maxTextLength
+            ? splitForLimit(text, config.maxTextLength)
+            : [text];
+        let firstId: string | undefined;
+        for (let i = 0; i < chunks.length; i++) {
+          const chunk = chunks[i];
+          const attachFiles = i === 0 && fileUploads && fileUploads.length > 0;
+          const result = await adapter.postMessage(
+            tid,
+            attachFiles ? { markdown: chunk, files: fileUploads } : { markdown: chunk },
+          );
+          if (i === 0) firstId = result?.id;
         }
+        return firstId;
       } else if (message.files && message.files.length > 0) {
         // Files only, no text
         const fileUploads = message.files.map((f: { data: Buffer; filename: string }) => ({


### PR DESCRIPTION
Two bugs that surfaced together in a live Discord session when a response exceeded 2000 chars.

## 1. SDK session_id lost on mid-turn container exit

`runPollLoop` calls `setStoredSessionId(continuation)` only **after** `processQuery` returns. The Claude SDK's `init` event (where the session id arrives) fires very early in the stream, so if the container exits between `init` and `result` the id is never persisted. The next wake reads `getStoredSessionId()` → undefined and starts a fresh Claude session, dropping all prior context.

Repro from a real incident on my install:
- Turn 1: container spawned, `init` event delivered session id `abc123`, long response streamed back, container died before stream end (heartbeat stopped; host-sweep later logged `reason="container not running"`).
- `outbound.db session_state` table: **empty** — id was in memory only.
- Turn 2: host spawned new container for the same session → no stored id → fresh Claude session `165c2f…` → agent had no memory of turn 1.

**Fix:** persist inside the `init` branch of `processQuery`. The existing post-query store stays as a harmless no-op (same value).

## 2. Silent truncation past adapter limits

`chat-sdk-bridge.deliver` hands full text straight to `adapter.postMessage`. The Discord adapter hard-truncates at 2000 chars (`DISCORD_MAX_CONTENT_LENGTH = 2000` → slice + `...`). The Telegram adapter does the same at 4096 via `truncateMessage`. Responses longer than the limit are silently cut off — no split, no warning, no signal to the user or host.

**Fix:** add optional `maxTextLength` to `ChatSdkBridgeConfig` and a `splitForLimit` helper that breaks on paragraph → line → hard-char boundaries, then posts chunks sequentially. Files ride on the first chunk; the returned id is the first chunk's so edits and reactions still target the reply head. When `maxTextLength` is unset, behavior is unchanged.

## ⚠️ Required follow-up on the `channels` branch

This PR only adds the `maxTextLength` config option and the splitter — it does **not** wire any specific adapter to use it. The actual adapter factories (`src/channels/discord.ts`, `telegram.ts`, …) live on the `channels` branch, so for the splitter to engage, a follow-up change is needed on `channels` **after this merges and `channels` syncs from v2**:

```ts
// src/channels/discord.ts — inside createChatSdkBridge({ ... })
maxTextLength: 1900,  // Discord hard-limit is 2000; buffer for adapter-added markdown

// src/channels/telegram.ts — inside createChatSdkBridge({ ... })
maxTextLength: 4000,  // Telegram hard-limit is 4096; buffer for sanitizer escapes
```

Without that wiring, this PR is infra-only and changes nothing for existing installs. Flagging so it doesn't get forgotten — happy to open the follow-up PR myself once v2 merges and `channels` syncs, or leave it to whoever owns the channels branch.

## Tests

- New `splitForLimit` unit tests covering paragraph, line, and hard-cut paths (`src/channels/chat-sdk-bridge.test.ts`).
- Full host suite: 172 / 172 pass.
- Full agent-runner suite: 50 / 50 pass.
- Host + container typecheck clean.