### PR TITLE
fix(setup): detect WSL-without-systemd before installing Docker

### DIFF
--- a/setup/install-docker.sh
+++ b/setup/install-docker.sh
@@ -30,6 +30,34 @@ case "$(uname -s)" in
     brew install --cask docker
     ;;
   Linux)
+    # WSL2 without systemd: get.docker.com installs fine but dockerd
+    # can't start (no init to supervise it). Bail early with both
+    # recommended paths so the user picks whichever fits, instead of
+    # installing ~400MB and failing at daemon-start 60s later.
+    if grep -qiE 'microsoft|wsl' /proc/version 2>/dev/null \
+       && [ ! -d /run/systemd/system ]; then
+      echo "STEP: detect-wsl-no-systemd"
+      cat <<'MSG'
+
+WSL detected without systemd. Docker can't run natively here yet.
+
+Recommended: install Docker Desktop on Windows
+  1) Download and install: https://www.docker.com/products/docker-desktop/
+  2) Launch Docker Desktop, accept the EULA.
+  3) Settings -> Resources -> WSL Integration -> enable for this distro.
+  4) Re-run ./nanoclaw.sh here.
+
+Alternative: enable systemd inside this WSL distro
+  1) sudo sh -c 'printf "\n[boot]\nsystemd=true\n" >> /etc/wsl.conf'
+  2) In Windows PowerShell: wsl --shutdown
+  3) Reopen this terminal and re-run ./nanoclaw.sh.
+
+MSG
+      echo "STATUS: failed"
+      echo "ERROR: wsl_no_systemd"
+      echo "=== END ==="
+      exit 1
+    fi
     echo "STEP: docker-get-script"
     curl -fsSL https://get.docker.com | sh
     echo "STEP: usermod-docker-group"


### PR DESCRIPTION
## Summary
- `get.docker.com` succeeds inside WSL2 but `dockerd` can't start without systemd to supervise it, producing a confusing 60s daemon-start timeout.
- Detect WSL-without-systemd (`/proc/version` match + no `/run/systemd/system`) and bail before the download.
- Point the user at the two viable paths: Docker Desktop (recommended, handles WSL integration) or enabling systemd in `/etc/wsl.conf`.

## Test plan
- [ ] On WSL2 with systemd disabled: `bash setup/install-docker.sh` prints the guidance block and exits 1 with `ERROR: wsl_no_systemd`.
- [ ] On WSL2 with systemd enabled: falls through to the normal `get.docker.com` path.
- [ ] On bare-metal Linux: unchanged behavior.
- [ ] On macOS: unchanged behavior (brew cask path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)