### PR TITLE
fix(setup): actually enable systemd linger and report honestly

### DIFF
--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -7,8 +7,12 @@
  * module check). This driver picks up from there.
  *
  * Config via env:
- *   NANOCLAW_DISPLAY_NAME  operator name for the CLI agent (default: $USER)
- *   NANOCLAW_AGENT_NAME    agent persona name (default: display name)
+ *   NANOCLAW_DISPLAY_NAME  operator name for the CLI agent (default: $USER).
+ *                          Initial value only — after a successful end-to-end
+ *                          ping, the user is prompted to confirm or override
+ *                          (with a probe-inferred name as the default).
+ *   NANOCLAW_AGENT_NAME    agent persona name (default: display name). Same
+ *                          confirm-or-override prompt fires post-ping.
  *   NANOCLAW_SKIP          comma-separated step names to skip
  *                          (environment|container|onecli|auth|
  *                           mounts|service|cli-agent|verify)
@@ -118,6 +122,81 @@ function runBashScript(relPath: string): Promise<number> {
   return new Promise((resolve) => {
     const child = spawn('bash', [relPath], { stdio: 'inherit' });
     child.on('close', (code) => resolve(code ?? 1));
+  });
+}
+
+/**
+ * Resolve the operator's display name from host signals, matching the chain
+ * probe.sh uses for INFERRED_DISPLAY_NAME on the /new-setup path: git global
+ * user.name → platform record (macOS `id -F`, Linux/WSL getent GECOS) →
+ * $USER → "User". Empty strings and "root" are rejected at each step.
+ */
+function inferDisplayName(): string {
+  const accept = (s: string | undefined): string | undefined => {
+    const t = s?.trim();
+    if (!t || t === 'root') return undefined;
+    return t;
+  };
+
+  const git = spawnSync('git', ['config', '--global', 'user.name'], {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+  const gitName = accept(git.status === 0 ? git.stdout : undefined);
+  if (gitName) return gitName;
+
+  const user =
+    accept(process.env.USER) ??
+    accept(spawnSync('id', ['-un'], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).stdout);
+
+  if (user) {
+    if (process.platform === 'darwin') {
+      const res = spawnSync('id', ['-F', user], {
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      });
+      const name = accept(res.status === 0 ? res.stdout : undefined);
+      if (name) return name;
+    } else if (process.platform === 'linux') {
+      // getent ships with glibc — present on WSL Ubuntu/Debian too. On a default
+      // WSL user the GECOS field is empty, so this falls through to $USER.
+      const res = spawnSync('getent', ['passwd', user], {
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      });
+      if (res.status === 0 && res.stdout) {
+        const gecos = res.stdout.split(':')[4] ?? '';
+        const name = accept(gecos.split(',')[0]);
+        if (name) return name;
+      }
+    }
+  }
+
+  return user ?? 'User';
+}
+
+async function promptNames(inferred: string): Promise<{ displayName: string; agentName: string }> {
+  const readline = await import('node:readline/promises');
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const dAns = (await rl.question(`\nWhat should your agent call you? [${inferred}] `)).trim();
+    const displayName = dAns || inferred;
+    const aAns = (await rl.question(`What would you like to call your agent? [${displayName}] `)).trim();
+    const agentName = aAns || displayName;
+    return { displayName, agentName };
+  } finally {
+    rl.close();
+  }
+}
+
+function runPing(): Promise<boolean> {
+  return new Promise((resolve) => {
+    console.log(
+      '\n── ping ────────────────────────────────────\n' +
+        '[setup:auto] Sending ping — first container boot can take ~60s…',
+    );
+    const child = spawn('pnpm', ['run', 'chat', 'ping'], { stdio: 'inherit' });
+    child.on('close', (code) => resolve(code === 0));
   });
 }
 
@@ -237,6 +316,30 @@ async function main(): Promise<void> {
         'CLI agent wiring failed',
         'Re-run `pnpm exec tsx scripts/init-cli-agent.ts --display-name "<your name>"` to fix.',
       );
+    }
+  }
+
+  if (!skip.has('finalize') && !skip.has('cli-agent')) {
+    const pingOk = await runPing();
+    if (!pingOk) {
+      console.warn(
+        '\n[setup:auto] CLI agent did not respond to ping. The agent group is\n' +
+          '             wired, but the pipeline may be stuck — check\n' +
+          '             logs/nanoclaw.log. Skipping name prompts.',
+      );
+    } else if (process.stdin.isTTY && process.stdout.isTTY) {
+      const { displayName, agentName } = await promptNames(inferDisplayName());
+      const res = await runStep('rename-agent', [
+        '--display-name',
+        displayName,
+        '--agent-name',
+        agentName,
+      ]);
+      if (!res.ok && res.fields.STATUS !== 'skipped') {
+        console.warn(
+          '[setup:auto] rename-agent step failed — CLI agent keeps its current names.',
+        );
+      }
     }
   }
 

--- a/setup/auto.ts
+++ b/setup/auto.ts
@@ -15,7 +15,7 @@
  *                          confirm-or-override prompt fires post-ping.
  *   NANOCLAW_SKIP          comma-separated step names to skip
  *                          (environment|container|onecli|auth|
- *                           mounts|service|cli-agent|verify)
+ *                           mounts|service|cli-agent|channel|verify)
  *
  * Timezone is not configured here — it defaults to the host system's TZ.
  * Run `pnpm exec tsx setup/index.ts --step timezone -- --tz <zone>` later
@@ -23,9 +23,13 @@
  *
  * Anthropic credential registration runs via setup/register-claude-token.sh
  * (the only step that truly requires human input — browser sign-in or a
- * pasted token/key). Channel auth and `/manage-channels` remain separate
- * because they're platform-specific and typically handled via `/add-<channel>`
- * and `/manage-channels` after this driver completes.
+ * pasted token/key).
+ *
+ * After a successful end-to-end ping and the name prompts, the driver
+ * offers a messaging channel picker (see setup/channel-wire.ts). Telegram
+ * and WhatsApp-native run end-to-end here; other channels install their
+ * adapter and print a pre-filled init-first-agent command the operator
+ * finishes manually (or via `/add-<channel>` in Claude Code).
  */
 import { spawn, spawnSync } from 'child_process';
 
@@ -339,6 +343,10 @@ async function main(): Promise<void> {
         console.warn(
           '[setup:auto] rename-agent step failed — CLI agent keeps its current names.',
         );
+      }
+      if (!skip.has('channel')) {
+        const { runChannelWire } = await import('./channel-wire.js');
+        await runChannelWire({ displayName, agentName });
       }
     }
   }

--- a/setup/channel-wire.ts
+++ b/setup/channel-wire.ts
@@ -1,0 +1,481 @@
+/**
+ * Channel picker + wiring for setup:auto. Runs after the scratch CLI agent
+ * has been renamed (see auto.ts) and offers the operator a real messaging
+ * channel. Two tiers:
+ *
+ *  - Fully scripted (Telegram, WhatsApp native): install the adapter,
+ *    restart the service so the new module loads, authenticate / pair,
+ *    read the operator's user-id + chat platform-id out of the status
+ *    block (Telegram) or store/auth/creds.json (WhatsApp), and invoke
+ *    scripts/init-first-agent.ts with the operator + agent names captured
+ *    pre-picker.
+ *
+ *  - Install + hand-off (other channels): run install-<channel>.sh, persist
+ *    the names to .env (so a follow-up `/add-<channel>` can read them), and
+ *    print the exact init-first-agent command with --display-name /
+ *    --agent-name pre-filled plus a short hint on where to find the
+ *    platform IDs. The operator finishes wiring after setup:auto exits.
+ *
+ * All readline prompts assume a TTY; auto.ts only calls us when stdio is
+ * interactive.
+ */
+import { spawn, spawnSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import readline from 'node:readline/promises';
+
+type Names = { displayName: string; agentName: string };
+type Tier = 'scripted' | 'handoff';
+type Channel = {
+  id: string;
+  label: string;
+  tier: Tier;
+  findIdHint: string;
+};
+
+const CHANNELS: Channel[] = [
+  { id: 'whatsapp', label: 'WhatsApp (native)', tier: 'scripted', findIdHint: '' },
+  {
+    id: 'whatsapp-cloud',
+    label: 'WhatsApp Cloud (Meta official)',
+    tier: 'handoff',
+    findIdHint:
+      'Your WABA + phone-number-id from business.facebook.com, plus the destination phone number. See /add-whatsapp-cloud.',
+  },
+  { id: 'telegram', label: 'Telegram', tier: 'scripted', findIdHint: '' },
+  {
+    id: 'slack',
+    label: 'Slack',
+    tier: 'handoff',
+    findIdHint:
+      'Right-click a channel > View channel details — ID at the bottom (C… for channels, D… for DMs). Your user-id is from your Slack profile (U…).',
+  },
+  {
+    id: 'discord',
+    label: 'Discord',
+    tier: 'handoff',
+    findIdHint:
+      'Enable Developer Mode, right-click the server > Copy Server ID, then the channel > Copy Channel ID. Platform-id format: discord:{guildId}:{channelId}. User-id is your Discord user snowflake (right-click your name > Copy User ID).',
+  },
+  {
+    id: 'imessage',
+    label: 'iMessage',
+    tier: 'handoff',
+    findIdHint: 'Use the phone number (E.164) or Apple-ID email you want the agent to talk to. See /add-imessage.',
+  },
+  {
+    id: 'teams',
+    label: 'Teams',
+    tier: 'handoff',
+    findIdHint:
+      'Tenant ID + team ID + channel ID from the Teams channel URL or admin center. See /add-teams.',
+  },
+  {
+    id: 'matrix',
+    label: 'Matrix',
+    tier: 'handoff',
+    findIdHint:
+      'Element > room name > Settings > Advanced — the "Internal room ID" (starts with !) is the platform-id. Or use a #alias:homeserver alias. Your user-id is @handle:homeserver.',
+  },
+  {
+    id: 'gchat',
+    label: 'Google Chat',
+    tier: 'handoff',
+    findIdHint: 'Workspace ID + space ID from the Google Chat URL. See /add-gchat.',
+  },
+  {
+    id: 'linear',
+    label: 'Linear',
+    tier: 'handoff',
+    findIdHint: 'Issue identifier (e.g. ENG-123) as platform-id; your Linear user email as user-id. See /add-linear.',
+  },
+  {
+    id: 'github',
+    label: 'GitHub',
+    tier: 'handoff',
+    findIdHint:
+      'Issue or PR URL — "owner/repo#N". Your user-id is your GitHub login. See /add-github.',
+  },
+  {
+    id: 'webex',
+    label: 'Webex',
+    tier: 'handoff',
+    findIdHint: 'Space ID (starts with Y2lzY29z…) from the Webex developer portal. See /add-webex.',
+  },
+  {
+    id: 'resend',
+    label: 'Resend (email)',
+    tier: 'handoff',
+    findIdHint: 'Destination email as platform-id; your own email as user-id. See /add-resend.',
+  },
+];
+
+type Fields = Record<string, string>;
+
+function parseStatus(stdout: string): Fields {
+  const out: Fields = {};
+  let inBlock = false;
+  for (const line of stdout.split('\n')) {
+    if (line.startsWith('=== NANOCLAW SETUP:')) {
+      inBlock = true;
+      continue;
+    }
+    if (line.startsWith('=== END ===')) {
+      inBlock = false;
+      continue;
+    }
+    if (!inBlock) continue;
+    const idx = line.indexOf(':');
+    if (idx === -1) continue;
+    const key = line.slice(0, idx).trim();
+    const value = line.slice(idx + 1).trim();
+    if (key) out[key] = value;
+  }
+  return out;
+}
+
+function runInherit(cmd: string, args: string[]): Promise<number> {
+  return new Promise((resolve) => {
+    const child = spawn(cmd, args, { stdio: 'inherit' });
+    child.on('close', (code) => resolve(code ?? 1));
+  });
+}
+
+function runCapturing(
+  cmd: string,
+  args: string[],
+): Promise<{ code: number; fields: Fields }> {
+  return new Promise((resolve) => {
+    const child = spawn(cmd, args, { stdio: ['inherit', 'pipe', 'inherit'] });
+    let buf = '';
+    child.stdout.on('data', (chunk: Buffer) => {
+      const s = chunk.toString('utf-8');
+      buf += s;
+      process.stdout.write(s);
+    });
+    child.on('close', (code) => resolve({ code: code ?? 1, fields: parseStatus(buf) }));
+  });
+}
+
+async function promptChannel(): Promise<Channel | null> {
+  console.log('\n── channel ────────────────────────────────────');
+  console.log('Pick a messaging channel to wire your agent to:');
+  console.log('');
+  CHANNELS.forEach((c, i) => {
+    const tag = c.tier === 'scripted' ? '  (fully scripted)' : '';
+    console.log(`  ${String(i + 1).padStart(2)}. ${c.label}${tag}`);
+  });
+  console.log('   0. Skip for now');
+  console.log('');
+
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    for (;;) {
+      const ans = (await rl.question('Choice: ')).trim().toLowerCase();
+      if (!ans || ans === '0' || ans === 'skip' || ans === 's') return null;
+      const asNum = Number(ans);
+      if (Number.isInteger(asNum) && asNum >= 1 && asNum <= CHANNELS.length) {
+        return CHANNELS[asNum - 1];
+      }
+      const byName = CHANNELS.find(
+        (c) => c.id === ans || c.label.toLowerCase() === ans,
+      );
+      if (byName) return byName;
+      console.log(`  Not a valid choice. Enter 1–${CHANNELS.length}, or 0 to skip.`);
+    }
+  } finally {
+    rl.close();
+  }
+}
+
+async function restartService(): Promise<void> {
+  console.log('\n[setup:auto] Restarting service so the new channel adapter loads…');
+  let ok = false;
+  if (process.platform === 'darwin') {
+    const uid = spawnSync('id', ['-u'], { encoding: 'utf-8' }).stdout.trim();
+    const res = spawnSync('launchctl', ['kickstart', '-k', `gui/${uid}/com.nanoclaw`], {
+      stdio: 'inherit',
+    });
+    ok = res.status === 0;
+  } else if (process.platform === 'linux') {
+    const res = spawnSync('systemctl', ['--user', 'restart', 'nanoclaw'], {
+      stdio: 'inherit',
+    });
+    ok = res.status === 0;
+  }
+  if (!ok) {
+    console.warn(
+      '[setup:auto] Service restart failed — if pairing hangs, restart the service manually and retry.',
+    );
+  }
+  // Brief settle so the adapter's polling loop is up before we try to pair.
+  await new Promise((r) => setTimeout(r, 3000));
+}
+
+function persistNamesToEnv(names: Names): void {
+  const envPath = path.resolve(process.cwd(), '.env');
+  let text = '';
+  try {
+    text = fs.readFileSync(envPath, 'utf-8');
+  } catch {
+    // fresh file is fine
+  }
+
+  for (const [key, value] of [
+    ['NANOCLAW_DISPLAY_NAME', names.displayName],
+    ['NANOCLAW_AGENT_NAME', names.agentName],
+  ] as const) {
+    const line = `${key}=${JSON.stringify(value)}`;
+    const rx = new RegExp(`^${key}=.*$`, 'm');
+    if (rx.test(text)) {
+      text = text.replace(rx, line);
+    } else {
+      if (text && !text.endsWith('\n')) text += '\n';
+      text += line + '\n';
+    }
+  }
+  fs.writeFileSync(envPath, text);
+}
+
+async function runInitFirstAgent(
+  channel: string,
+  userId: string,
+  platformId: string,
+  names: Names,
+): Promise<boolean> {
+  console.log('\n── init-first-agent ───────────────────────────');
+  const code = await runInherit('pnpm', [
+    'exec',
+    'tsx',
+    'scripts/init-first-agent.ts',
+    '--channel',
+    channel,
+    '--user-id',
+    userId,
+    '--platform-id',
+    platformId,
+    '--display-name',
+    names.displayName,
+    '--agent-name',
+    names.agentName,
+  ]);
+  if (code !== 0) {
+    console.warn('[setup:auto] init-first-agent failed — you can re-run the command above manually.');
+    return false;
+  }
+  console.log(
+    `\n[setup:auto] Your agent is now available on ${channel}. Start chatting when you're ready.`,
+  );
+  return true;
+}
+
+async function wireTelegram(names: Names): Promise<void> {
+  console.log('\n── install-telegram ───────────────────────────');
+  const installCode = await runInherit('bash', ['setup/install-telegram.sh']);
+  if (installCode !== 0) {
+    console.warn('[setup:auto] Telegram install failed — skipping channel wiring.');
+    return;
+  }
+
+  console.log(
+    '\nIn Telegram, DM @BotFather: `/newbot` → pick a friendly name → username ending in "bot" → copy the token.',
+  );
+  console.log(
+    'For groups: @BotFather → /mybots → your bot → Bot Settings → Group Privacy → Turn off.',
+  );
+
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  let token: string;
+  try {
+    token = (await rl.question('\nPaste your bot token: ')).trim();
+  } finally {
+    rl.close();
+  }
+  if (!token) {
+    console.warn('[setup:auto] No token provided — skipping channel wiring.');
+    return;
+  }
+
+  const setEnvRes = await runCapturing('pnpm', [
+    'exec',
+    'tsx',
+    'setup/index.ts',
+    '--step',
+    'set-env',
+    '--',
+    '--key',
+    'TELEGRAM_BOT_TOKEN',
+    '--value',
+    token,
+    '--sync-container',
+  ]);
+  if (setEnvRes.code !== 0 || setEnvRes.fields.STATUS !== 'success') {
+    console.warn('[setup:auto] set-env failed — skipping channel wiring.');
+    return;
+  }
+
+  await restartService();
+
+  console.log(
+    '\n── pair-telegram ──────────────────────────────\n' +
+      '[setup:auto] A 4-digit code will appear below. Send it from the Telegram chat you want to register.',
+  );
+  const pairRes = await runCapturing('pnpm', [
+    'exec',
+    'tsx',
+    'setup/index.ts',
+    '--step',
+    'pair-telegram',
+    '--',
+    '--intent',
+    'main',
+  ]);
+  if (pairRes.code !== 0 || pairRes.fields.STATUS !== 'success') {
+    console.warn(
+      '[setup:auto] pair-telegram did not complete — adapter is installed but no chat is wired yet.',
+    );
+    return;
+  }
+
+  const platformId = pairRes.fields.PLATFORM_ID;
+  const pairedUserId = pairRes.fields.PAIRED_USER_ID;
+  if (!platformId || !pairedUserId) {
+    console.warn(
+      '[setup:auto] pair-telegram success block missing PLATFORM_ID / PAIRED_USER_ID — channel is installed but not wired.',
+    );
+    return;
+  }
+
+  await runInitFirstAgent('telegram', pairedUserId, platformId, names);
+}
+
+async function wireWhatsApp(names: Names): Promise<void> {
+  console.log('\n── install-whatsapp ───────────────────────────');
+  const installCode = await runInherit('bash', ['setup/install-whatsapp.sh']);
+  if (installCode !== 0) {
+    console.warn('[setup:auto] WhatsApp install failed — skipping channel wiring.');
+    return;
+  }
+
+  await restartService();
+
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  let method: 'qr-terminal' | 'qr-browser' | 'pairing-code';
+  let phone: string | undefined;
+  try {
+    console.log('\nAuth method:');
+    console.log('  1. QR code in terminal');
+    console.log('  2. QR code in browser (for remote / headless hosts)');
+    console.log('  3. Pairing code (WhatsApp → Linked devices → Link with phone number)');
+    const pick = (await rl.question('Choice [1]: ')).trim() || '1';
+    if (pick === '2') {
+      method = 'qr-browser';
+    } else if (pick === '3') {
+      method = 'pairing-code';
+      phone = (await rl.question('Your phone number (digits only, E.164, no +): ')).trim();
+      if (!phone) {
+        console.warn('[setup:auto] No phone provided — skipping channel wiring.');
+        return;
+      }
+    } else {
+      method = 'qr-terminal';
+    }
+  } finally {
+    rl.close();
+  }
+
+  console.log('\n── whatsapp-auth ──────────────────────────────');
+  const args = [
+    'exec',
+    'tsx',
+    'setup/index.ts',
+    '--step',
+    'whatsapp-auth',
+    '--',
+    '--method',
+    method,
+  ];
+  if (phone) args.push('--phone', phone);
+  const authRes = await runCapturing('pnpm', args);
+  if (authRes.code !== 0 || authRes.fields.STATUS !== 'authenticated') {
+    console.warn(
+      '[setup:auto] WhatsApp auth did not complete — channel is installed but no chat is wired yet.',
+    );
+    return;
+  }
+
+  let jid: string;
+  try {
+    const credsPath = path.resolve(process.cwd(), 'store', 'auth', 'creds.json');
+    const creds = JSON.parse(fs.readFileSync(credsPath, 'utf-8'));
+    const rawMeId: string | undefined = creds?.me?.id;
+    if (!rawMeId) throw new Error('me.id missing from creds.json');
+    // me.id is `<phone>:<device>@s.whatsapp.net` — drop the device suffix so the
+    // JID addresses the operator's own chat, not a specific linked device.
+    const phoneOnly = rawMeId.split(':')[0].split('@')[0];
+    if (!phoneOnly) throw new Error(`could not parse phone from me.id=${rawMeId}`);
+    jid = `${phoneOnly}@s.whatsapp.net`;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `[setup:auto] Authenticated but couldn't derive JID from store/auth/creds.json (${msg}) — channel is installed but not wired.`,
+    );
+    return;
+  }
+
+  await runInitFirstAgent('whatsapp', jid, jid, names);
+}
+
+async function wireHandoff(channel: Channel, names: Names): Promise<void> {
+  console.log(`\n── install-${channel.id} ───────────────────────────`);
+  const installCode = await runInherit('bash', [`setup/install-${channel.id}.sh`]);
+  if (installCode !== 0) {
+    console.warn(`[setup:auto] ${channel.label} install failed.`);
+    return;
+  }
+
+  persistNamesToEnv(names);
+
+  console.log(`\n[setup:auto] ${channel.label} adapter is installed.`);
+  console.log('');
+  console.log('To finish wiring you need two IDs from the platform:');
+  console.log('  • your user-id');
+  console.log('  • the chat / channel platform-id');
+  if (channel.findIdHint) {
+    console.log('');
+    console.log(channel.findIdHint);
+  }
+  console.log(
+    '\nOnce you have them (service restart may be needed so the adapter picks up credentials):',
+  );
+  console.log('');
+  console.log(
+    `  pnpm exec tsx scripts/init-first-agent.ts \\\n` +
+      `    --channel ${channel.id} \\\n` +
+      `    --user-id "<YOUR_USER_ID>" \\\n` +
+      `    --platform-id "<CHAT_PLATFORM_ID>" \\\n` +
+      `    --display-name ${JSON.stringify(names.displayName)} \\\n` +
+      `    --agent-name ${JSON.stringify(names.agentName)}`,
+  );
+  console.log(
+    `\nOr run \`/add-${channel.id}\` in Claude Code — it walks the credential + ID capture and calls init-first-agent for you. Your names are persisted to .env so the skill can pick them up.`,
+  );
+}
+
+export async function runChannelWire(names: Names): Promise<void> {
+  const choice = await promptChannel();
+  if (!choice) {
+    console.log(
+      '[setup:auto] No channel wired. You can add one later via `/add-<channel>` in Claude Code.',
+    );
+    return;
+  }
+
+  if (choice.id === 'telegram') {
+    await wireTelegram(names);
+  } else if (choice.id === 'whatsapp') {
+    await wireWhatsApp(names);
+  } else {
+    await wireHandoff(choice, names);
+  }
+}

--- a/setup/index.ts
+++ b/setup/index.ts
@@ -20,6 +20,7 @@ const STEPS: Record<
   onecli: () => import('./onecli.js'),
   auth: () => import('./auth.js'),
   'cli-agent': () => import('./cli-agent.js'),
+  'rename-agent': () => import('./rename-agent.js'),
 };
 
 async function main(): Promise<void> {

--- a/setup/install-docker.sh
+++ b/setup/install-docker.sh
@@ -30,6 +30,34 @@ case "$(uname -s)" in
     brew install --cask docker
     ;;
   Linux)
+    # WSL2 without systemd: get.docker.com installs fine but dockerd
+    # can't start (no init to supervise it). Bail early with both
+    # recommended paths so the user picks whichever fits, instead of
+    # installing ~400MB and failing at daemon-start 60s later.
+    if grep -qiE 'microsoft|wsl' /proc/version 2>/dev/null \
+       && [ ! -d /run/systemd/system ]; then
+      echo "STEP: detect-wsl-no-systemd"
+      cat <<'MSG'
+
+WSL detected without systemd. Docker can't run natively here yet.
+
+Recommended: install Docker Desktop on Windows
+  1) Download and install: https://www.docker.com/products/docker-desktop/
+  2) Launch Docker Desktop, accept the EULA.
+  3) Settings -> Resources -> WSL Integration -> enable for this distro.
+  4) Re-run ./nanoclaw.sh here.
+
+Alternative: enable systemd inside this WSL distro
+  1) sudo sh -c 'printf "\n[boot]\nsystemd=true\n" >> /etc/wsl.conf'
+  2) In Windows PowerShell: wsl --shutdown
+  3) Reopen this terminal and re-run ./nanoclaw.sh.
+
+MSG
+      echo "STATUS: failed"
+      echo "ERROR: wsl_no_systemd"
+      echo "=== END ==="
+      exit 1
+    fi
     echo "STEP: docker-get-script"
     curl -fsSL https://get.docker.com | sh
     echo "STEP: usermod-docker-group"

--- a/setup/rename-agent.ts
+++ b/setup/rename-agent.ts
@@ -1,0 +1,117 @@
+/**
+ * Step: rename-agent — Update the scratch CLI agent's operator + persona names.
+ *
+ * Invoked post-ping from `setup:auto`, after the user confirms or overrides
+ * the names inferred from the host. Updates two rows: `users.display_name`
+ * for the synthetic `cli:local` identity, and `agent_groups.name` for the
+ * agent wired to the CLI channel. The folder path stays as-is — it's an
+ * infrastructural identifier, not a presentation name.
+ *
+ * Args:
+ *   --display-name <name>   (required) operator's display name
+ *   --agent-name   <name>   (required) agent persona name
+ *
+ * Idempotent: calling with values that already match the DB is a no-op.
+ */
+import path from 'path';
+
+import { DATA_DIR } from '../src/config.js';
+import { getAgentGroup, updateAgentGroup } from '../src/db/agent-groups.js';
+import { initDb } from '../src/db/connection.js';
+import {
+  getMessagingGroupAgents,
+  getMessagingGroupByPlatform,
+} from '../src/db/messaging-groups.js';
+import { runMigrations } from '../src/db/migrations/index.js';
+import { log } from '../src/log.js';
+import { getUser, updateDisplayName } from '../src/modules/permissions/db/users.js';
+import { emitStatus } from './status.js';
+
+const CLI_USER_ID = 'cli:local';
+
+function parseArgs(args: string[]): { displayName: string; agentName: string } {
+  let displayName: string | undefined;
+  let agentName: string | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    const key = args[i];
+    const val = args[i + 1];
+    if (key === '--display-name') {
+      displayName = val;
+      i++;
+    } else if (key === '--agent-name') {
+      agentName = val;
+      i++;
+    }
+  }
+
+  if (!displayName || !agentName) {
+    emitStatus('RENAME_AGENT', {
+      STATUS: 'failed',
+      ERROR: 'missing_args',
+      LOG: 'logs/setup.log',
+    });
+    process.exit(2);
+  }
+
+  return { displayName, agentName };
+}
+
+export async function run(args: string[]): Promise<void> {
+  const { displayName, agentName } = parseArgs(args);
+
+  const db = initDb(path.join(DATA_DIR, 'v2.db'));
+  runMigrations(db);
+
+  const user = getUser(CLI_USER_ID);
+  if (!user) {
+    emitStatus('RENAME_AGENT', {
+      STATUS: 'failed',
+      ERROR: 'cli_user_not_found',
+      LOG: 'logs/setup.log',
+    });
+    process.exit(1);
+  }
+
+  const mg = getMessagingGroupByPlatform('cli', 'local');
+  if (!mg) {
+    emitStatus('RENAME_AGENT', {
+      STATUS: 'failed',
+      ERROR: 'cli_messaging_group_not_found',
+      LOG: 'logs/setup.log',
+    });
+    process.exit(1);
+  }
+
+  const wirings = getMessagingGroupAgents(mg.id);
+  const ag = wirings.length > 0 ? getAgentGroup(wirings[0].agent_group_id) : undefined;
+  if (!ag) {
+    emitStatus('RENAME_AGENT', {
+      STATUS: 'failed',
+      ERROR: 'cli_agent_group_not_found',
+      LOG: 'logs/setup.log',
+    });
+    process.exit(1);
+  }
+
+  const userChanged = user.display_name !== displayName;
+  const agentChanged = ag.name !== agentName;
+
+  if (userChanged) {
+    updateDisplayName(CLI_USER_ID, displayName);
+    log.info('Updated CLI user display_name', { from: user.display_name, to: displayName });
+  }
+  if (agentChanged) {
+    updateAgentGroup(ag.id, { name: agentName });
+    log.info('Updated CLI agent name', { from: ag.name, to: agentName });
+  }
+
+  emitStatus('RENAME_AGENT', {
+    DISPLAY_NAME: displayName,
+    AGENT_NAME: agentName,
+    USER_CHANGED: userChanged,
+    AGENT_CHANGED: agentChanged,
+    STATUS: userChanged || agentChanged ? 'success' : 'skipped',
+    LOG: 'logs/setup.log',
+  });
+}

--- a/setup/service.ts
+++ b/setup/service.ts
@@ -291,15 +291,56 @@ WantedBy=${runningAsRoot ? 'multi-user.target' : 'default.target'}`;
 
   // Enable lingering so the user service survives SSH logout.
   // Without linger, systemd terminates all user processes when the last session closes.
+  let lingerEnabled = false;
   if (!runningAsRoot) {
-    try {
-      execSync('loginctl enable-linger', { stdio: 'ignore' });
-      log.info('Enabled loginctl linger for current user');
-    } catch (err) {
-      log.warn(
-        'loginctl enable-linger failed — service may stop on SSH logout',
-        { err },
-      );
+    const currentUser = execSync('whoami', { encoding: 'utf-8' }).trim();
+    const isLingerOn = (): boolean => {
+      try {
+        const out = execSync(`loginctl show-user ${currentUser}`, {
+          encoding: 'utf-8',
+        });
+        return /^Linger=yes$/m.test(out);
+      } catch {
+        return false;
+      }
+    };
+
+    // Fast path: already enabled from a previous run.
+    if (isLingerOn()) {
+      lingerEnabled = true;
+    } else {
+      // Self-target first — works on most standalone Linux systems via polkit.
+      try {
+        execSync('loginctl enable-linger', { stdio: 'ignore' });
+      } catch {
+        // On WSL (and some polkit-hardened systems) the self-call fails with
+        // "No such device or address". Fall through to sudo-targeted form.
+      }
+
+      if (!isLingerOn()) {
+        // sudo-targeted form. stdio: 'inherit' so the user can enter their
+        // password if needed (matches the setfacl escalation above). NOPASSWD
+        // configs succeed silently; no-TTY contexts fail fast rather than hang.
+        log.info(
+          `Self-target linger failed — escalating via sudo. If prompted, enter your password for: sudo loginctl enable-linger ${currentUser}`,
+        );
+        try {
+          execSync(`sudo loginctl enable-linger ${currentUser}`, {
+            stdio: 'inherit',
+          });
+        } catch {
+          // user cancelled, wrong password, or no sudo available
+        }
+      }
+
+      lingerEnabled = isLingerOn();
+      if (lingerEnabled) {
+        log.info('Enabled loginctl linger for current user');
+      } else {
+        log.warn(
+          `loginctl enable-linger failed — service will stop on logout. Fix manually: sudo loginctl enable-linger ${currentUser}`,
+        );
+      }
     }
   }
 
@@ -338,7 +379,7 @@ WantedBy=${runningAsRoot ? 'multi-user.target' : 'default.target'}`;
     UNIT_PATH: unitPath,
     SERVICE_LOADED: serviceLoaded,
     ...(dockerGroupStale ? { DOCKER_GROUP_STALE: true } : {}),
-    LINGER_ENABLED: !runningAsRoot,
+    LINGER_ENABLED: runningAsRoot ? 'n/a' : lingerEnabled,
     STATUS: 'success',
     LOG: 'logs/setup.log',
   });


### PR DESCRIPTION
## Summary
- Self-target `loginctl enable-linger` fails on WSL with "No such device or address"; previous code swallowed the error and moved on.
- `LINGER_ENABLED` in the status block was hardcoded to `!runningAsRoot`, so setup reported success even when linger was never enabled.
- Now: try self-target → fall back to `sudo loginctl enable-linger <user>` (interactive, matching the existing `setfacl` escalation pattern) → verify via `loginctl show-user` → warn with the exact manual command if still off. Status field now reflects reality.

## Test plan
- [ ] Fresh Linux (polkit-friendly): self-target succeeds silently, no sudo prompt
- [ ] WSL without passwordless sudo: one password prompt mid-setup, linger actually enabled afterward
- [ ] WSL with passwordless sudo: silent success via sudo fallback
- [ ] Re-run on a box where linger is already on: fast path, no escalation, status correct
- [ ] Headless/CI (no TTY): sudo fails fast (no hang), warn logs the manual command
- [ ] User cancels sudo / wrong password: setup continues, warn shows manual command, status correctly reports `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)